### PR TITLE
fix: :bug: fixed wrong calculation of second putt number

### DIFF
--- a/src/types/roundData.types.tsx
+++ b/src/types/roundData.types.tsx
@@ -1,10 +1,10 @@
-interface IState {
-  roundID: string;
-  playerID: string;
-  roundCourse: string;
-  roundDate: string;
-  shots: IShots[];
-}
+// interface IState {
+//   roundID: string;
+//   playerID: string;
+//   roundCourse: string;
+//   roundDate: string;
+//   shots: IShots[];
+// }
 
 export interface IShots {
   holeNumber: number;

--- a/src/utils/calculator/TotalsCalculator.utils.tsx
+++ b/src/utils/calculator/TotalsCalculator.utils.tsx
@@ -105,6 +105,14 @@ export const totalsCalculator = (shots: IShots[]) => {
     ...totals,
     playerID: "playerID",
 
+    mainData: {
+      roundCourse: '',
+      roundDate: '',
+      roundNumber: 0,
+      roundTee: '',
+      coursePar: totalALL.par,
+      playerHCP: 0
+    },
     score: {
       totals: totalALL.score,
       avg: divide(totalALL.score, holes).toFixed(2),

--- a/src/utils/constant.utils.tsx
+++ b/src/utils/constant.utils.tsx
@@ -424,31 +424,31 @@ export const catConversion = (string: string) => {
       result = 'Irons';
       break;
     case 'puttsU2M':
-      result = 'Under 2 Mts.';
+      result = 'First putt under 2 mts.';
       break;
     case 'putts24M':
-      result = '2 to 4 Mts.';
+      result = 'First putt from 2 to 4 mts.';
       break;
     case 'putts46M':
-      result = '4 to 6 Mts.';
+      result = 'First putt from 4 to 6 mts.';
       break;
     case 'putts610M':
-      result = '6 to 10 Mts.';
+      result = 'First putt from 6 to 10 mts.';
       break;
     case 'puttsO10M':
-      result = 'Over 10 Mts.';
+      result = 'First putt over 10 Mts.';
       break;
     case 'over100mt':
-      result = 'Over 100 Mts.';
+      result = 'Over 100 mts.';
       break;
     case 'inside10081':
-      result = '100 to 80 Mts.'
+      result = '100 to 80 mts.'
       break;
     case 'inside8061':
-      result = '80 to 60 Mts.'
+      result = '80 to 60 mts.'
       break;
     case 'inside60':
-      result = 'Inside 60 Mts.'
+      result = 'Inside 60 mts.'
       break;
   }
   return result;

--- a/src/utils/totals/totals.utils.tsx
+++ b/src/utils/totals/totals.utils.tsx
@@ -11,8 +11,8 @@ export const calculatePuttsStatistics = (shots: IShots[]) => {
       acc.puttsHoled += (isWithinRange && curr.puttsLength.length === 1) ? 1 : 0;
       acc.puttsAttempts += isWithinRange ? 1 : 0;
       acc.numberPuttsInRange += isWithinRange ? curr.puttsLength.length : 0;
-      acc.distanceSecondPutt += (isWithinRange && curr.puttsLength.length === 2) ? curr.puttsLength[1] : 0;
-      acc.numberSecondPutt += (isWithinRange && curr.puttsLength.length === 2) ? 1 : 0;
+      acc.distanceSecondPutt += (isWithinRange && curr.puttsLength.length > 1) ? curr.puttsLength[1] : 0;
+      acc.numberSecondPutt += (isWithinRange && curr.puttsLength.length > 1) ? 1 : 0;
       acc.distanceFirstPutt += isWithinRange ? curr.puttsLength[0] : 0;
       acc.putts3 += isWithinRange && curr.puttsLength.length >= 3 ? 1 : 0;
 
@@ -160,7 +160,6 @@ export const calculateChippingPitchingStatistics = (shots: IShots[]) => {
   ];
 
   const createFinalObject = (array: any) => {
-    debugger;
     return (
       {
         ...array,


### PR DESCRIPTION
This bug will prevent system to calculate the real average distance of second putt for the selected distance.
This bug was caused by the assumption that if I used more than 1 putt to finish the hole than puttsLength.length === 2, instead od puttsLength.length > 1.

Resolved checking just that puttsLength.length is strictly more than 1.

---
ISSUE: PGS-18