### PR TITLE
Navigation & Sidebar Reorg — mini variant drawer, no AppBar, Federgolf import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 # dependencies
 /node_modules
 /.pnp
+
+# planning docs (local only)
+/.planning
 .pnp.js
 
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1,0 +1,57 @@
+# Roadmap: Personal Golf Score — Handicap & Course Management
+
+## Overview
+
+This roadmap delivers WHS (World Handicap System) handicap calculation, a shared golf course database, and admin tooling to the existing round-tracking app, plus a unique handicap simulator that lets players project how future scores would affect their index. The work is split into two vertical slices: first the administrative foundation (course database + admin panel), then the player-facing calculation engine (WHS formulas + simulator).
+
+## Phases
+
+- [ ] **Phase 1: Course Database & Admin Foundation** - Admin authentication, route protection, golf course CRUD, and the public `golf_courses` collection
+- [ ] **Phase 2: WHS Engine & Handicap Simulator** - WHS Score Differential and Handicap Index calculation engine plus a dedicated Simulator with course/teebox selection and projected HI display
+
+## Phase Details
+
+### Phase 1: Course Database & Admin Foundation
+**Goal**: Establish course database infrastructure with admin management
+**Mode**: mvp
+**Depends on**: Nothing (first phase)
+**Requirements**: COURSE-01, ADMIN-01, ADMIN-02, ADMIN-03, ADMIN-04
+**Success Criteria** (what must be TRUE):
+  1. Admin users can access admin-only pages; non-admin users are redirected away from admin routes
+  2. Admin can view a list of golf courses, create new courses, edit existing courses, and delete courses via the admin interface
+  3. Admin can promote other users to the admin role and revoke admin access
+  4. A public `golf_courses` Firestore collection stores course data (name, PAR, CR, SR per teebox) with proper security rules — public read, authenticated create, admin-only update/delete
+**Plans**: 3 plans
+**UI hint**: yes
+
+Plans:
+- [x] 01-01-PLAN.md — Foundation: types, Firestore service, security rules (Wave 1)
+- [x] 01-02-PLAN.md — Admin UI Components: AdminRoute, DataGrids, dialogs, snackbar (Wave 2)
+- [ ] 01-03-PLAN.md — Page Integration: admin pages, routes, nav, seed admin (Wave 3)
+
+### Phase 2: WHS Engine & Handicap Simulator
+**Goal**: Enable players to calculate their WHS Handicap Index and simulate future scores
+**Mode**: mvp
+**Depends on**: Phase 1
+**Requirements**: CALC-01, CALC-02, SIM-01, SIM-02, SIM-03
+**Success Criteria** (what must be TRUE):
+  1. User can navigate to the Simulator tab, select a course from the database, and choose a teebox with PAR/CR/SR values
+  2. User can input hypothetical Stableford scores for 18 holes and the system calculates the correct Score Differential using the WHS formula
+  3. User can view their current Handicap Index displayed in the simulator
+  4. User can see a projected Handicap Index alongside their current one, showing what their HI would be with the simulated round included
+  5. User can verify that simulated data does not appear anywhere in their actual round history (no database writes)
+**Plans**: 2 plans
+**UI hint**: yes
+
+Plans:
+- [ ] 02-01-PLAN.md — WHS Calculation Engine + SD Storage + Tests (Wave 1)
+- [ ] 02-02-PLAN.md — Handicap Simulator Page + Nav Integration (Wave 2)
+
+## Progress
+
+**Execution Order:** Phases execute in numeric order: 1 → 2
+
+| Phase | Plans Complete | Status | Completed |
+|-------|----------------|--------|-----------|
+| 1. Course Database & Admin Foundation | 2/3 | In Progress|  |
+| 2. WHS Engine & Handicap Simulator | 0/0 | Not started | - |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -6,8 +6,9 @@ This roadmap delivers WHS (World Handicap System) handicap calculation, a shared
 
 ## Phases
 
-- [ ] **Phase 1: Course Database & Admin Foundation** - Admin authentication, route protection, golf course CRUD, and the public `golf_courses` collection
-- [ ] **Phase 2: WHS Engine & Handicap Simulator** - WHS Score Differential and Handicap Index calculation engine plus a dedicated Simulator with course/teebox selection and projected HI display
+- [x] **Phase 1: Course Database & Admin Foundation** - Admin authentication, route protection, golf course CRUD, and the public `golf_courses` collection (completed 2026-05-31)
+- [x] **Phase 2: WHS Engine & Handicap Simulator** - WHS Score Differential and Handicap Index calculation engine plus a dedicated Simulator with course/teebox selection and projected HI display (completed 2026-06-01)
+- [x] **Phase 3: Navigation & Sidebar Reorg** - Move Avatar menu (HCP, settings, logout) to sidebar; fix admin link visibility; make sidebar responsive across all screen sizes (completed 2026-06-01)
 
 ## Phase Details
 
@@ -31,7 +32,7 @@ Plans:
 
 - [x] 01-01-PLAN.md — Foundation: types, Firestore service, security rules (Wave 1)
 - [x] 01-02-PLAN.md — Admin UI Components: AdminRoute, DataGrids, dialogs, snackbar (Wave 2)
-- [ ] 01-03-PLAN.md — Page Integration: admin pages, routes, nav, seed admin (Wave 3)
+- [x] 01-03-PLAN.md — Page Integration: admin pages, routes, nav, seed admin (Wave 3)
 
 ### Phase 2: WHS Engine & Handicap Simulator
 
@@ -51,19 +52,47 @@ Plans:
 **UI hint**: yes
 
 Plans:
+
 **Wave 1**
 
-- [ ] 02-01-PLAN.md — WHS Calculation Engine + SD Storage + Tests (Wave 1)
+- [x] 02-01-PLAN.md — WHS Calculation Engine + SD Storage + Tests (Wave 1)
 
 **Wave 2** *(blocked on Wave 1 completion)*
 
-- [ ] 02-02-PLAN.md — Handicap Simulator Page + Nav Integration (Wave 2)
+- [x] 02-02-PLAN.md — Handicap Simulator Page + Nav Integration (Wave 2)
+
+### Phase 3: Navigation & Sidebar Reorg
+
+**Goal**: Reorganize navigation so the sidebar (hamburger drawer) contains all user actions — HCP, settings, logout, and admin links — instead of the Avatar menu, and make the sidebar accessible on all screen sizes
+**Depends on**: Phase 1 (admin infra), Phase 2 (HCP display)
+**Requirements**: NAV-01, NAV-02, NAV-03, NAV-04, NAV-05
+**Success Criteria** (what must be TRUE):
+
+  1. Avatar dropdown no longer shows HCP, Settings, or Logout — only the avatar image remains as a visual indicator
+  2. Sidebar drawer is accessible from both mobile and desktop (responsive: temporary on mobile, persistent/toggleable on desktop)
+  3. Sidebar contains: HCP display, Settings link, Logout button (moved from Avatar menu)
+  4. Sidebar properly filters navigation links: public links shown to all users, admin links shown only when `player.isAdmin` is true
+  5. No duplicate link rendering in sidebar (current bug: admin links render twice — once from `links.map()` and once from conditional block)
+
+**Plans**: 2 plans
+**UI hint**: yes
+
+Plans:
+
+**Wave 1**
+
+- [x] 03-01-PLAN.md — Simplify Avatar + create compact SidebarHCP component (Wave 1)
+
+**Wave 2** *(blocked on Wave 1 completion)*
+
+- [x] 03-02-PLAN.md — Responsive sidebar drawer with filtered links, HCP/Settings/Logout (Wave 2)
 
 ## Progress
 
-**Execution Order:** Phases execute in numeric order: 1 → 2
+**Execution Order:** Phases execute in numeric order: 1 → 2 → 3
 
 | Phase | Plans Complete | Status | Completed |
 |-------|----------------|--------|-----------|
-| 1. Course Database & Admin Foundation | 2/3 | In Progress|  |
-| 2. WHS Engine & Handicap Simulator | 0/0 | Not started | - |
+| 1. Course Database & Admin Foundation | 3/3 | Complete   | 2026-05-31 |
+| 2. WHS Engine & Handicap Simulator | 2/2 | Complete   | 2026-06-01 |
+| 3. Navigation & Sidebar Reorg | 2/2 | Complete   | 2026-06-01 |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -12,39 +12,51 @@ This roadmap delivers WHS (World Handicap System) handicap calculation, a shared
 ## Phase Details
 
 ### Phase 1: Course Database & Admin Foundation
+
 **Goal**: Establish course database infrastructure with admin management
 **Mode**: mvp
 **Depends on**: Nothing (first phase)
 **Requirements**: COURSE-01, ADMIN-01, ADMIN-02, ADMIN-03, ADMIN-04
 **Success Criteria** (what must be TRUE):
+
   1. Admin users can access admin-only pages; non-admin users are redirected away from admin routes
   2. Admin can view a list of golf courses, create new courses, edit existing courses, and delete courses via the admin interface
   3. Admin can promote other users to the admin role and revoke admin access
   4. A public `golf_courses` Firestore collection stores course data (name, PAR, CR, SR per teebox) with proper security rules — public read, authenticated create, admin-only update/delete
+
 **Plans**: 3 plans
 **UI hint**: yes
 
 Plans:
+
 - [x] 01-01-PLAN.md — Foundation: types, Firestore service, security rules (Wave 1)
 - [x] 01-02-PLAN.md — Admin UI Components: AdminRoute, DataGrids, dialogs, snackbar (Wave 2)
 - [ ] 01-03-PLAN.md — Page Integration: admin pages, routes, nav, seed admin (Wave 3)
 
 ### Phase 2: WHS Engine & Handicap Simulator
+
 **Goal**: Enable players to calculate their WHS Handicap Index and simulate future scores
 **Mode**: mvp
 **Depends on**: Phase 1
 **Requirements**: CALC-01, CALC-02, SIM-01, SIM-02, SIM-03
 **Success Criteria** (what must be TRUE):
+
   1. User can navigate to the Simulator tab, select a course from the database, and choose a teebox with PAR/CR/SR values
   2. User can input hypothetical Stableford scores for 18 holes and the system calculates the correct Score Differential using the WHS formula
   3. User can view their current Handicap Index displayed in the simulator
   4. User can see a projected Handicap Index alongside their current one, showing what their HI would be with the simulated round included
   5. User can verify that simulated data does not appear anywhere in their actual round history (no database writes)
+
 **Plans**: 2 plans
 **UI hint**: yes
 
 Plans:
+**Wave 1**
+
 - [ ] 02-01-PLAN.md — WHS Calculation Engine + SD Storage + Tests (Wave 1)
+
+**Wave 2** *(blocked on Wave 1 completion)*
+
 - [ ] 02-02-PLAN.md — Handicap Simulator Page + Nav Integration (Wave 2)
 
 ## Progress

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,13 +3,13 @@ gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: milestone
 status: executing
-stopped_at: Phase 2 planning complete
-last_updated: "2026-06-01T05:38:04.189Z"
-last_activity: 2026-05-31 -- Phase 01 execution started
+stopped_at: Phase 2 context gathered
+last_updated: "2026-06-01T05:54:59.073Z"
+last_activity: 2026-06-01 -- Phase 02 planning complete
 progress:
   total_phases: 2
   completed_phases: 1
-  total_plans: 3
+  total_plans: 5
   completed_plans: 3
   percent: 50
 ---
@@ -27,8 +27,8 @@ See: .planning/PROJECT.md (updated 2026-05-31)
 
 Phase: 02 (whs-engine-handicap-simulator) — PLANNED
 Plan: 0 of 2
-Status: Planning complete
-Last activity: 2026-06-01 -- Phase 02 planning completed
+Status: Ready to execute
+Last activity: 2026-06-01 -- Phase 02 planning complete
 
 Progress: [░░░░░░░░░░] 0%
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,7 +3,7 @@ gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: milestone
 status: executing
-stopped_at: Phase 2 context gathered
+stopped_at: Phase 2 planning complete
 last_updated: "2026-06-01T05:38:04.189Z"
 last_activity: 2026-05-31 -- Phase 01 execution started
 progress:
@@ -21,14 +21,14 @@ progress:
 See: .planning/PROJECT.md (updated 2026-05-31)
 
 **Core value:** Players can accurately calculate their WHS handicap index from their rounds and simulate how future scores would affect it.
-**Current focus:** Phase 01 — course-database-admin-foundation
+**Current focus:** Phase 02 — whs-engine-handicap-simulator
 
 ## Current Position
 
-Phase: 01 (course-database-admin-foundation) — EXECUTING
-Plan: 1 of 3
-Status: Executing Phase 01
-Last activity: 2026-05-31 -- Phase 01 execution started
+Phase: 02 (whs-engine-handicap-simulator) — PLANNED
+Plan: 0 of 2
+Status: Planning complete
+Last activity: 2026-06-01 -- Phase 02 planning completed
 
 Progress: [░░░░░░░░░░] 0%
 
@@ -36,7 +36,7 @@ Progress: [░░░░░░░░░░] 0%
 
 **Velocity:**
 
-- Total plans completed: 0
+- Total plans completed: 2 (Phase 1)
 - Average duration: —
 - Total execution time: —
 
@@ -44,11 +44,12 @@ Progress: [░░░░░░░░░░] 0%
 
 | Phase | Plans | Total | Avg/Plan |
 |-------|-------|-------|----------|
-| — | — | — | — |
+| 1. Course Database & Admin Foundation | 2/3 | — | — |
+| 2. WHS Engine & Handicap Simulator | 0/2 | — | — |
 
 **Recent Trend:**
 
-- Last 5 plans: —
+- Last 5 plans: Phase 1 plans 01–02 completed
 - Trend: —
 
 *Updated after each plan completion*

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,15 +3,15 @@ gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: milestone
 status: executing
-stopped_at: Phase 2 context gathered
-last_updated: "2026-06-01T05:54:59.073Z"
-last_activity: 2026-06-01 -- Phase 02 planning complete
+stopped_at: Completed 03-02-PLAN.md
+last_updated: "2026-06-01T09:35:00.000Z"
+last_activity: 2026-06-01 -- Phase 03 execution completed
 progress:
-  total_phases: 2
-  completed_phases: 1
-  total_plans: 5
-  completed_plans: 3
-  percent: 50
+  total_phases: 3
+  completed_phases: 3
+  total_plans: 7
+  completed_plans: 7
+  percent: 100
 ---
 
 # Project State
@@ -21,16 +21,16 @@ progress:
 See: .planning/PROJECT.md (updated 2026-05-31)
 
 **Core value:** Players can accurately calculate their WHS handicap index from their rounds and simulate how future scores would affect it.
-**Current focus:** Phase 02 — whs-engine-handicap-simulator
+**Current focus:** Phase 03 — navigation-and-sidebar-reorg (completed 2026-06-01)
 
 ## Current Position
 
-Phase: 02 (whs-engine-handicap-simulator) — PLANNED
-Plan: 0 of 2
-Status: Ready to execute
-Last activity: 2026-06-01 -- Phase 02 planning complete
+Phase: 03 (navigation-and-sidebar-reorg) — COMPLETE
+Plans: 2 of 2
+Status: Complete
+Last activity: 2026-06-01 -- Phase 03 execution completed
 
-Progress: [░░░░░░░░░░] 0%
+Progress: [██████████] 100%
 
 ## Performance Metrics
 
@@ -44,15 +44,20 @@ Progress: [░░░░░░░░░░] 0%
 
 | Phase | Plans | Total | Avg/Plan |
 |-------|-------|-------|----------|
-| 1. Course Database & Admin Foundation | 2/3 | — | — |
-| 2. WHS Engine & Handicap Simulator | 0/2 | — | — |
+| 1. Course Database & Admin Foundation | 3/3 | — | — |
+| 2. WHS Engine & Handicap Simulator | 2/2 | — | — |
+| 3. Navigation & Sidebar Reorg | 2/2 | — | — |
 
 **Recent Trend:**
 
-- Last 5 plans: Phase 1 plans 01–02 completed
+- Last 5 plans: Phase 1 plans 01–03, Phase 2 plans 01–02 completed
 - Trend: —
 
 *Updated after each plan completion*
+| Phase 02-whs-engine-handicap-simulator P01 | 18min | 3 tasks | 9 files |
+| Phase 02 P02 | 3min | 2 tasks | 5 files |
+| Phase 03-01 P01 | 2min | 2 tasks | 2 files |
+| Phase 03-02 P02 | 2min | 2 tasks | 1 file |
 
 ## Accumulated Context
 
@@ -61,7 +66,13 @@ Progress: [░░░░░░░░░░] 0%
 Decisions are logged in PROJECT.md Key Decisions table.
 Recent decisions affecting current work:
 
-- None yet — phase planning will surface decisions.
+- — phase planning will surface decisions.
+- [Phase 3]: Avatar is visual-only — no dropdown, no popover, no HCP/settings/logout
+- [Phase 3]: Sidebar drawer is primary navigation hub on all screen sizes
+- [Phase 3]: Desktop drawer uses persistent variant (toggleable via hamburger)
+- [Phase 3]: Nav link clicks do NOT close drawer on desktop (only hamburger toggle)
+- [Phase 3]: Admin links render only inside `player.isAdmin` conditional block — not from links.map()
+- [Phase 3]: Navigation links filtered by `show === true` property
 
 ### Pending Todos
 
@@ -79,6 +90,6 @@ None yet.
 
 ## Session Continuity
 
-Last session: 2026-06-01T05:38:04.178Z
-Stopped at: Phase 2 context gathered
-Resume file: .planning/phases/02-whs-engine-handicap-simulator/02-CONTEXT.md
+Last session: 2026-06-01T09:35:00.000Z
+Stopped at: Completed 03-02-PLAN.md
+Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,0 +1,83 @@
+---
+gsd_state_version: 1.0
+milestone: v1.0
+milestone_name: milestone
+status: executing
+stopped_at: Phase 2 context gathered
+last_updated: "2026-06-01T05:38:04.189Z"
+last_activity: 2026-05-31 -- Phase 01 execution started
+progress:
+  total_phases: 2
+  completed_phases: 1
+  total_plans: 3
+  completed_plans: 3
+  percent: 50
+---
+
+# Project State
+
+## Project Reference
+
+See: .planning/PROJECT.md (updated 2026-05-31)
+
+**Core value:** Players can accurately calculate their WHS handicap index from their rounds and simulate how future scores would affect it.
+**Current focus:** Phase 01 — course-database-admin-foundation
+
+## Current Position
+
+Phase: 01 (course-database-admin-foundation) — EXECUTING
+Plan: 1 of 3
+Status: Executing Phase 01
+Last activity: 2026-05-31 -- Phase 01 execution started
+
+Progress: [░░░░░░░░░░] 0%
+
+## Performance Metrics
+
+**Velocity:**
+
+- Total plans completed: 0
+- Average duration: —
+- Total execution time: —
+
+**By Phase:**
+
+| Phase | Plans | Total | Avg/Plan |
+|-------|-------|-------|----------|
+| — | — | — | — |
+
+**Recent Trend:**
+
+- Last 5 plans: —
+- Trend: —
+
+*Updated after each plan completion*
+
+## Accumulated Context
+
+### Decisions
+
+Decisions are logged in PROJECT.md Key Decisions table.
+Recent decisions affecting current work:
+
+- None yet — phase planning will surface decisions.
+
+### Pending Todos
+
+None yet.
+
+### Blockers/Concerns
+
+None yet.
+
+## Deferred Items
+
+| Category | Item | Status | Deferred At |
+|----------|------|--------|-------------|
+| *(none)* | | | |
+
+## Session Continuity
+
+Last session: 2026-06-01T05:38:04.178Z
+Stopped at: Phase 2 context gathered
+Resume file: .planning/phases/02-whs-engine-handicap-simulator/02-CONTEXT.md

--- a/.planning/phases/02-whs-engine-handicap-simulator/02-01-PLAN.md
+++ b/.planning/phases/02-whs-engine-handicap-simulator/02-01-PLAN.md
@@ -1,0 +1,268 @@
+---
+phase: 02-whs-engine-handicap-simulator
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/dev-tools/whsTestData.ts
+  - src/dev-tools/whsTestRunner.ts
+  - src/utils/whs/whs.utils.tsx
+  - src/utils/whs/hi.utils.tsx
+  - src/types/roundData.types.tsx
+  - src/utils/round/round.utils.tsx
+  - src/utils/firestore/round.firestore.ts
+  - src/utils/firestore/course.firestore.ts
+  - package.json
+autonomous: true
+requirements: [CALC-01, CALC-02]
+user_setup: []
+must_haves:
+  truths:
+    - "Score Differential is correctly computed from Stableford + course data using WHS Rule 5.1 formula"
+    - "Handicap Index is correctly computed from existing round SDs using WHS Rule 5.2a with proper scaling for fewer rounds"
+    - "Newly saved rounds have their SD computed and stored in Firestore at save time"
+    - "WHS test runner produces passing results matching known expected values"
+  artifacts:
+    - path: "src/utils/whs/whs.utils.tsx"
+      provides: "Score Differential and Playing Handicap calculation"
+      exports: ["calculateScoreDifferential", "IScoreDifferentialProps", "IScoreDifferentialResult"]
+    - path: "src/utils/whs/hi.utils.tsx"
+      provides: "Handicap Index calculation and projection"
+      exports: ["calculateHandicapIndex", "calculateProjectedHandicapIndex"]
+    - path: "src/types/roundData.types.tsx"
+      provides: "scoreDifferential field on IBasicRoundData"
+      contains: "scoreDifferential?: number | null"
+    - path: "src/dev-tools/whsTestRunner.ts"
+      provides: "WHS-specific test execution"
+      exports: ["WHSTestRunner"]
+    - path: "src/utils/firestore/course.firestore.ts"
+      provides: "getCourseByName helper for SD computation"
+      exports: ["getCourseByName"]
+  key_links:
+    - from: "src/utils/firestore/round.firestore.ts"
+      to: "src/utils/whs/whs.utils.tsx"
+      via: "import calculateScoreDifferential"
+      pattern: "calculateScoreDifferential"
+    - from: "src/utils/firestore/round.firestore.ts"
+      to: "src/utils/firestore/course.firestore.ts"
+      via: "import getCourseByName to fetch courseRating/slopeRating"
+      pattern: "getCourseByName"
+    - from: "src/utils/round/round.utils.tsx"
+      to: "src/types/roundData.types.tsx"
+      via: "scoreDifferential field in batch.set call"
+      pattern: "scoreDifferential"
+---
+
+## Phase Goal
+
+**As a** player, **I want to** calculate my WHS Handicap Index and simulate how future scores would affect it, **so that** I can understand my current handicap and plan my game improvement.
+
+<objective>
+**Plan 01 — WHS Calculation Engine & Score Differential Storage**
+
+Deliver the core WHS calculation functions (Score Differential, Handicap Index) plus the integration that stores SDs when rounds are saved. This is the engine that both the Simulator page (Plan 02) and future automatic HI features depend on.
+
+**Purpose:** Establish all pure WHS math functions in a testable, auditable form and wire SD computation into the round save flow.
+**Output:** Pure calculation utilities in `src/utils/whs/`, Firestore schema + save integration, WHS-specific dev-tool tests.
+</objective>
+
+<execution_context>
+@/Users/abstract/.config/opencode/get-shit-done/workflows/execute-plan.md
+@/Users/abstract/.config/opencode/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/phases/02-whs-engine-handicap-simulator/02-CONTEXT.md
+@.planning/phases/02-whs-engine-handicap-simulator/02-RESEARCH.md
+@.planning/phases/02-whs-engine-handicap-simulator/02-PATTERNS.md
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Create WHS test suite with failing test cases for Score Differential and Handicap Index</name>
+  <files>
+    src/dev-tools/whsTestData.ts
+    src/dev-tools/whsTestRunner.ts
+    package.json
+  </files>
+  <read_first>
+    src/dev-tools/edgeCaseTests.ts
+    src/dev-tools/testRunner.ts
+    src/dev-tools/testDataGenerator.ts
+  </read_first>
+  <behavior>
+    - Test 1: calculateScoreDifferential with known inputs produces expected SD (72 par, 72.5 CR, 135 SR, 42 Stableford points, 18 Playing HCP → 4.6 SD)
+    - Test 2: calculateHandicapIndex with 20 SDs (best 8) produces expected HI
+    - Test 3: calculateHandicapIndex with 5 SDs (scaling: lowest 1) produces expected HI
+    - Test 4: calculateHandicapIndex with 2 SDs returns null (< 3 rounds)
+    - Test 5: calculateProjectedHandicapIndex appends simulated SD as most recent
+    - Test 6: calculatePlayingHandicap produces expected rounded result
+  </behavior>
+  <action>
+    Create `src/dev-tools/whsTestData.ts` with static arrays of test cases following the pattern from `edgeCaseTests.ts`. Define `WHSScoreDifferentialTestCases`, `WHSHandicapIndexTestCases`, `WHSProjectedHITestCases`, and `WHSPlayingHCPTestCases`. Each test case has: `name`, `input` object, `expectedSD`/`expectedHI`/`expectedAGS`/`expectedPlayingHCP` as appropriate.
+
+    Create `src/dev-tools/whsTestRunner.ts` as a CLI-entry test runner following the `testRunner.ts` pattern. Import test cases from `whsTestData.ts`. Export `WHSTestRunner` class with `runAll()` (runs every test case with pass/fail output) and `runQuick()` (runs a representative subset). The runner must: iterate cases, call the calculation function, compare actual vs expected with a tolerance of 0.1, log pass/fail per case, and return a summary.
+
+    Add npm scripts to `package.json`:
+    - `"test:calc:whs": "tsx src/dev-tools/whsTestRunner.ts all"`
+    - `"test:calc:whs-quick": "tsx src/dev-tools/whsTestRunner.ts quick"`
+
+    Use the import path `@/utils/whs/whs.utils` and `@/utils/whs/hi.utils` for the calculation functions (they will NOT exist yet, so the tests will fail — this is intentional per MVP mode).
+  </action>
+  <verify>
+    <automated>npm run test:calc:whs-quick && npm run test:calc:whs</automated>
+  </verify>
+  <done>
+    <acceptance_criteria>
+      - `src/dev-tools/whsTestData.ts` exists with named test case arrays (WHSScoreDifferentialTestCases, WHSHandicapIndexTestCases, WHSProjectedHITestCases, WHSPlayingHCPTestCases)
+      - `src/dev-tools/whsTestRunner.ts` exists with WHSTestRunner class (static runAll, runQuick methods)
+      - `package.json` contains "test:calc:whs" and "test:calc:whs-quick" scripts using `tsx` runner (not `node --import tsx`)
+      - Running `npm run test:calc:whs-quick` fails with module-not-found errors for @/utils/whs/ imports (expected — Task 2 creates these)
+    </acceptance_criteria>
+  </done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Implement WHS calculation engine (whs.utils.tsx + hi.utils.tsx) to pass all tests</name>
+  <files>
+    src/utils/whs/whs.utils.tsx
+    src/utils/whs/hi.utils.tsx
+  </files>
+  <read_first>
+    src/utils/calculator/TotalsCalculator.utils.tsx
+    src/utils/calculator/math.utils.tsx
+    src/utils/whs/whs.utils.tsx (if already created — will create fresh)
+    src/utils/whs/hi.utils.tsx (if already created — will create fresh)
+  </read_first>
+  <action>
+    Create `src/utils/whs/whs.utils.tsx` with:
+    - Import `{ safeDivide }` from `@/utils/calculator/math.utils` (D-02)
+    - Export `IScoreDifferentialProps` interface with fields: `par: number`, `courseRating: number`, `slopeRating: number`, `stablefordPoints: number`, `playingHCP: number`
+    - Export `IScoreDifferentialResult` interface with fields: `adjustedGrossScore: number`, `scoreDifferential: number`
+    - Export `calculateScoreDifferential(props: IScoreDifferentialProps): IScoreDifferentialResult` — pure function per WHS Rule 5.1: AGS = par + playingHCP + (36 - stablefordPoints); SD = Math.max(0, safeDivide((AGS - courseRating) * 113, slopeRating, 1))
+    - Export `calculatePlayingHandicap(handicapIndex: number, courseRating: number, slopeRating: number, par: number): number` — returns Math.round(handicapIndex * (slopeRating / 113) + (courseRating - par)) per D-09
+
+    Create `src/utils/whs/hi.utils.tsx` with:
+    - Import `{ safeDivide }` from `@/utils/calculator/math.utils`
+    - Export `calculateHandicapIndex(scoreDifferentials: number[]): number | null` — per WHS Rule 5.2a: filter to most recent 20, use HI_SCALING table (3→1, 4→1, 5→1, 6→2, 7→2, 8→2, 9→3, 10→3, 11→3, 12→4, 13→4, 14→4, 15→5, 16→5, 17→6, 18→6, 19→7, 20→8), sort ascending, take lowest N, average with safeDivide precision 1. Return null if < 3 rounds.
+    - Export `calculateProjectedHandicapIndex(currentSDs: number[], simulatedSD: number): number | null` — creates virtual array [simulatedSD, ...currentSDs.slice(0, 19)] and delegates to calculateHandicapIndex. Per SIM-03: no database interaction.
+    - Both files follow the TotalsCalculator pattern: named exports, typed interfaces, pure functions, no side effects, no I/O, no try/catch (D-02).
+  </action>
+  <verify>
+    <automated>npm run test:calc:whs-quick && npm run test:calc:whs</automated>
+  </verify>
+  <done>
+    <acceptance_criteria>
+      - `npm run test:calc:whs-quick` exits 0 with all tests passing
+      - `npm run test:calc:whs` exits 0 with all tests passing
+      - `calculateScoreDifferential({ par: 72, courseRating: 72.5, slopeRating: 135, stablefordPoints: 42, playingHCP: 18 })` returns `{ adjustedGrossScore: 78, scoreDifferential: 4.6 }`
+      - `calculateHandicapIndex([])` returns null (no rounds)
+      - `calculateHandicapIndex([14.6, 10.2, 12.1, 15.0, 9.8])` returns lowest 1 of most recent 5 sorted ascending (the 5-SD scaling case)
+      - `calculatePlayingHandicap(12.4, 72.5, 135, 72)` returns `Math.round(12.4 * 135/113 + (72.5 - 72))` = 15
+    </acceptance_criteria>
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Integrate Score Differential storage into round save flow</name>
+  <files>
+    src/types/roundData.types.tsx
+    src/utils/round/round.utils.tsx
+    src/utils/firestore/round.firestore.ts
+    src/utils/firestore/course.firestore.ts
+  </files>
+  <read_first>
+    src/types/roundData.types.tsx
+    src/types/round.types.tsx
+    src/types/course.types.tsx
+    src/utils/round/round.utils.tsx
+    src/utils/firestore/round.firestore.ts
+    src/utils/firestore/course.firestore.ts
+  </read_first>
+  <action>
+    **Step 1 — Add `scoreDifferential` field to types (per D-03):**
+    In `src/types/roundData.types.tsx`, add `scoreDifferential?: number | null;` to the `IBasicRoundData` interface (after `createdAt`, before `totals`).
+
+    No changes needed in `src/types/roundDetails.types.tsx` — `scoreDifferential` is inherited from `IBasicRoundData`.
+
+    **Step 2 — Add `getCourseByName` to course.firestore.ts:**
+    Add a new exported async function `getCourseByName(name: string): Promise<ICourse | null>` following the exact pattern of `getCourseById`. Query the `golf_courses` collection with `where('name', '==', name)` constraint. Use `getDocs` and return the first matching doc, or null if none found. Import `where` from `firebase/firestore`. Follow the same try/catch + console.error pattern.
+
+    **Step 3 — Add `scoreDifferential` field to prepareRoundSaveBatch:**
+    In `src/utils/round/round.utils.tsx`, add `scoreDifferential: null,` to the `batch.set(roundRef, {...})` call inside `prepareRoundSaveBatch()`. This ensures the field exists on every round document going forward. Per D-03: existing rounds remain null; SD is only computed for new saves.
+
+    **Step 4 — Compute SD in saveNewRound and pass to prepareRoundSaveBatch:**
+    The goal: compute `scoreDifferential` from round data before `prepareRoundSaveBatch` is called, then pass it as a new parameter.
+
+    Option A (preferred, simpler): Modify `prepareRoundSaveBatch` to accept an optional `scoreDifferential?: number | null` parameter. In `saveNewRound()`, compute the SD before calling `prepareRoundSaveBatch`, then pass it.
+
+    Specific integration in `src/utils/firestore/round.firestore.ts` — in `saveNewRound()`:
+    1. Before calling `prepareRoundSaveBatch`, read `general.roundCourse` (course name) and `general.roundTee` (teebox name).
+    2. Call `getCourseByName(general.roundCourse)` to get the course.
+    3. Find the teebox: `course?.teeboxes.find(t => t.name === general.roundTee)`.
+    4. If teebox found, compute SD using `calculateScoreDifferential({ par: general.roundPar, courseRating: teebox.courseRating, slopeRating: teebox.slopeRating, stablefordPoints: currentTotals.points.totals, playingHCP: general.roundPlayingHCP })`.
+    5. Import `calculateScoreDifferential` from `@/utils/whs/whs.utils` (D-02, D-03).
+    6. If course/teebox not found, set `scoreDifferential = null` and log a warning — round save continues without SD.
+    7. Pass the computed `scoreDifferential` to `prepareRoundSaveBatch`.
+
+    In `src/utils/round/round.utils.tsx`, update `prepareRoundSaveBatch` signature to accept `scoreDifferential?: number | null`, and set the field in the batch write instead of hardcoding `null`.
+
+    Do NOT modify the `holes.forEach` batch writes — only the round document itself.
+
+    Import path for `calculateScoreDifferential` in round.firestore.ts: `import { calculateScoreDifferential } from '@/utils/whs/whs.utils';`
+  </action>
+  <verify>
+    <automated>npm run type-check && npm run test:calc:whs-quick</automated>
+  </verify>
+  <done>
+    <acceptance_criteria>
+      - `src/types/roundData.types.tsx` — `IBasicRoundData` has `scoreDifferential?: number | null` field
+      - `src/utils/firestore/course.firestore.ts` exports `getCourseByName(name: string): Promise<ICourse | null>`
+      - `src/utils/round/round.utils.tsx` — `prepareRoundSaveBatch` accepts `scoreDifferential` parameter and includes it in the batch.set call
+      - `src/utils/firestore/round.firestore.ts` — `saveNewRound()` computes SD via `calculateScoreDifferential` and passes it to `prepareRoundSaveBatch`
+      - `npm run type-check` exits 0
+      - `npm run test:calc:whs-quick` exits 0 (existing tests unaffected)
+    </acceptance_criteria>
+  </done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| client→Firestore (round save) | SD computed client-side, stored in Firestore round documents |
+| client→Firestore (course read) | Course data fetched from public `golf_courses` collection |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-02-01 | Tampering | `saveNewRound()` — Stableford/PlayingHCP input could be manipulated client-side before SD computation | accept | SD is informational display data, not financial. No integrity-critical dependency on accurate SD at this stage. v2 CALC-03 (automatic HI) will require server-side SD validation. |
+| T-02-02 | Spoofing | `getCourseByName` — query by course name string could mismatch if names are not unique | mitigate | Use Firestore `where('name', '==', name)` query with limit(1); log warning if no match found or multiple matches; fall back to null SD without blocking round save. |
+| T-02-03 | Information Disclosure | `scoreDifferential` field on round documents readable by authenticated users | accept | Existing Firestore rules already restrict round reads to the round owner. SD is on the same document — inherits existing protection. |
+| T-02-SC | Tampering | npm scripts — no new packages in this plan; existing packages unchanged | accept | No npm install occurs. No package legitimacy check needed. |
+</threat_model>
+
+<verification>
+- All WHS test cases pass (npm run test:calc:whs exits 0)
+- TypeScript compilation passes (npm run type-check exits 0)
+- SD computation integration doesn't break existing round save flow
+</verification>
+
+<success_criteria>
+- WHS engine calculates Score Differential and Handicap Index correctly per WHS Rules 5.1 and 5.2a
+- New rounds saved during this phase store their SD in Firestore
+- Existing rounds retain null SD (no backfill)
+- All tests pass; type-check passes
+</success_criteria>
+
+<output>
+Create `.planning/phases/02-whs-engine-handicap-simulator/02-01-SUMMARY.md` when done
+</output>

--- a/.planning/phases/02-whs-engine-handicap-simulator/02-01-PLAN.md
+++ b/.planning/phases/02-whs-engine-handicap-simulator/02-01-PLAN.md
@@ -19,10 +19,12 @@ requirements: [CALC-01, CALC-02]
 user_setup: []
 must_haves:
   truths:
-    - "Score Differential is correctly computed from Stableford + course data using WHS Rule 5.1 formula"
-    - "Handicap Index is correctly computed from existing round SDs using WHS Rule 5.2a with proper scaling for fewer rounds"
-    - "Newly saved rounds have their SD computed and stored in Firestore at save time"
-    - "WHS test runner produces passing results matching known expected values"
+    - "D-01: New `src/utils/whs/whs.utils.tsx` and `hi.utils.tsx` exist with exported calculation functions"
+    - "D-02: WHS calculation functions follow TotalsCalculator pattern — typed Props interface, pure function, typed return, safeDivide usage"
+    - "D-03: Score Differential stored on round document at save time (`scoreDifferential: number | null`)"
+    - "Running `npm run test:calc:whs-quick` shows Score Differential values matching WHS Rule 5.1 expected outputs"
+    - "Running `npm run test:calc:whs` shows Handicap Index values following WHS Rule 5.2a scaling rules"
+    - "`npm run test:calc:whs` exits with code 0 and reports all tests passing"
   artifacts:
     - path: "src/utils/whs/whs.utils.tsx"
       provides: "Score Differential and Playing Handicap calculation"

--- a/.planning/phases/02-whs-engine-handicap-simulator/02-02-PLAN.md
+++ b/.planning/phases/02-whs-engine-handicap-simulator/02-02-PLAN.md
@@ -1,0 +1,292 @@
+---
+phase: 02-whs-engine-handicap-simulator
+plan: 02
+type: execute
+wave: 2
+depends_on: [02-01]
+files_modified:
+  - src/pages/Simulator.page.tsx
+  - src/components/Simulator/Simulator.component.tsx
+  - src/App.tsx
+  - src/utils/links/links.utils.tsx
+  - src/components/layout/MainLayout2.component.tsx
+autonomous: true
+requirements: [SIM-01, SIM-02, SIM-03]
+user_setup: []
+must_haves:
+  truths:
+    - "User can navigate to the Simulator tab from the app navigation"
+    - "User can select a course from the dropdown, then select a teebox with PAR/CR/SR visible"
+    - "User can enter total Stableford points for a hypothetical round"
+    - "Simulator displays current Handicap Index vs projected Handicap Index with delta (+/-)"
+    - "Simulator shows the simulated Score Differential and a best-8 breakdown comparison"
+    - "Simulator never writes to Firestore — all computation is local"
+  artifacts:
+    - path: "src/pages/Simulator.page.tsx"
+      provides: "Simulator route entry point"
+      exports: ["default SimulatorPage"]
+    - path: "src/components/Simulator/Simulator.component.tsx"
+      provides: "Full simulator UI: course selection, Stableford input, results display"
+      contains: "useState, useMemo, calculateHandicapIndex, calculateScoreDifferential"
+    - path: "src/App.tsx"
+      provides: "/simulator route"
+      contains: "Route path='/simulator'"
+    - path: "src/utils/links/links.utils.tsx"
+      provides: "Simulator nav item"
+      contains: "id: 5, name: 'Simulator', link: '/simulator'"
+    - path: "src/components/layout/MainLayout2.component.tsx"
+      provides: "Simulator breadcrumbs"
+      contains: "path === '/simulator'"
+  key_links:
+    - from: "src/components/Simulator/Simulator.component.tsx"
+      to: "src/utils/whs/whs.utils"
+      via: "import calculateScoreDifferential"
+      pattern: "calculateScoreDifferential"
+    - from: "src/components/Simulator/Simulator.component.tsx"
+      to: "src/utils/whs/hi.utils"
+      via: "import calculateHandicapIndex, calculateProjectedHandicapIndex"
+      pattern: "calculateHandicapIndex|calculateProjectedHandicapIndex"
+    - from: "src/components/Simulator/Simulator.component.tsx"
+      to: "src/store/zustand/app.store"
+      via: "useAppStore select roundsList"
+      pattern: "useAppStore"
+    - from: "src/components/Simulator/Simulator.component.tsx"
+      to: "src/utils/firestore/course.firestore"
+      via: "import getAllCourses"
+      pattern: "getAllCourses"
+---
+
+## Phase Goal
+
+**As a** player, **I want to** calculate my WHS Handicap Index and simulate how future scores would affect it, **so that** I can understand my current handicap and plan my game improvement.
+
+<objective>
+**Plan 02 — Handicap Simulator Page**
+
+Build the full Simulator page where players can select a course/teebox, enter hypothetical Stableford points, and see projected Handicap Index impact — all without saving anything to the database.
+
+**Purpose:** Deliver the user-facing simulator experience that makes the WHS engine from Plan 01 visible and interactive.
+**Output:** Simulator page + component, route, nav item, breadcrumbs.
+</objective>
+
+<execution_context>
+@/Users/abstract/.config/opencode/get-shit-done/workflows/execute-plan.md
+@/Users/abstract/.config/opencode/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/phases/02-whs-engine-handicap-simulator/02-CONTEXT.md
+@.planning/phases/02-whs-engine-handicap-simulator/02-RESEARCH.md
+@.planning/phases/02-whs-engine-handicap-simulator/02-PATTERNS.md
+@.planning/phases/02-whs-engine-handicap-simulator/02-01-PLAN.md
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Create Simulator page and component with course selection, Stableford input, and results display</name>
+  <files>
+    src/pages/Simulator.page.tsx
+    src/components/Simulator/Simulator.component.tsx
+  </files>
+  <read_first>
+    src/pages/Statistics.page.tsx
+    src/components/Statistics/StatisticsMain.component.tsx
+    src/utils/firestore/course.firestore.ts
+    src/store/zustand/app.store.ts
+    src/types/course.types.tsx
+    src/utils/whs/whs.utils.tsx (created in Plan 01)
+    src/utils/whs/hi.utils.tsx (created in Plan 01)
+  </read_first>
+  <action>
+    Create `src/pages/Simulator.page.tsx` as a slim page component (following the `Statistics.page.tsx` pattern) that delegates entirely to `<Simulator />` and exports as default.
+
+    Create `src/components/Simulator/Simulator.component.tsx` with the following structure and behavior per D-05 through D-10:
+
+    **State management:** Use React component state (useState) per discretion area — simulator state is ephemeral and does not need Zustand persist. Per D-08: no Firestore writes.
+
+    **Imports:**
+    - `{ useState, useEffect, useMemo }` from 'react'
+    - MUI components: `Card, CardContent, Typography, TextField, Select, MenuItem, FormControl, InputLabel, Grid, Box, Divider, Alert, CircularProgress, Tooltip, IconButton`
+    - `{ getAllCourses }` from `@/utils/firestore/course.firestore`
+    - `{ useAppStore }` from `@/store/zustand`
+    - `{ ICourse, ITeebox }` from `@/types/course.types`
+    - `{ calculateScoreDifferential, calculatePlayingHandicap }` from `@/utils/whs/whs.utils` (D-01)
+    - `{ calculateHandicapIndex, calculateProjectedHandicapIndex }` from `@/utils/whs/hi.utils`
+    - `AutoGraphIcon` from `@mui/icons-material/AutoGraph`
+
+    **State variables:**
+    - `courses: ICourse[]` — all active courses loaded from Firestore
+    - `selectedCourse: ICourse | null` — currently selected course
+    - `selectedTeebox: ITeebox | null` — currently selected teebox
+    - `stablefordPoints: number` — default 36 (neutral round)
+    - `manualPlayingHCP: string` — empty string means auto-calc; number string means manual override (D-10)
+    - `loading: boolean` — true while courses are loading
+
+    **Course loading (useEffect on mount):**
+    - Call `getAllCourses()` and filter `c => c.status === 'Active'`
+    - Set courses in state
+    - Error handling: log error, set empty courses array
+    - Follow the pattern from PATTERNS.md Section "Course loading pattern"
+
+    **Computed values (useMemo):**
+    - `currentHI: number | null` — from `calculateHandicapIndex()` on `roundsList` SDs. Read `roundsList` from Zustand via `useAppStore((state) => state.roundsList)`. Filter null SDs, map to number[], pass to calculateHandicapIndex.
+    - `autoPlayingHCP: number | null` — when `selectedTeebox` and `currentHI` are available, compute `calculatePlayingHandicap(currentHI, selectedTeebox.courseRating, selectedTeebox.slopeRating, selectedTeebox.par)`. Per D-09 and D-10.
+    - `effectivePlayingHCP: number | null` — if `manualPlayingHCP` is non-empty string, parse it; otherwise use `autoPlayingHCP`
+    - `simulatedResult: IScoreDifferentialResult | null` — when teebox, effectivePlayingHCP, and stablefordPoints are valid, call `calculateScoreDifferential({ par: selectedTeebox.par, courseRating: selectedTeebox.courseRating, slopeRating: selectedTeebox.slopeRating, stablefordPoints, playingHCP: effectivePlayingHCP })`
+    - `projectedHI: number | null` — when `simulatedResult` is available, build virtual array: `[simulatedResult.scoreDifferential, ...realSDs.slice(0, 19)]` and call `calculateProjectedHandicapIndex()`. Per SIM-03: no database writes — operates entirely on local data.
+
+    **Layout (per D-06, D-07):**
+
+    1. **Header section:** Page title with icon "Handicap Simulator" (using AutoGraphIcon)
+    2. **Course Selection card:**
+       - Course dropdown (Select/FormControl) — label "Course", show all active courses. On change: reset teebox selection.
+       - Teebox dropdown (Select/FormControl) — label "Teebox", enabled only when course selected. Each MenuItem shows: `{teebox.name} — Par {teebox.par}, CR {teebox.courseRating}, SR {teebox.slopeRating}`
+       - If selectedCourse has no teeboxes: show Alert "No teeboxes defined for this course" and disable teebox selection
+    3. **Score Input card:**
+       - TextField for Stableford points — numeric, type="number", min=0, max=36, label "Total Stableford Points", helperText "Enter total Stableford points (0-36)"
+       - TextField for Playing Handicap — label "Playing Handicap", shows auto-calculated value as default (D-10), allows manual override. Use helperText to indicate auto-calc source: e.g., `Auto-calculated from HI: {autoPlayingHCP}` when manual override is empty, or show the auto value in a Tooltip.
+       - Validate Stableford input: clamp to 0-36, show error if out of range. Per V5 input validation requirement.
+    4. **Results card (per D-07):**
+       - Only visible when simulatedResult is computed (all inputs valid)
+       - Show as Card with CardContent containing:
+         - "Current Handicap Index: {value}" — if null, show "— (need at least 3 rounds)"
+         - "Simulated Score Differential: {simulatedResult.scoreDifferential}" — show AGS in parentheses
+         - "Projected Handicap Index: {projectedHI}" — if null, show "—" 
+         - "Delta: {delta}" — projectedHI - currentHI, with +/- prefix and color (green for improvement, red for worsening)
+       - **Best-8 breakdown section:** A table or list comparing current best-8 SDs vs projected best-8 SDs. Show the 8 SD values side by side. Use a simple MUI Table or List with columns: #, Current SDs, Projected SDs. Highlight the simulated SD in the projected list.
+
+    **Edge cases (per RESEARCH.md Section 4.5):**
+    - No rounds (< 3): Show "Need at least 3 rounds to calculate Handicap Index" with currentHI shown as "—"
+    - 0 rounds: Show "No rounds recorded yet. Play some rounds first!" and disable the form entirely
+    - No active courses: Show Alert "No courses available. Contact an administrator."
+    - Courses failed to load: Error boundary with "Unable to load courses" message
+    - Invalid Stableford input: Show error on TextField, disable results display
+
+    **Container strategy:** Use MUI Grid with 2-column layout on desktop (>md) — course selection card on the left, results card on the right. The score input card spans full width between them. On mobile (<md), stack vertically.
+
+    **Styling:** Follow existing MUI patterns from StatisticsMain.component.tsx. Use consistent spacing (sx prop with theme.spacing). No custom CSS.
+  </action>
+  <verify>
+    <automated>npm run type-check</automated>
+  </verify>
+  <done>
+    <acceptance_criteria>
+      - `src/pages/Simulator.page.tsx` exists with default export component that renders `<Simulator />`
+      - `src/components/Simulator/Simulator.component.tsx` exists with full UI:
+        - Course dropdown loads from `getAllCourses()` on mount
+        - Teebox dropdown enables on course selection, shows par/CR/SR
+        - Stableford points TextField with 0-36 validation
+        - Playing Handicap TextField with auto-calculated default and manual override
+        - Results card visible when inputs are valid: shows current HI, simulated SD, projected HI, delta with +/- sign
+        - Best-8 breakdown table comparing current vs projected SDs
+      - Component reads `roundsList` from Zustand store (not from Firestore)
+      - Component does not use Zustand persist for simulator state
+      - All imports resolve correctly: `calculateScoreDifferential` from whs.utils, `calculateHandicapIndex`/`calculateProjectedHandicapIndex` from hi.utils, `getAllCourses` from course.firestore
+      - `npm run type-check` exits 0
+    </acceptance_criteria>
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Add simulator route, nav item, and breadcrumbs</name>
+  <files>
+    src/App.tsx
+    src/utils/links/links.utils.tsx
+    src/components/layout/MainLayout2.component.tsx
+  </files>
+  <read_first>
+    src/App.tsx
+    src/utils/links/links.utils.tsx
+    src/components/layout/MainLayout2.component.tsx
+  </read_first>
+  <action>
+    **Step 1 — Route in App.tsx (per D-05):**
+    - Add import at top: `import SimulatorPage from './pages/Simulator.page';` (alongside existing page imports)
+    - Inside the `/` layout's `<Routes>` block, add a new route after the `/settings` route (line 49): `<Route path='/simulator' element={<SimulatorPage />} />`
+
+    **Step 2 — Nav item in links.utils.tsx (per D-05):**
+    Add new import: `import AutoGraphIcon from '@mui/icons-material/AutoGraph';`
+    Add a new entry to the `navbar_items` array after the existing entries (after id: 4, before the closing bracket):
+    ```
+    {
+      id: 5,
+      name: "Simulator",
+      link: "/simulator",
+      icon: AutoGraphIcon,
+      show: true,
+    },
+    ```
+    Since `show: true`, the nav item renders automatically via the `links.map()` loop in `MainLayout2.component.tsx` (line 170-194 area). No hardcoded nav item needed.
+
+    **Step 3 — Breadcrumbs in MainLayout2.component.tsx:**
+    In `getBreadcrumbs()` function (line 69-113), add a new else-if case after the `/settings` case (line 95):
+    ```
+    } else if (path === '/simulator') {
+      breadcrumbs.push({ label: 'Simulator', path: '/simulator' });
+    }
+    ```
+    Make the same addition in `getMobileBreadcrumbs()` function (line 115-157) after the `/settings` case (line 142):
+    ```
+    } else if (path === '/simulator') {
+      breadcrumbs.push({ label: 'Simulator', path: '/simulator' });
+    }
+    ```
+  </action>
+  <verify>
+    <automated>npm run type-check</automated>
+  </verify>
+  <done>
+    <acceptance_criteria>
+      - `src/App.tsx` imports `SimulatorPage` and has `<Route path='/simulator' element={<SimulatorPage />} />` inside the `/` layout routes
+      - `src/utils/links/links.utils.tsx` imports `AutoGraphIcon` and has nav item with `id: 5, name: "Simulator", link: "/simulator", icon: AutoGraphIcon, show: true`
+      - `src/components/layout/MainLayout2.component.tsx` has `path === '/simulator'` breadcrumb case in BOTH `getBreadcrumbs()` and `getMobileBreadcrumbs()`
+      - `npm run type-check` exits 0
+    </acceptance_criteria>
+  </done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| client→Firestore (course read) | Simulator reads `golf_courses` collection via `getAllCourses()` — public read per COURSE-01 |
+| client side (computation) | All SD and HI computation happens client-side in the browser — no data leaves the client |
+| client side (no writes) | Per SIM-03 and D-08: simulator performs ZERO Firestore writes |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-02-04 | Tampering | Stableford points input — user could enter values outside 0-36 range | mitigate | Client-side validation: TextField type="number" with min=0 max=36; clamp in onChange handler; show error/helper text for invalid input |
+| T-02-05 | Tampering | Course/teebox selection — user could manipulate dropdown values | mitigate | Teebox selection is derived from loaded courses array; validate selectedTeebox exists in selectedCourse.teeboxes before computing results |
+| T-02-06 | Tampering | Playing Handicap manual override — user could enter non-numeric or negative values | mitigate | TextField type="number"; parse in useMemo with NaN guard; show error state |
+| T-02-07 | Denial of Service | Firestore course read failure prevents simulator usage | accept | Error handling: courses load failure shows Alert "Unable to load courses"; doesn't crash the page. Simpler: user refreshes. |
+| T-02-08 | Information Disclosure | SD data leaked via simulator state | accept | Simulator uses React component state (not Zustand persist). No localStorage persistence. Refreshing the page clears state. Per D-08 and SIM-03. |
+| T-02-SC | Tampering | npm/pip/cargo installs | accept | No new packages in this plan. No package legitimacy check needed. |
+</threat_model>
+
+<verification>
+- `npm run type-check` exits 0
+- `npm run test:calc:whs` exits 0 (Plan 01 dependency — verify WHS engine still works)
+- `/simulator` route renders the Simulator component
+- Nav item with "Simulator" label and AutoGraphIcon appears in the drawer
+- Breadcrumbs show "Home > Simulator" on the simulator page
+</verification>
+
+<success_criteria>
+- User can navigate to `/simulator` via the nav drawer or URL
+- User sees course dropdown with all active courses, teebox selection, Stableford input
+- Results update reactively: current HI, projected HI, delta, simulated SD, best-8 breakdown
+- No Firestore writes occur during simulator usage
+- All type checks pass; Plan 01 WHS tests remain passing
+</success_criteria>
+
+<output>
+Create `.planning/phases/02-whs-engine-handicap-simulator/02-02-SUMMARY.md` when done
+</output>

--- a/.planning/phases/02-whs-engine-handicap-simulator/02-02-PLAN.md
+++ b/.planning/phases/02-whs-engine-handicap-simulator/02-02-PLAN.md
@@ -15,6 +15,13 @@ requirements: [SIM-01, SIM-02, SIM-03]
 user_setup: []
 must_haves:
   truths:
+    - "D-04: Current Handicap Index calculated on-the-fly from stored SDs (recomputed from roundsList)"
+    - "D-05: Simulator page exists at `/simulator` as a top-level nav item in DrawerAppBar"
+    - "D-06: Simulator form has course dropdown → teebox dropdown → total Stableford points input"
+    - "D-07: Results card shows current HI, projected HI, delta, simulated SD, and best-8 breakdown"
+    - "D-08: Simulator uses local React state only — no Firestore writes (SIM-03)"
+    - "D-09: Playing HCP auto-calculated via `HI × (SR / 113) + (CR - PAR)`"
+    - "D-10: Playing HCP auto-calculated value shown with manual override option"
     - "User can navigate to the Simulator tab from the app navigation"
     - "User can select a course from the dropdown, then select a teebox with PAR/CR/SR visible"
     - "User can enter total Stableford points for a hypothetical round"

--- a/.planning/phases/02-whs-engine-handicap-simulator/02-CONTEXT.md
+++ b/.planning/phases/02-whs-engine-handicap-simulator/02-CONTEXT.md
@@ -1,0 +1,128 @@
+# Phase 2: WHS Engine & Handicap Simulator - Context
+
+**Gathered:** 2026-06-01
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+Deliver a WHS-compliant Score Differential and Handicap Index calculation engine (pure calculation functions), plus a dedicated Simulator page where players can select a course/teebox, enter total Stableford points for a hypothetical round, and see the projected impact on their Handicap Index without saving anything to the database.
+
+This phase does NOT include automatic SD computation on real round save (CALC-03 — deferred to v2), course search for non-admin users (COURSE-02/03 — v2), round entry course integration (ROUND-01/02/03 — v2), or Federgolf import (ADMIN-05 — v2).
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### WHS Engine Organization
+- **D-01:** New `src/utils/whs/` directory with two files:
+  - `whs.utils.tsx` — Score Differential calculation: `(AGS - CR - PCC) × (113 / SR)` where `AGS = PAR + Playing HCP + (36 - Stableford points)` and PCC is always 0
+  - `hi.utils.tsx` — Handicap Index calculation: average of best 8 SDs from last 20 rounds, with proper scaling for fewer rounds per WHS Rule 5.2a
+- **D-02:** Follow the same pattern as `TotalsCalculator.utils.tsx` — typed Props interface, pure function, typed return, safe math via existing `safeDivide`
+
+### Score Differential Storage
+- **D-03:** Score Differential stored on each round document at save time. Add `scoreDifferential: number | null` field to the Firestore round document schema. Computed during `saveNewRound()` using course/tee data from the round.
+- **D-04:** Current Handicap Index calculated on-the-fly from stored SDs (never stored as a single persisted value — recomputed from the SD list when needed).
+
+### Simulator Page
+- **D-05:** New page at `/simulator` — added as a top-level nav item in DrawerAppBar
+- **D-06:** Input form: select course from `golf_courses` collection → select teebox → enter total Stableford points for the round (single number, not per-hole). No hole-by-hole entry.
+- **D-07:** Results display: numbers + breakdown card showing current HI, projected HI, delta (+/-), the simulated Score Differential, and a summary of how it affects the best-8 calculation
+- **D-08:** Simulator operates entirely in local/transient state — no Firestore writes (SIM-03)
+
+### Playing Handicap for Simulator
+- **D-09:** Auto-calculated using standard WHS formula: `Playing HCP = HI × (SR / 113) + (CR - PAR)`
+- **D-10:** Auto-calculated value is shown as a default — user can override with manual input
+
+### the agent's Discretion
+- Simulator UI layout details (card placement, form layout) — planner flexes within MUI patterns
+- How the "best-8 breakdown" is visualized (chart? table? MUI x-chart?)
+- Whether simulator state is Zustand (transient) or React component state
+- Nav icon and label text for the Simulator nav item
+- Error/edge case UI (no rounds yet? fewer than 20 rounds?)
+
+</decisions>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Requirements & Scope
+- `.planning/REQUIREMENTS.md` — CALC-01, CALC-02, SIM-01, SIM-02, SIM-03 requirements
+- `.planning/ROADMAP.md` — Phase 2 goal, success criteria (5 items), dependencies on Phase 1
+- `.planning/phases/01-course-database-admin-foundation/01-CONTEXT.md` — Prior decisions: admin infra, course data model (ICourse/ITeebox with courseRating, slopeRating)
+
+### Codebase Patterns (must follow)
+- `src/types/course.types.tsx` — ICourse, ITeebox interfaces (courseRating and slopeRating already defined)
+- `src/utils/calculator/TotalsCalculator.utils.tsx` — Calculation function pattern (typed props, pure function, typed return)
+- `src/store/zustand/app.store.ts` — Zustand store pattern for new state slices
+- `src/utils/firestore/round.firestore.ts` — Firestore service pattern; `saveNewRound()` for SD storage integration point
+- `src/types/round.types.tsx` and `src/types/roundData.types.tsx` — Round document types (will need `scoreDifferential` field)
+- `src/types/player.types.tsx` — IPlayerDetails (has `HCP` field — raw user-entered value, not WHS HI)
+- `src/pages/AddNewRound.page.tsx` — Reference for round entry flow (not reused for simulator per decision)
+- `src/components/common/header/` — DrawerAppBar (where Simulator nav item will be added)
+- `src/App.tsx` — Route definition pattern
+- `src/utils/calculator/math.utils.tsx` — `safeDivide` utility for safe math
+
+### Test Infrastructure
+- `src/dev-tools/testRunner.ts` — Test orchestrator to extend for WHS calculations
+- `src/dev-tools/testDataGenerator.ts` — Test data generation pattern (add WHS scenarios)
+- `src/dev-tools/edgeCaseTests.ts` — Edge case testing pattern (add WHS edge cases)
+
+### WHS Formula Reference
+- WHS Rule 5.1: Score Differential = (AGS - CR - PCC) × (113 / SR), PCC = 0 always
+- WHS Rule 5.2a: Handicap Index = average of best 8 SDs from last 20 rounds; scaling for fewer rounds
+- AGS from Stableford: AGS = PAR + Playing HCP + (36 - Stableford points)
+- Playing HCP from HI: Playing HCP = HI × (SR / 113) + (CR - PAR)
+
+</canonical_refs>
+
+<code_context>
+## Existing Code Insights
+
+### Reusable Assets
+- **`ICourse` / `ITeebox`** (`src/types/course.types.tsx`) — courseRating and slopeRating already exist on teeboxes; simulator course selection reuses `getCourses` from `course.firestore.ts`
+- **`TotalsCalculator.utils.tsx` pattern** — blueprint for WHS calculation functions (typed props, pure functions, safe divide)
+- **`safeDivide`** (`src/utils/calculator/math.utils.tsx`) — guards against NaN/Infinity in WHS calculations
+- **Dev-tools test infrastructure** (`src/dev-tools/`) — extend `TestDataGenerator` with WHS scenarios, `TestInspector` with WHS validation rules
+- **`drawerAppBar`** — existing nav component; add Simulator nav item following the admin links pattern from Phase 1
+
+### Established Patterns
+- Calculation functions in `src/utils/` with named exports and typed return values
+- Zustand persist for state that survives refresh (HI cache, simulator transient state)
+- Firestore services in `src/utils/firestore/*.ts` with async try-catch
+- Pages in `src/pages/*.page.tsx`, routed in `src/App.tsx`
+- Admin route from Phase 1 shows how to add conditional nav items
+
+### Integration Points
+- **Route tree** in `src/App.tsx` — add `/simulator` route under existing `/` layout
+- **DrawerAppBar** — add Simulator nav item (top-level, always visible)
+- **Zustand store** — add simulator state slice (course selection, stableford input, results) and HI helper action
+- **`round.firestore.ts`** — add `scoreDifferential` computation inside `saveNewRound()` (or via a new function called during save)
+- **Course Firestore service** (`src/utils/firestore/course.firestore.ts`) — simulator reads courses for selection
+
+</code_context>
+
+<specifics>
+## Specific Ideas
+
+- Simulator is a simple form: course dropdown → teebox dropdown → Stableford points input → results card updates
+- Results card shows current HI, projected HI, delta with +/- sign, simulated SD value, and a mini list showing the best-8 SDs (current vs projected)
+- Playing HCP auto-fills from HI + teebox data, with an edit button to override
+- Nav item labeled "Simulator" (or "Simula" if space is tight) with a calculate/forecast icon
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+None — discussion stayed within phase scope.
+
+</deferred>
+
+---
+
+*Phase: 2-WHS-Engine-Handicap-Simulator*
+*Context gathered: 2026-06-01*

--- a/.planning/phases/02-whs-engine-handicap-simulator/02-DISCUSSION-LOG.md
+++ b/.planning/phases/02-whs-engine-handicap-simulator/02-DISCUSSION-LOG.md
@@ -1,0 +1,108 @@
+# Phase 2: WHS Engine & Handicap Simulator - Discussion Log
+
+> **Audit trail only.** Do not use as input to planning, research, or execution agents.
+> Decisions are captured in CONTEXT.md — this log preserves the alternatives considered.
+
+**Date:** 2026-06-01
+**Phase:** 2-WHS-Engine-Handicap-Simulator
+**Areas discussed:** WHS Engine location, SD storage strategy, Simulator input UX, Simulator results display, Simulator nav placement, Playing Handicap source, Playing HCP formula
+
+---
+
+## WHS Engine Location
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| New `src/utils/whs/` directory | Dedicated directory for whs.utils.tsx + hi.utils.tsx — clean separation | ✓ |
+| Add to existing `src/utils/calculator/` | New whs.utils.tsx alongside TotalsCalculator | |
+| Single file in calculator/ | One whs.utils.tsx file | |
+
+**User's choice:** New `src/utils/whs/` directory
+**Notes:** Clean separation from round-level statistics. Follows the same pattern as TotalsCalculator (typed props, pure function, typed return, safeDivide).
+
+---
+
+## Score Differential Storage
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Compute on-the-fly | Calculate SD each time from round scores + course data. No DB writes. | |
+| Store SD on round save | Compute and store SD on the round document during saveNewRound() | ✓ |
+| Lazy compute + cache locally | Calculate on first load, cache in Zustand persist | |
+
+**User's choice:** Store SD on round save
+**Notes:** SD is computed during `saveNewRound()` and stored on the Firestore round document. HI is still calculated on-the-fly from stored SDs.
+
+---
+
+## Simulator Input UX
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Single-page 18-hole grid | Table layout with hole #, par, Stableford input | |
+| Two-panel split view | Course info + summary on one side, input grid on other | |
+| Freeform | User described their vision | ✓ |
+
+**User's choice:** Simple form — select course/teebox, enter total Stableford points (single number). Not hole-by-hole. Reuses course selection, but not the existing round entry form.
+**Notes:** "We already have the forms for the insert of the 18 holes of the round. We don't need a new one." — but also doesn't want to reuse them. Just total Stableford + course selection.
+
+---
+
+## Simulator Results Display
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Just the two numbers | Current HI and Projected HI side by side | |
+| Numbers + breakdown | Current HI, projected HI, delta, simulated SD, best-8 detail | ✓ |
+
+**User's choice:** Numbers + breakdown
+**Notes:** Show current HI, projected HI, delta, the Score Differential the simulated round would produce, and how it affects best-8 calculation.
+
+---
+
+## Simulator Nav Placement
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| New top-level nav item | Dedicated Simulator item in DrawerAppBar | ✓ |
+| Sub-page under Statistics | Accessed from Statistics page | |
+
+**User's choice:** New top-level nav item
+
+---
+
+## Playing Handicap Source
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Manual input field | User enters Playing HCP manually | |
+| Auto-calculate from teebox | Derive from slope + HI | |
+| Both — auto with override | Auto-calculate with manual override | ✓ |
+
+**User's choice:** Both — auto with override
+
+---
+
+## Playing HCP Formula
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Standard WHS formula | Playing HCP = HI × (SR / 113) + (CR - PAR) | ✓ |
+| Simplified — HI × (SR / 113) | Slope adjustment only | |
+| Ask the user every time | Default to auto with override | |
+
+**User's choice:** Standard WHS formula
+
+---
+
+## the agent's Discretion
+
+- Simulator UI layout details (card placement, form layout)
+- How the "best-8 breakdown" is visualized
+- Simulator state management approach (Zustand transient vs React local state)
+- Nav icon and label text for the Simulator nav item
+- Error/edge case UI (no rounds, fewer than 20)
+
+## Deferred Ideas
+
+None — discussion stayed within phase scope.

--- a/.planning/phases/02-whs-engine-handicap-simulator/02-PATTERNS.md
+++ b/.planning/phases/02-whs-engine-handicap-simulator/02-PATTERNS.md
@@ -1,0 +1,659 @@
+# Phase 2: WHS Engine & Handicap Simulator - Pattern Map
+
+**Mapped:** 2026-06-01
+**Files analyzed:** 14 (6 new, 8 modified)
+**Analogs found:** 14 / 14
+
+## File Classification
+
+| New/Modified File | Role | Data Flow | Closest Analog | Match Quality |
+|---|---|---|---|---|
+| `src/utils/whs/whs.utils.tsx` | utility | transform | `src/utils/calculator/TotalsCalculator.utils.tsx` | exact (same role + data flow + safeDivide usage) |
+| `src/utils/whs/hi.utils.tsx` | utility | transform | `src/utils/calculator/TotalsCalculator.utils.tsx` | exact (same role + data flow + safeDivide usage + typed return) |
+| `src/pages/Simulator.page.tsx` | page | request-response | `src/pages/Statistics.page.tsx` | exact (same role — delegates to child component) |
+| `src/components/Simulator/Simulator.component.tsx` | component | request-response | `src/components/Statistics/StatisticsMain.component.tsx` | role-match (MUI composition, data loading pattern) |
+| `src/dev-tools/whsTestData.ts` | test | batch | `src/dev-tools/edgeCaseTests.ts` | exact (same role — static test case definitions with expected values) |
+| `src/dev-tools/whsTestRunner.ts` | test | batch | `src/dev-tools/testRunner.ts` | exact (same role — test orchestrator class) |
+| `src/types/roundData.types.tsx` (mod) | model | CRUD | existing file (add single field to IBasicRoundData) | in-file pattern |
+| `src/types/roundDetails.types.tsx` (mod) | model | CRUD | existing file (inherits from IBasicRoundData) | in-file pattern |
+| `src/utils/firestore/round.firestore.ts` (mod) | service | CRUD | `src/utils/firestore/course.firestore.ts` | role-match (Firestore async service pattern) |
+| `src/utils/round/round.utils.tsx` (mod) | utility | CRUD | existing file (add SD field to prepareRoundSaveBatch) | in-file pattern |
+| `src/App.tsx` (mod) | config | request-response | existing file (add route inside `/` layout) | in-file pattern |
+| `src/store/zustand/app.store.ts` (mod, optional) | store | CRUD | existing file (AppState interface + persist pattern) | in-file pattern |
+| `src/utils/links/links.utils.tsx` (mod) | config | — | existing file (add nav item to navbar_items array) | in-file pattern |
+| `src/components/layout/MainLayout2.component.tsx` (mod) | component | — | existing file (add breadcrumb case + nav render) | in-file pattern |
+
+---
+
+## Pattern Assignments
+
+### `src/utils/whs/whs.utils.tsx` (utility, transform)
+
+**Analog:** `src/utils/calculator/TotalsCalculator.utils.tsx` (227 lines)
+
+**Imports pattern** (file lines 1-6):
+```typescript
+import { IShots } from "@/types/roundData.types";
+import { IRoundTotals } from "@/types/roundTotals.types";
+import _ from "lodash";
+import { initialStateRoundTotals } from "../constant.utils";
+import { calculateChippingPitchingStatistics, calculateFWIrons, calculateInside100mtStatistics, calculatePuttsStatistics, calculateTeeShotsStatistics } from "../totals/totals.utils";
+import { safeDivide, safePercentage } from "./math.utils";
+```
+
+**Pattern to copy:** Import only what's needed — `{ safeDivide }` from `@/utils/calculator/math.utils`. No UI imports, no Firestore imports. Pure calculation utility.
+
+**Core pattern** (lines 8-227): Named export pure function receiving typed parameters, returning typed result object:
+```typescript
+export const totalsCalculator = (shots: IShots[]) => {
+  let totals: IRoundTotals = _.cloneDeep(initialStateRoundTotals);
+  // ... pure computation ...
+  return totals;
+};
+```
+
+**Pattern for whs.utils.tsx:**
+```typescript
+import { safeDivide } from '@/utils/calculator/math.utils';
+
+export interface IScoreDifferentialProps {
+  par: number;
+  courseRating: number;
+  slopeRating: number;
+  stablefordPoints: number;
+  playingHCP: number;
+}
+
+export interface IScoreDifferentialResult {
+  adjustedGrossScore: number;
+  scoreDifferential: number;
+}
+
+export const calculateScoreDifferential = (
+  props: IScoreDifferentialProps
+): IScoreDifferentialResult => {
+  // pure function, no side effects, safeDivide for division
+};
+```
+
+**Safe divide pattern** (`src/utils/calculator/math.utils.tsx` lines 12-24) — copy usage:
+```typescript
+export const safeDivide = (numerator: number | undefined, denominator: number | undefined, precision: number = 2): number => {
+  const num = numerator || 0;
+  const den = denominator || 0;
+  if (den === 0) return 0;
+  const result = num / den;
+  if (isNaN(result) || !isFinite(result)) return 0;
+  return parseFloat(result.toFixed(precision));
+};
+```
+
+**Error handling:** No try/catch needed — pure function with no I/O. safeDivide handles zero/NaN/Infinity internally.
+
+---
+
+### `src/utils/whs/hi.utils.tsx` (utility, transform)
+
+**Analog:** `src/utils/calculator/TotalsCalculator.utils.tsx` (same pattern as whs.utils.tsx)
+
+**Imports pattern:** Same as whs.utils.tsx — import `{ safeDivide }` from `@/utils/calculator/math.utils`.
+
+**Core pattern** — pure function, array input, nullable return for edge cases:
+```typescript
+export const calculateHandicapIndex = (scoreDifferentials: number[]): number | null => {
+  // null for < 3 rounds (no valid HI)
+  // average of lowest N from most recent 20
+  // safeDivide for final average
+};
+```
+
+**Pattern from existing code** — the null return pattern matches Firestore service functions like `getCourseById` which returns `Promise<ICourse | null>`.
+
+---
+
+### `src/pages/Simulator.page.tsx` (page, request-response)
+
+**Analog:** `src/pages/Statistics.page.tsx` (9 lines) — simplest page pattern in the codebase
+
+**Imports + core pattern** (lines 1-9):
+```typescript
+import StatisticsMain from "../components/Statistics/StatisticsMain.component";
+
+const Statistics = () => {
+  return (
+    <StatisticsMain />
+  )
+}
+
+export default Statistics
+```
+
+**Pattern to copy:** Slim page component that delegates entirely to a child component. Default export.
+
+**Alternative analog:** `src/pages/Dashboard.page.tsx` (49 lines) — for data-loading pages:
+
+**Data loading pattern** (lines 10-34):
+```typescript
+const DashboardPage = () => {
+  const navigate = useNavigate();
+  const isLoadingPlayer = useAppStore((state) => state.isLoadingPlayer);
+  const getPlayerDetails = useAppStore((state) => state.getPlayerDetails);
+  const roundsList = useAppStore((state) => state.roundsList);
+  // ...
+
+  useEffect(() => {
+    if (uid) {
+      fetchInitialTheme(uid);
+      if (auth) {
+        getPlayerDetails(uid).then((result) => {
+          if (result) {
+            setRounds(result.rounds || []);
+          }
+        });
+      }
+    }
+  }, [uid]);
+
+  if (!uid || !!isLoadingPlayer) return <Spinner />;
+
+  return <Dashboard />;
+};
+```
+
+**Pattern for Simulator.page.tsx:** Use Statistics.page.tsx pattern (slim delegation) if data loading is inside the component; use Dashboard.page.tsx pattern if course loading + HI computation happen at the page level.
+
+---
+
+### `src/components/Simulator/Simulator.component.tsx` (component, request-response)
+
+**Analog:** `src/components/Statistics/StatisticsMain.component.tsx` — MUI composition with data display
+
+**Pattern for MUI form + card display:** Use MUI components following the project's standard imports:
+```typescript
+import { useState, useEffect, useMemo } from 'react';
+import {
+  Card, CardContent, Typography, TextField,
+  Select, MenuItem, FormControl, InputLabel,
+  Grid, Box, Divider
+} from '@mui/material';
+import { getAllCourses } from '@/utils/firestore/course.firestore';
+import { useAppStore } from '@/store/zustand';
+import { ICourse, ITeebox } from '@/types/course.types';
+import { calculateScoreDifferential } from '@/utils/whs/whs.utils';
+import { calculateHandicapIndex, calculateProjectedHandicapIndex } from '@/utils/whs/hi.utils';
+```
+
+**Transient state pattern** (React component state, not Zustand — per discretion area in D-08):
+```typescript
+const [courses, setCourses] = useState<ICourse[]>([]);
+const [selectedCourse, setSelectedCourse] = useState<ICourse | null>(null);
+const [selectedTeebox, setSelectedTeebox] = useState<ITeebox | null>(null);
+const [stablefordPoints, setStablefordPoints] = useState<number>(36);
+const [manualPlayingHCP, setManualPlayingHCP] = useState<number | null>(null);
+const [loading, setLoading] = useState(true);
+```
+
+**Course loading pattern** (from existing `src/utils/firestore/course.firestore.ts` `getAllCourses`):
+```typescript
+useEffect(() => {
+  getAllCourses().then(all => {
+    setCourses(all.filter(c => c.status === 'Active'));
+    setLoading(false);
+  }).catch(err => {
+    console.error('Failed to load courses:', err);
+    setLoading(false);
+  });
+}, []);
+```
+
+**HI computation pattern** (reads `roundsList` from Zustand store, computes on the fly):
+```typescript
+const roundsList = useAppStore((state) => state.roundsList);
+
+const currentHI = useMemo(() => {
+  const sds = roundsList
+    .filter(r => r.scoreDifferential != null)
+    .map(r => r.scoreDifferential as number);
+  return calculateHandicapIndex(sds);
+}, [roundsList]);
+```
+
+**Playing HCP auto-calc with manual override pattern** (D-09, D-10):
+```typescript
+const playingHCP = useMemo(() => {
+  if (!selectedTeebox || currentHI == null) return null;
+  return manualPlayingHCP ?? Math.round(
+    currentHI * (selectedTeebox.slopeRating / 113) +
+    (selectedTeebox.courseRating - selectedTeebox.par)
+  );
+}, [selectedTeebox, currentHI, manualPlayingHCP]);
+```
+
+**Simulated SD + projected HI pattern** (virtual array for SIM-03):
+```typescript
+const simulatedResult = useMemo(() => {
+  if (!selectedTeebox || playingHCP == null) return null;
+  return calculateScoreDifferential({
+    par: selectedTeebox.par,
+    courseRating: selectedTeebox.courseRating,
+    slopeRating: selectedTeebox.slopeRating,
+    stablefordPoints,
+    playingHCP,
+  });
+}, [selectedTeebox, playingHCP, stablefordPoints]);
+
+const projectedHI = useMemo(() => {
+  if (!simulatedResult) return null;
+  const sds = roundsList
+    .filter(r => r.scoreDifferential != null)
+    .map(r => r.scoreDifferential as number);
+  // Virtual array: simulated SD + last 19 real SDs
+  const virtual = [simulatedResult.scoreDifferential, ...sds.slice(0, 19)];
+  return calculateHandicapIndex(virtual);
+}, [simulatedResult, roundsList]);
+```
+
+---
+
+### `src/dev-tools/whsTestData.ts` (test, batch)
+
+**Analog:** `src/dev-tools/edgeCaseTests.ts` (605 lines) — static test case definitions
+
+**Pattern** (lines 1-80): Static methods returning arrays of test case objects with named scenarios:
+```typescript
+export class EdgeCaseTests {
+  static getVariableMismatchTests(): { [key: string]: TestRoundConfig } {
+    return {
+      arrayLengthMismatch: {
+        roundName: 'Array Length Mismatch Test',
+        description: 'Testing scenarios where puttsLength array might not match putts count',
+        courseInfo: { name: 'Mismatch Course', par: 36, tee: 'Test', playerHCP: 18 },
+        expectedIssues: ['puttsLength array mismatch', 'putts count vs array length'],
+        holeConfigs: [ /* ... */ ],
+      },
+    };
+  }
+}
+```
+
+**Pattern for whsTestData.ts — simpler static data:**
+```typescript
+export const WHSScoreDifferentialTestCases = [
+  {
+    name: 'Good round - Standard Course',
+    input: { par: 72, courseRating: 72.5, slopeRating: 135, stablefordPoints: 42, playingHCP: 18 },
+    expectedAGS: 78,
+    expectedSD: 4.6,
+  },
+  // ...
+];
+
+export const WHSHandicapIndexTestCases = [
+  {
+    name: '20 rounds - best 8',
+    scoreDifferentials: [ /* 20 numbers */ ],
+    expectedHI: 12.4,
+  },
+  // ...
+];
+```
+
+---
+
+### `src/dev-tools/whsTestRunner.ts` (test, batch)
+
+**Analog:** `src/dev-tools/testRunner.ts` (308 lines) — test orchestrator pattern
+
+**Pattern** (lines 1-29): Class with static methods that execute tests and log results:
+```typescript
+import { TestDataGenerator } from './testDataGenerator';
+import { StepByStepTester, runQuickTest, formatTestResults } from './stepByStepTester';
+import { EdgeCaseTests, knownIssueTests } from './edgeCaseTests';
+
+export class InteractiveTestRunner {
+  static runQuickTest(): void {
+    console.log('🏌️  Running Quick 3-Hole Test...\n');
+    const result = runQuickTest('mixedScenarios', 3);
+    console.log(formatTestResults(result));
+    if (!result.overallPassed) {
+      console.log('\n🚨 Issues found! Check the details above.\n');
+    } else {
+      console.log('\n✅ All calculations passed!\n');
+    }
+  }
+  // ...
+}
+```
+
+**Pattern for whsTestRunner.ts — simpler, focused on WHS:**
+```typescript
+import { WHSScoreDifferentialTestCases, WHSHandicapIndexTestCases } from './whsTestData';
+import { calculateScoreDifferential } from '../utils/whs/whs.utils';
+import { calculateHandicapIndex } from '../utils/whs/hi.utils';
+
+export class WHSTestRunner {
+  static runAll(): void { /* iterate test cases */ }
+  static runQuick(): void { /* run a few representative cases */ }
+}
+
+// CLI entry point
+const args = process.argv.slice(2);
+const mode = args[0] || 'quick';
+if (mode === 'all') WHSTestRunner.runAll();
+else WHSTestRunner.runQuick();
+```
+
+---
+
+### `src/types/roundData.types.tsx` (modify — model, CRUD)
+
+**Analog:** Existing file — add `scoreDifferential` field to `IBasicRoundData`
+
+**Current IBasicRoundData** (lines 159-173):
+```typescript
+export interface IBasicRoundData {
+  id: string,
+  roundCourse?: string,
+  roundDate: number,
+  roundHoles?: string,
+  roundTee?: string,
+  roundPar?: string,
+  roundNumber?: string,
+  roundPlayingHCP?: string,
+  roundStrokes?: number,
+  userId?: string
+  createdAt: number,
+  totals: IRoundTotals
+}
+```
+
+**Add after `totals`:**
+```typescript
+  scoreDifferential?: number | null;
+```
+
+---
+
+### `src/types/roundDetails.types.tsx` (modify — model, CRUD)
+
+**Current** (lines 4-7):
+```typescript
+export interface IRoundDetails extends IBasicRoundData {
+  holes: IShots[];
+  distances?: IDistance[];
+}
+```
+
+No changes needed — `scoreDifferential` is inherited from `IBasicRoundData`.
+
+---
+
+### `src/utils/firestore/round.firestore.ts` (modify — service, CRUD)
+
+**Analog Firestore service:** `src/utils/firestore/course.firestore.ts` (132 lines)
+
+**Pattern for async Firestore operations** (lines 32-49):
+```typescript
+export const getAllCourses = async (): Promise<ICourse[]> => {
+  try {
+    const coursesRef = collection(db, COURSES_COLLECTION);
+    const coursesQuery = query(coursesRef, orderBy('name', 'asc'));
+    const snapshot = await getDocs(coursesQuery);
+    return snapshot.docs.map((doc) => {
+      const data = doc.data();
+      return { ...convertTimestamps(data), id: doc.id } as ICourse;
+    });
+  } catch (error: any) {
+    console.error('course.firestore: Error fetching all courses:', error);
+    throw error;
+  }
+};
+```
+
+**SD computation integration point** in `saveNewRound()` (file lines 63-139):
+After the batch commit (line 89), or inside `prepareRoundSaveBatch`, compute SD:
+
+```typescript
+// Inside saveNewRound, after batchSaveRound.commit():
+// Compute and store scoreDifferential
+const stablefordPoints = currentTotals.points.totals;
+// Read course/tee from newRoundMain.round
+const { roundCourse, roundTee, roundPar, roundPlayingHCP } = general;
+// Get courseRating + slopeRating from stored data or query
+// Store on round doc in a separate update or as part of prepareRoundSaveBatch
+```
+
+**Add `getCourseByName` helper** if needed (following `getCourseById` pattern from `course.firestore.ts` lines 51-74).
+
+---
+
+### `src/utils/round/round.utils.tsx` (modify — utility, CRUD)
+
+**Current `prepareRoundSaveBatch`** (lines 84-114):
+```typescript
+export const prepareRoundSaveBatch = (
+  batch: WriteBatch,
+  userId: string,
+  general: INewRound,
+  totals: IRoundTotals,
+  currentRoundDistances: IDistance[],
+  holes: IShots[]
+): string => {
+  // ...
+  batch.set(roundRef, {
+    ...general,
+    totals: totals,
+    distances: currentRoundDistances,
+    userId: userId,
+    roundDate: general.roundDate ? Timestamp.fromDate(new Date(general.roundDate)) : serverTimestamp(),
+    createdAt: serverTimestamp(),
+  });
+  // ...
+};
+```
+
+**Add `scoreDifferential: number | null` field** to the `batch.set()` call:
+```typescript
+batch.set(roundRef, {
+  ...general,
+  totals: totals,
+  distances: currentRoundDistances,
+  userId: userId,
+  scoreDifferential: null, // computed by saveNewRound before calling this
+  roundDate: general.roundDate ? Timestamp.fromDate(new Date(general.roundDate)) : serverTimestamp(),
+  createdAt: serverTimestamp(),
+});
+```
+
+---
+
+### `src/App.tsx` (modify — config, request-response)
+
+**Current route pattern** (lines 34-52):
+```typescript
+<Route
+  path="/"
+  element={
+    <ProtectedRoute>
+      <SharedLayout />
+    </ProtectedRoute>
+  }
+>
+  <Route index element={<DashboardPage />} />
+  <Route path="/dashboard" element={<DashboardPage />} />
+  <Route path="/clubs" element={<ClubsPage />} />
+  <Route path="/all-rounds" element={<AllRounds />} />
+  <Route path="/round/:roundID" element={<RoundsData />} />
+  <Route path='/addNewRound' element={<AddNewRound />} />
+  <Route path='/statistics' element={<Statistics />} />
+  <Route path='/settings' element={<SettingsPage />} />
+  <Route path="/admin/courses" element={<AdminRoute><AdminCoursesPage /></AdminRoute>} />
+  <Route path="/admin/users" element={<AdminRoute><AdminUsersPage /></AdminRoute>} />
+</Route>
+```
+
+**Add after the `/settings` route:**
+```typescript
+<Route path='/simulator' element={<SimulatorPage />} />
+```
+
+**Import to add** (with other page imports at top):
+```typescript
+import SimulatorPage from './pages/Simulator.page';
+```
+
+---
+
+### `src/store/zustand/app.store.ts` (modify — store, CRUD)
+
+**AppState interface** (lines 150-239) — add optional simulator state if not using React component state:
+```typescript
+export interface AppState {
+  // ...existing fields...
+  simulator?: {
+    selectedCourse: ICourse | null;
+    selectedTeebox: ITeebox | null;
+    stablefordPoints: number;
+    playingHCP: number;
+    manualHCPOverride: boolean;
+  };
+  // ...existing actions...
+  setSimulatorState?: (state: Partial<AppState['simulator']>) => void;
+}
+```
+
+**IMPORTANT:** If adding simulator state, ensure it is NOT in the `partialize` function (lines 767-788) so it doesn't persist to localStorage:
+```typescript
+partialize: (state) => ({
+  themePreference: state.themePreference,
+  // ...existing fields — DO NOT add simulator here
+}),
+```
+
+---
+
+### `src/utils/links/links.utils.tsx` (modify — config)
+
+**Current pattern** (lines 7-36):
+```typescript
+const navbar_items: TLinkSidebar[] = [
+  {
+    id: 1,
+    name: "Dashboard",
+    link: "/",
+    icon: HomeWorkIcon,
+    show: false,
+  },
+  // ...
+  {
+    id: 4,
+    name: "Users",
+    link: "/admin/users",
+    icon: PeopleIcon,
+    show: false,
+  },
+];
+```
+
+**Add after the existing items** (before the `export default`):
+```typescript
+  {
+    id: 5,
+    name: "Simulator",
+    link: "/simulator",
+    icon: CalculateIcon, // or AutoGraphIcon, TrendingUpIcon
+    show: true,
+  },
+```
+
+**Import to add:**
+```typescript
+import CalculateIcon from '@mui/icons-material/Calculate';
+// or: import AutoGraphIcon from '@mui/icons-material/AutoGraph';
+```
+
+---
+
+### `src/components/layout/MainLayout2.component.tsx` (modify — component)
+
+**Breadcrumbs pattern** — add `/simulator` case in `getBreadcrumbs()` (around line 94):
+```typescript
+} else if (path === '/settings') {
+  breadcrumbs.push({ label: 'Settings', path: '/settings' });
+} else if (path === '/simulator') {                    // NEW
+  breadcrumbs.push({ label: 'Simulator', path: '/simulator' });  // NEW
+} else if (path.startsWith('/round/')) {
+```
+
+**Same addition in `getMobileBreadcrumbs()`** (around line 142):
+```typescript
+} else if (path === '/settings') {
+  breadcrumbs.push({ label: 'Settings', path: '/settings' });
+} else if (path === '/simulator') {                    // NEW
+  breadcrumbs.push({ label: 'Simulator', path: '/simulator' });  // NEW
+} else if (path.startsWith('/round/')) {
+```
+
+**Note:** The nav item renders automatically via `links.map()` (line 170-194) since the Simulator link has `show: true`. No hardcoded nav item needed.
+
+---
+
+## Shared Patterns
+
+### Pure Calculation Functions (whs.utils.tsx + hi.utils.tsx)
+
+**Source:** `src/utils/calculator/TotalsCalculator.utils.tsx`
+**Applies to:** Both `whs.utils.tsx` and `hi.utils.tsx`
+
+Key shared characteristics:
+- Named exports, not default exports
+- Typed Props interface or typed function parameters
+- Return type defined as interface (or `number | null` for edge cases)
+- Uses `safeDivide` from `@/utils/calculator/math.utils` for ALL division
+- No I/O, no side effects, no try/catch
+- `Math.max(0, result)` guard for non-negative SD values
+
+### Firestore Service Pattern (round.firestore.ts modification)
+
+**Source:** `src/utils/firestore/course.firestore.ts`
+**Applies to:** `round.firestore.ts` SD storage integration
+
+Key shared characteristics:
+- Named async functions returning typed Promises
+- try/catch with `console.error('prefix: message:', error)` + `throw error`
+- Input validation at top (throw early if missing params)
+- Timestamp conversion helper for Firestore Timestamp → milliseconds
+
+### Zustand Store Slicing (optional simulator state)
+
+**Source:** `src/store/zustand/app.store.ts`
+**Applies to:** Any simulator state added to the store
+
+Key shared characteristics:
+- Interface/type for state properties within `AppState`
+- Async actions: `set({ loading: true })` → try block → `set({ ...result })` → catch block → `set({ error })`
+- Protected from persistence: simulator state excluded from `partialize`
+- Zustand devtools wrapping for debugging
+
+### Nav Integration
+
+**Source:** `src/utils/links/links.utils.tsx` + `src/components/layout/MainLayout2.component.tsx`
+**Applies to:** Route + nav + breadcrumbs for `/simulator`
+
+Key shared characteristics:
+- Route added inside the `/` layout's `<Routes>` in `App.tsx`
+- Nav item in `links.utils.tsx` with `show: true` renders automatically via `links.map()`
+- Breadcrumbs added as simple `else if` statements in both `getBreadcrumbs()` and `getMobileBreadcrumbs()`
+- Page component imported with default export
+
+---
+
+## No Analog Found
+
+All files have close analogs in the codebase. No unmatched files.
+
+## Metadata
+
+**Analog search scope:** `src/utils/calculator/`, `src/utils/firestore/`, `src/pages/`, `src/components/`, `src/types/`, `src/store/zustand/`, `src/utils/links/`, `src/components/layout/`, `src/dev-tools/`
+**Files scanned:** 20+
+**Pattern extraction date:** 2026-06-01

--- a/.planning/phases/02-whs-engine-handicap-simulator/02-RESEARCH.md
+++ b/.planning/phases/02-whs-engine-handicap-simulator/02-RESEARCH.md
@@ -1,0 +1,833 @@
+# Phase 2: WHS Engine & Handicap Simulator — Research
+
+**Researched:** 2026-06-01
+**Domain:** WHS World Handicap System calculation engine, transient-state simulator UI, Firestore schema extension
+**Confidence:** HIGH (WHS formulas are standardised; codebase patterns well-established; decisions locked in CONTEXT.md)
+
+---
+
+<user_constraints>
+## User Constraints (from CONTEXT.md)
+
+### Locked Decisions
+
+- **D-01:** New `src/utils/whs/` directory with `whs.utils.tsx` (Score Differential) and `hi.utils.tsx` (Handicap Index)
+- **D-02:** Follow `TotalsCalculator.utils.tsx` pattern — typed Props interface, pure function, typed return, safe math via `safeDivide`
+- **D-03:** Score Differential stored on each round document at save time. Add `scoreDifferential: number | null` field to Firestore round document. Computed during `saveNewRound()`
+- **D-04:** Current Handicap Index calculated on-the-fly from stored SDs (never stored as a single persisted value)
+- **D-05:** New page at `/simulator` — top-level nav item in DrawerAppBar
+- **D-06:** Simulator input: select course → select teebox → enter total Stableford points (single number). No per-hole entry.
+- **D-07:** Results card with: current HI, projected HI, delta (+/-), simulated SD, best-8 breakdown
+- **D-08:** Simulator operates entirely in local/transient state — no Firestore writes (SIM-03)
+- **D-09:** Playing HCP auto-calculated: `HI × (SR / 113) + (CR - PAR)`
+- **D-10:** Auto-calculated Playing HCP shown as default — user can override manually
+
+### the agent's Discretion
+
+- Simulator UI layout details (card placement, form layout)
+- How "best-8 breakdown" is visualized (chart, table, MUI x-chart)
+- Whether simulator state is Zustand (transient) or React component state
+- Nav icon and label text for Simulator nav item
+- Error/edge case UI (no rounds yet, fewer than 20 rounds)
+
+### Deferred Ideas (OUT OF SCOPE)
+
+None — discussion stayed within phase scope.
+</user_constraints>
+
+<phase_requirements>
+## Phase Requirements
+
+| ID | Description | Research Support |
+|----|-------------|------------------|
+| CALC-01 | System calculates Score Differential (SD) from Stableford input using SD = (AGS - CR - PCC) × (113 / SR), with AGS = PAR + Playing HCP + (36 - Stableford points) | Section 1: WHS Formula Implementation — `whs.utils.tsx` pattern |
+| CALC-02 | System calculates Handicap Index (HI) as average of best 8 SDs from last 20 rounds, with proper scaling for fewer rounds per WHS Rule 5.2a | Section 1: HI Calculation with scaling table |
+| SIM-01 | Dedicated "Simulator" tab/route lets users select a course/teebox and input hypothetical Stableford scores | Section 4: Simulator Page Integration — route, nav item, course selection |
+| SIM-02 | Simulator displays current HI vs projected HI in a results card with breakdown | Section 1: HI calculation engine + Section 4: Simulator results display |
+| SIM-03 | Simulator computes projection using a virtual array (last 19 real SDs + 1 simulated SD) without writing to the database | Section 2: Firestore Schema — ensures no writes; Section 1: virtual array pattern |
+</phase_requirements>
+
+---
+
+## Summary
+
+This phase delivers a pure WHS calculation engine (Score Differential + Handicap Index) and a transient-state Simulator page. No new database writes from the simulator itself — the only structural change to Firestore is adding `scoreDifferential: number | null` to existing round documents at save time (an integration point in `prepareRoundSaveBatch`).
+
+**Primary recommendation:** Implement the calculation engine as two pure functions in `src/utils/whs/`, then build the simulator as a self-contained page component with local React state for its transient form data. The HI is computed on-the-fly from existing `roundsList` in the Zustand store — no separate HI persistence needed.
+
+### Architectural Responsibility Map
+
+| Capability | Primary Tier | Secondary Tier | Rationale |
+|------------|-------------|----------------|-----------|
+| Score Differential calculation | Pure utility (`src/utils/whs/whs.utils.tsx`) | — | No I/O, pure math. Follows `TotalsCalculator.utils.tsx` pattern |
+| Handicap Index calculation | Pure utility (`src/utils/whs/hi.utils.tsx`) | — | Pure function over an array of SD numbers |
+| Simulator transient state | React component state (local `useState`) | OR Zustand transient slice | No persistence needed — local state is simpler. Discretion area |
+| Course selection in simulator | `course.firestore.ts` read (getAllCourses) | — | Reads from existing `golf_courses` collection (Phase 1) |
+| Nav item / route | DrawerAppBar + App.tsx | — | Follows existing pattern: links list + route element |
+| SD storage on round save | `prepareRoundSaveBatch` in `round.utils.tsx` | — | Add SD field to the Firestore document batch |
+| Current HI display | Simulator page (on-mount computation) | — | Reads `roundsList` from Zustand store, computes HI client-side |
+
+---
+
+## 1. WHS Formula Implementation
+
+### 1.1 Score Differential Formula
+
+The WHS Score Differential (SD) per round is:
+
+```
+SD = (AGS - CR - PCC) × (113 / SR)
+```
+
+Where:
+- **AGS** (Adjusted Gross Score) from Stableford: `AGS = PAR + Playing HCP + (36 - Stableford points)`
+- **CR** = Course Rating (from teebox selection)
+- **SR** = Slope Rating (from teebox selection)
+- **PCC** = Playing Conditions Calculation — **always 0** per project scope (confirmed in REQUIREMENTS.md Out of Scope)
+
+**Code pattern** (`src/utils/whs/whs.utils.tsx`):
+
+```typescript
+// Source: WHS Rule 5.1, [CITED: REQUIREMENTS.md]
+export interface IScoreDifferentialProps {
+  par: number;
+  courseRating: number;
+  slopeRating: number;
+  stablefordPoints: number;
+  playingHCP: number;
+}
+
+export interface IScoreDifferentialResult {
+  adjustedGrossScore: number;
+  scoreDifferential: number;
+}
+
+export const calculateScoreDifferential = (
+  props: IScoreDifferentialProps
+): IScoreDifferentialResult => {
+  const { par, courseRating, slopeRating, stablefordPoints, playingHCP } = props;
+
+  const adjustedGrossScore = par + playingHCP + (36 - stablefordPoints);
+  const scoreDifferential = safeDivide(
+    (adjustedGrossScore - courseRating - 0) * 113,
+    slopeRating,
+    1  // WHS standard: 1 decimal place
+  );
+
+  return {
+    adjustedGrossScore,
+    scoreDifferential,
+  };
+};
+```
+
+**Key details:**
+- `safeDivide` is the existing utility in `src/utils/calculator/math.utils.tsx` [VERIFIED: codebase grep]. It handles zero divisor, NaN, Infinity and returns 0 with configurable precision (default 2).
+- WHS standard rounds SD to 1 decimal place [ASSUMED]. Use safeDivide's `precision: 1` parameter.
+- SD should never be negative in practice, but guard against it: `Math.max(0, result)`.
+
+### 1.2 Handicap Index Calculation
+
+Per WHS Rule 5.2a [ASSUMED based on WHS standard]:
+
+**With 20 rounds:** Average the lowest 8 Score Differentials from the most recent 20.
+
+**With fewer than 20 rounds:** Use the WHS scaling table:
+
+| Number of Rounds | SDs to Average |
+|-----------------|----------------|
+| 3 | Lowest 1 |
+| 4 | Lowest 1 |
+| 5 | Lowest 1 |
+| 6 | Lowest 2 |
+| 7 | Lowest 2 |
+| 8 | Lowest 2 |
+| 9 | Lowest 3 |
+| 10 | Lowest 3 |
+| 11 | Lowest 3 |
+| 12 | Lowest 4 |
+| 13 | Lowest 4 |
+| 14 | Lowest 4 |
+| 15 | Lowest 5 |
+| 16 | Lowest 5 |
+| 17 | Lowest 6 |
+| 18 | Lowest 6 |
+| 19 | Lowest 7 |
+| 20 | Lowest 8 |
+
+[ASSUMED — WHS Rules 2024, Rule 5.2a. Verify against official WHS documentation before finalizing.]
+
+**Code pattern** (`src/utils/whs/hi.utils.tsx`):
+
+```typescript
+// Source: WHS Rule 5.2a, [ASSUMED]
+const SCALING_TABLE: Record<number, number> = {
+  3: 1, 4: 1, 5: 1,
+  6: 2, 7: 2, 8: 2,
+  9: 3, 10: 3, 11: 3,
+  12: 4, 13: 4, 14: 4,
+  15: 5, 16: 5, 17: 6,
+  18: 6, 19: 7, 20: 8,
+};
+
+export const calculateHandicapIndex = (scoreDifferentials: number[]): number | null => {
+  // Need at least 3 rounds for a valid HI per WHS
+  if (scoreDifferentials.length < 3) return null;
+
+  const count = Math.min(scoreDifferentials.length, 20);
+  const toUse = SCALING_TABLE[count] || 1;
+
+  // Take most recent `count`, sort ascending, take lowest `toUse`
+  const recent = scoreDifferentials.slice(0, count);
+  recent.sort((a, b) => a - b);
+  const best = recent.slice(0, toUse);
+
+  return safeDivide(
+    best.reduce((sum, sd) => sum + sd, 0),
+    best.length,
+    1
+  );
+};
+```
+
+**Important:** `scoreDifferentials` should be passed in **most recent first** (already sorted desc by `roundDate` from Firestore).
+
+### 1.3 Playing Handicap for Simulator
+
+Per D-09 and D-10:
+
+```
+Playing HCP = HI × (SR / 113) + (CR - PAR)
+```
+
+```typescript
+export const calculatePlayingHandicap = (
+  handicaps: number,
+  courseRating: number,
+  slopeRating: number,
+  par: number
+): number => {
+  return Math.round(handicaps * (slopeRating / 113) + (courseRating - par));
+};
+```
+
+This is a simple helper — no separate file needed unless complexity grows. Can live in either `whs.utils.tsx` or inline in the simulator page.
+
+### 1.4 Projected HI (Simulator)
+
+The simulated SD replaces the oldest SD in the last-20 window:
+
+```typescript
+export const calculateProjectedHandicapIndex = (
+  currentSDs: number[],
+  simulatedSD: number
+): number | null => {
+  // Take last 19 real SDs + the simulated one (will be most recent)
+  const virtual = [simulatedSD, ...currentSDs.slice(0, 19)];
+  return calculateHandicapIndex(virtual);
+};
+```
+
+The `virtual` array puts the simulated SD at index 0 (newest). The `calculateHandicapIndex` function then takes the first `count` entries (up to 20) and computes normally.
+
+---
+
+## 2. Firestore Schema Changes
+
+### 2.1 Add `scoreDifferential` to Round Documents
+
+The round document currently written in `prepareRoundSaveBatch` (`src/utils/round/round.utils.tsx:96-103`) needs a new field:
+
+```typescript
+batch.set(roundRef, {
+  ...general,
+  totals: totals,
+  distances: currentRoundDistances,
+  userId: userId,
+  scoreDifferential: null, // NEW — computed during save or left null for existing rounds
+  roundDate: general.roundDate ? Timestamp.fromDate(new Date(general.roundDate)) : serverTimestamp(),
+  createdAt: serverTimestamp(),
+});
+```
+
+**Integration pattern:** The SD is computed during `saveNewRound()` using the course/tee data already stored in the round. Since `roundCourse` and `roundTee` are already present in `general`, and `roundPar` is also present, the SD calculation needs:
+1. Query the course document to get `courseRating` and `slopeRating` for the selected teebox
+2. Compute AGS from the round totals (Stableford points are in `totals.points.totals`)
+3. Store the result in `scoreDifferential`
+
+**For existing rounds:** Set `scoreDifferential: null`. The HI calculation will skip null SDs when building the last-20 window. This avoids a costly backfill migration.
+
+### 2.2 Type Changes
+
+**`IBasicRoundData`** (`src/types/roundData.types.tsx`):
+```typescript
+export interface IBasicRoundData {
+  // ...existing fields...
+  scoreDifferential?: number | null;  // NEW
+  createdAt: number,
+  totals: IRoundTotals
+}
+```
+
+**`IRoundDetails`** (`src/types/roundDetails.types.tsx`):
+```typescript
+export interface IRoundDetails extends IBasicRoundData {
+  holes: IShots[];
+  distances?: IDistance[];
+  // scoreDifferential inherited from IBasicRoundData
+}
+```
+
+### 2.3 Fetching Rounds for HI Calculation
+
+The existing `roundsList` (`IBasicRoundData[]`) is already sorted by `roundDate` descending from the Firestore query in `player.firestore.ts:25`:
+
+```typescript
+const roundsQuery = query(roundsColRef, orderBy('roundDate', 'desc'));
+```
+
+**To compute current HI:**
+1. Access `roundsList` from Zustand store
+2. Filter to entries with `scoreDifferential !== null && scoreDifferential !== undefined`
+3. Map to extract just the SD numbers (already in desc date order)
+4. Pass to `calculateHandicapIndex()`
+
+```typescript
+const allSDs = roundsList
+  .filter(r => r.scoreDifferential != null)
+  .map(r => r.scoreDifferential as number);
+```
+
+**No additional Firestore reads needed** — the data is already in the client store.
+
+---
+
+## 3. Zustand Store Architecture
+
+### 3.1 Simulator State
+
+Per discretion area: simulator state can be either React component state or a Zustand transient slice.
+
+**Recommendation:** React component state (`useState` + `useMemo` for computed values). The simulator has no lifecycle across page navigations, no persistence requirement, and no shared state. Using `useState` keeps the store lean and follows React best practices for ephemeral UI state.
+
+If the planner prefers Zustand (e.g., for devtools tracing), a minimal transient slice:
+
+```typescript
+// In app.store.ts AppState interface:
+simulator: {
+  selectedCourse: ICourse | null;
+  selectedTeebox: ITeebox | null;
+  stablefordPoints: number;
+  playingHCP: number;
+  manualHCPOverride: boolean;
+};
+```
+
+### 3.2 HI Helper
+
+No additional Zustand action needed for HI calculation — it's a pure function consuming existing store data. The simulator page can compute HI on mount:
+
+```typescript
+const roundsList = useAppStore((state) => state.roundsList);
+const currentHI = useMemo(() => {
+  const sds = roundsList
+    .filter(r => r.scoreDifferential != null)
+    .map(r => r.scoreDifferential as number);
+  return calculateHandicapIndex(sds);
+}, [roundsList]);
+```
+
+### 3.3 SD on Round Save
+
+The `saveNewRound()` action in the store (`app.store.ts:735-752`) chains to the `saveNewRound()` Firestore service. The SD computation should happen inside the Firestore service or in `prepareRoundSaveBatch`, not in the store action itself.
+
+**Option A (recommended):** Compute SD inside `round.firestore.ts:saveNewRound()` before calling `prepareRoundSaveBatch`. Add the course query + SD computation there, then pass `scoreDifferential` to the batch:
+
+```typescript
+// In saveNewRound() — compute SD
+const stablefordPoints = currentTotals.points.totals;
+const course = await getCourseByName(general.roundCourse); // need to add or use existing
+const teebox = course?.teeboxes.find(t => t.name === general.roundTee);
+const sd = teebox ? calculateScoreDifferential({
+  par: general.roundPar,
+  courseRating: teebox.courseRating,
+  slopeRating: teebox.slopeRating,
+  stablefordPoints,
+  playingHCP: general.roundPlayingHCP,
+}) : null;
+```
+
+**Option B:** Accept this is low priority (deferred to v2 per CALC-03). The simulator will compute SD from the round data alone, and real-round SD storage happens in a future phase. The `scoreDifferential` field is added to the schema now but stays `null`.
+
+**Decision D-03 explicitly states** "Score Differential stored on each round document at save time" — so we must implement it now. But this only applies to **new** rounds saved going forward. Existing rounds remain `null`.
+
+---
+
+## 4. Simulator Page Integration
+
+### 4.1 Route Definition
+
+Add to `src/App.tsx` inside the `/` layout's `<Routes>`:
+
+```typescript
+import SimulatorPage from './pages/Simulator.page';
+
+// Inside the "/" Route, alongside existing routes:
+<Route path="/simulator" element={<SimulatorPage />} />
+```
+
+### 4.2 Nav Item
+
+**Option A:** Add to `src/utils/links/links.utils.tsx` navbar_items array:
+```typescript
+{
+  id: 5,
+  name: "Simulator",
+  link: "/simulator",
+  icon: CalculateIcon, // or AnalyticsIcon, TrendingUpIcon
+  show: true,
+}
+```
+
+This automatically renders in the "Menu" section of the drawer via the `links.map()` loop at `MainLayout2.component.tsx:170`.
+
+**Option B (if label needs to stand out):** Add hardcoded nav item in `MainLayout2.component.tsx` between lines 237-238, similar to the admin links pattern (lines 195-219).
+
+**Recommendation:** Option A is cleaner. The existing `links.map()` already renders all items with `show: true` in the main menu. Add an appropriate icon like `CalculateIcon` or `AutoGraphIcon`.
+
+### 4.3 Breadcrumbs
+
+Add to `getBreadcrumbs()` and `getMobileBreadcrumbs()` in `MainLayout2.component.tsx`:
+```typescript
+} else if (path === '/simulator') {
+  breadcrumbs.push({ label: 'Simulator', path: '/simulator' });
+}
+```
+
+### 4.4 Simulator Page Layout
+
+Per D-06 and D-07, the page has three sections:
+
+**1. Course Selection:**
+- Dropdown listing all courses from `getAllCourses()` (reads `golf_courses` collection)
+- On course select, filter teeboxes to that course
+- Dropdown to select teebox (shows name, par, CR, SR)
+
+**2. Score Input:**
+- Text field for total Stableford points (0-36, integer)
+- Auto-calculated Playing HCP display with manual override toggle
+- Playing HCP formula: `HI × (SR / 113) + (CR - PAR)`
+
+**3. Results Card (updates reactively):**
+- Current Handicap Index: from `calculateHandicapIndex()` on existing rounds
+- Simulated Score Differential: from `calculateScoreDifferential()` with the form inputs
+- Projected Handicap Index: from `calculateProjectedHandicapIndex()`
+- Delta: Projected HI - Current HI (with +/- sign)
+- Best-8 breakdown: table or minimal list showing the current best 8 SDs vs. projected best 8
+
+### 4.5 Edge Cases
+
+| State | Behavior |
+|-------|----------|
+| No rounds yet (< 3 rounds) | Show "Need at least 3 rounds to calculate HI" with current HI shown as "—" |
+| 0 rounds | Show "No rounds recorded yet. Go play some golf!" with simulator disabled |
+| Course has no teeboxes | Disable teebox selection, show "No teeboxes defined for this course" |
+| Invalid Stableford points | Validate input range, show error for > 36 or < 0 |
+
+---
+
+## 5. Reading Existing Rounds for HI Calculation
+
+The existing data flow already supports this:
+
+1. `Dashboard.page.tsx` calls `getPlayerDetails(uid)` on mount, which fetches rounds sorted by `roundDate` descending
+2. `roundsList` is stored in the Zustand store via `setRounds(result.rounds)`
+3. Any page can access `roundsList` via `useAppStore((state) => state.roundsList)`
+
+**The HI calculation pipeline:**
+```
+roundsList (IBasicRoundData[], sorted desc by date)
+  → filter(r => r.scoreDifferential != null)
+  → map to number[] (already in desc date order)
+  → calculateHandicapIndex(sds) → number | null
+```
+
+**No new Firestore queries needed** for the current HI. The data is already in the store from the Dashboard load.
+
+---
+
+## 6. Test Strategy
+
+### 6.1 Extending the Dev-Tool Infrastructure
+
+The existing test infrastructure in `src/dev-tools/` can be extended:
+- `testDataGenerator.ts` — add WHS test scenarios
+- `testRunner.ts` — add WHS-specific test commands
+- `edgeCaseTests.ts` — add WHS edge cases
+
+**New npm scripts** (in `package.json`):
+```json
+"test:calc:whs": "node --import tsx src/dev-tools/whsTestRunner.ts all",
+"test:calc:whs-quick": "node --import tsx src/dev-tools/whsTestRunner.ts quick"
+```
+
+Or simpler: extend the existing `testRunner.ts` CLI with a `whs` command.
+
+### 6.2 WHS Test Scenarios
+
+**Known WHS verification examples** (from WHS官方 documentation) [ASSUMED — verify against official WHS examples]:
+
+| Scenario | Par | CR | SR | Playing HCP | Stableford Pts | Expected AGS | Expected SD |
+|----------|-----|----|----|-------------|----------------|-------------|-------------|
+| Good round | 72 | 72.5 | 135 | 18 | 42 | 78 | 4.6 |
+| Average round | 72 | 72.5 | 135 | 18 | 36 | 90 | 14.6 |
+| Poor round | 72 | 72.5 | 135 | 18 | 24 | 102 | 24.7 |
+
+**Test data generation pattern:**
+```typescript
+const whsTestRound: TestRoundConfig = {
+  roundName: 'WHS Standard Round',
+  description: 'Standard round to verify Score Differential calculation',
+  courseInfo: { name: 'WHS Test Course', par: 72, tee: 'Test', playerHCP: 18 },
+  holeConfigs: generateHolesFromStableford(42, 72, 18, /* per-hole configs */),
+};
+```
+
+### 6.3 WHS-Specific Test Functions
+
+```typescript
+export const calculateScoreDifferential_testCases = [
+  {
+    name: 'Good round - Standard Course',
+    input: { par: 72, courseRating: 72.5, slopeRating: 135, stablefordPoints: 42, playingHCP: 18 },
+    expectedSD: 4.6, // (78 - 72.5) * 113 / 135
+  },
+  // ...
+];
+```
+
+---
+
+## 7. Don't Hand-Roll
+
+| Problem | Don't Build | Use Instead | Why |
+|---------|-------------|-------------|-----|
+| Rounding/safe math | Custom division | `safeDivide` in `math.utils.tsx` | Already handles NaN/Infinity/zero, already in codebase |
+| Course data fetch | Custom Firestore query | `getAllCourses()` / `getCourseById()` in `course.firestore.ts` | Already exists from Phase 1 |
+| Nav integration | Custom nav component | Existing `links.utils.tsx` + `MainLayout2.drawer` | Adding a link renders the nav item automatically |
+| State persistence for simulator | localStorage/Zustand persist | React `useState` | Simulator is ephemeral — no persistence needed per D-08 |
+| Date handling | Raw Date math | `dayjs` | Already in codebase, handles Firestore Timestamp conversion |
+
+---
+
+## 8. Common Pitfalls
+
+### Pitfall 1: Mixing Current HI with Player's HCP Field
+**What goes wrong:** The `HCP` field on `IPlayerDetails` (`src/types/player.types.tsx:36`) is a user-entered value, NOT the WHS Handicap Index. Confusing these leads to incorrect calculations.
+**Root cause:** The existing app has a manual `HCP` field on the player profile. The WHS HI must be a computed value, not a stored field (per D-04).
+**How to avoid:** Never read `player.HCP` for WHS calculations. Always compute HI from `roundsList` score differentials. The `HCP` field is only for display/reference.
+**Warning signs:** Tests showing incorrect HI values that match the player's stored HCP.
+
+### Pitfall 2: Off-by-One in Last-20 Round Selection
+**What goes wrong:** Taking the last 20 rounds includes the wrong set because `roundsList` is already sorted desc. Taking indices 0-19 works, but filtering by null SDs changes the effective count.
+**Root cause:** Some rounds may have `scoreDifferential === null` (existing rounds). Filtering them out and then taking 20 from the remaining may skip more recent rounds.
+**How to avoid:** Filter null SDs first, THEN take the most recent 20 (indices 0-19 from the filtered, already-sorted list).
+**Warning signs:** HI that doesn't match manual calculation from known rounds.
+
+### Pitfall 3: Forgetting WHS Scaling for < 20 Rounds
+**What goes wrong:** Implementing "average of best 8" for all cases produces incorrect results for new players with fewer rounds.
+**Root cause:** Rule 5.2a requires fewer SDs to be averaged when fewer rounds are available. Applying the 20-round rule universally is incorrect.
+**How to avoid:** Use the scaling table from Section 1.2. If `rounds.length < 3`, return null (no valid HI).
+**Warning signs:** A player with 5 rounds gets an HI that doesn't match the WHS table.
+
+### Pitfall 4: Simulator State Persistence
+**What goes wrong:** The simulator writes its transient state to localStorage via Zustand persist, violating SIM-03's "no database writes" intent at the client level.
+**Root cause:** If simulator state is added to the Zustand store inside the `partialize` function, it gets persisted to localStorage.
+**How to avoid:** Either use React component state (preferred) or add the simulator slice outside the `partialize` function so it's not persisted.
+**Warning signs:** Refreshing the simulator page restores form state.
+
+---
+
+## 9. Code Examples
+
+### 9.1 Pure SD Calculation Function
+
+```typescript
+// src/utils/whs/whs.utils.tsx
+// Source: WHS Rule 5.1, [CITED: CONTEXT.md canonical refs]
+
+import { safeDivide } from '@/utils/calculator/math.utils';
+
+export interface IScoreDifferentialProps {
+  par: number;
+  courseRating: number;
+  slopeRating: number;
+  stablefordPoints: number;
+  playingHCP: number;
+}
+
+export interface IScoreDifferentialResult {
+  adjustedGrossScore: number;
+  scoreDifferential: number;
+}
+
+export const calculateScoreDifferential = (
+  props: IScoreDifferentialProps
+): IScoreDifferentialResult => {
+  const { par, courseRating, slopeRating, stablefordPoints, playingHCP } = props;
+
+  const adjustedGrossScore = par + playingHCP + (36 - stablefordPoints);
+
+  const scoreDifferential = Math.max(0,
+    safeDivide(
+      (adjustedGrossScore - courseRating) * 113,
+      slopeRating,
+      1  // WHS standard
+    )
+  );
+
+  return { adjustedGrossScore, scoreDifferential };
+};
+```
+
+### 9.2 HI Calculation with Scaling
+
+```typescript
+// src/utils/whs/hi.utils.tsx
+// Source: WHS Rule 5.2a, [ASSUMED]
+
+import { safeDivide } from '@/utils/calculator/math.utils';
+
+const HI_SCALING: Record<number, number> = {
+  3: 1, 4: 1, 5: 1,
+  6: 2, 7: 2, 8: 2,
+  9: 3, 10: 3, 11: 3,
+  12: 4, 13: 4, 14: 4,
+  15: 5, 16: 5, 17: 6,
+  18: 6, 19: 7, 20: 8,
+};
+
+/**
+ * Calculate Handicap Index from Score Differentials.
+ * Input must be sorted with most recent first (descending date).
+ * Returns null if fewer than 3 valid SDs available.
+ */
+export const calculateHandicapIndex = (scoreDifferentials: number[]): number | null => {
+  const count = Math.min(scoreDifferentials.length, 20);
+
+  if (count < 3) return null;
+
+  const toUse = HI_SCALING[count] ?? 1;
+  const recent = scoreDifferentials.slice(0, count);
+
+  // Sort ascending to find lowest SDs
+  const sorted = [...recent].sort((a, b) => a - b);
+  const bestN = sorted.slice(0, toUse);
+
+  return safeDivide(
+    bestN.reduce((sum, sd) => sum + sd, 0),
+    bestN.length,
+    1
+  );
+};
+```
+
+### 9.3 Simulator Course Selection (React Hook-based)
+
+```typescript
+// Inside Simulator.page.tsx (pattern reference)
+// Source: [CITED: getAllCourses from course.firestore.ts]
+
+import { getAllCourses } from '@/utils/firestore/course.firestore';
+import { ICourse, ITeebox } from '@/types/course.types';
+import { useAppStore } from '@/store/zustand';
+
+const SimulatorPage = () => {
+  const [courses, setCourses] = useState<ICourse[]>([]);
+  const [selectedCourse, setSelectedCourse] = useState<ICourse | null>(null);
+  const [selectedTeebox, setSelectedTeebox] = useState<ITeebox | null>(null);
+  const [stablefordPoints, setStablefordPoints] = useState<number>(36);
+  const [manualHCP, setManualHCP] = useState<number | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const roundsList = useAppStore((state) => state.roundsList);
+
+  useEffect(() => {
+    getAllCourses().then(all => {
+      setCourses(all.filter(c => c.status === 'Active'));
+      setLoading(false);
+    });
+  }, []);
+
+  const currentHI = useMemo(() => {
+    const sds = roundsList
+      .filter(r => r.scoreDifferential != null)
+      .map(r => r.scoreDifferential as number);
+    return calculateHandicapIndex(sds);
+  }, [roundsList]);
+
+  const playingHCP = useMemo(() => {
+    if (!selectedTeebox || currentHI == null) return null;
+    return manualHCP ?? Math.round(
+      currentHI * (selectedTeebox.slopeRating / 113) +
+      (selectedTeebox.courseRating - selectedTeebox.par)
+    );
+  }, [selectedTeebox, currentHI, manualHCP]);
+});
+```
+
+---
+
+## 10. Validation Architecture
+
+> workflow.nyquist_validation is not explicitly disabled — validation section included.
+
+### Test Framework
+
+| Property | Value |
+|----------|-------|
+| Framework | Vitest 4.1.2 (existing) + Dev-tools custom runner (existing) |
+| Config file | `vitest.config.ts` (existing) |
+| Quick run command | `npm run test:calc:whs-quick` (new script to add) |
+| Full suite command | `npm run test:calc:whs` (new script to add) |
+
+### Phase Requirements → Test Map
+
+| Req ID | Behavior | Test Type | Automated Command | File Exists? |
+|--------|----------|-----------|-------------------|-------------|
+| CALC-01 | SD calculated from Stableford input with correct WHS formula | Unit | `npm run test:calc:whs` — whs SD validation | ❌ Wave 0 |
+| CALC-01 | AGS correctly computed from par + playing HCP + (36 - Stableford points) | Unit | `npm run test:calc:whs` — AGS validation | ❌ Wave 0 |
+| CALC-02 | HI correctly computed as avg of best 8 from last 20 | Unit | `npm run test:calc:whs` — best-8 validation | ❌ Wave 0 |
+| CALC-02 | HI scaling table works for < 20 rounds | Unit | `npm run test:calc:whs` — scaling table validation | ❌ Wave 0 |
+| CALC-02 | HI returns null for < 3 rounds | Unit | `npm run test:calc:whs` — minimum rounds validation | ❌ Wave 0 |
+| SIM-01 | Simulator loads courses from Firestore | Integration | Manual (no test DB) | — |
+| SIM-02 | SD appears in results when all inputs provided | Integration | Manual + dev-tools WHS test data | — |
+| SIM-03 | No Firestore writes during simulator session | Code review | Manual inspection | — |
+
+### Sampling Rate
+- **Per task commit:** `npm run type-check` + `npm run test:calc:whs-quick`
+- **Per wave merge:** Full WHS test suite + `npm run test:calc:all` (existing)
+- **Phase gate:** Full suite green before `/gsd-verify-work`
+
+### Wave 0 Gaps
+- [ ] `src/dev-tools/whsTestRunner.ts` — New test runner for WHS-specific tests (or extend existing)
+- [ ] `src/dev-tools/whsTestData.ts` — WHS test data and expected values
+- [ ] New npm scripts in `package.json` for WHS test commands
+
+---
+
+## 11. Standard Stack
+
+No new libraries needed. Everything uses existing stack:
+
+| Library | Version | Purpose | Why Standard |
+|---------|---------|---------|--------------|
+| React 19 | 19.2.6 | UI components | Existing app framework |
+| MUI v7 | 7.3.11 | UI components (Select, TextField, Card, Typography) | Existing UI library |
+| Zustand | 5.0.13 | State management (read roundsList) | Existing state management |
+| Firestore | Firebase 12.13 | Read courses (simulator) + store SD on save | Existing data layer |
+| dayjs | 1.11.20 | Date handling | Existing date utility |
+| `safeDivide` | internal | Safe division in WHS formulas | Already in codebase, guards NaN/Infinity |
+
+No npm install needed for this phase.
+
+---
+
+## 12. Assumptions Log
+
+| # | Claim | Section | Risk if Wrong |
+|---|-------|---------|---------------|
+| A1 | WHS Rule 5.2a scaling table is accurate as documented | Section 1.2 | HI calculation would be non-compliant with actual WHS rules. **Mitigation:** Verify against official WHS documentation before finalizing. |
+| A2 | WHS rounds SD to 1 decimal place | Section 1.1 | Cosmetic difference — results display would round differently. Easily changed. |
+| A3 | The `HCP` field on `IPlayerDetails` is a user-entered value, not a computed HI | Section 8, Pitfall 1 | If HCP field was already being computed elsewhere, we might double-compute. Codebase search confirms it's just stored raw. Low risk. |
+| A4 | WHS formula examples (AGS = PAR + PHCP + 36 - SPoints) is correct | Section 1.1 | Core formula — if wrong, all calculations are wrong. **Mitigation:** This is the standard WHS Stableford-to-SD formula [CITED: WHS Rules]. |
+
+**If this table is empty:** Not applicable — assumptions exist in this research.
+
+---
+
+## 13. Open Questions (RESOLVED)
+
+1. **[WHS Scaling Table precision]** — Is the scaling table documented in Section 1.2 current for 2024 WHS rules?
+   - **RESOLVED:** The documented table is accepted as-is for implementation. If the 2024 WHS rules changed scaling thresholds, the table can be updated in a future phase. The formula and structure are correct — only specific threshold values may differ. Flagged as `[ASSUMED]` in the hi.utils.tsx implementation with a comment referencing WHS Rule 5.2a for easy verification.
+
+2. **[Existing rounds SD storage]** — Do we compute SD for rounds saved during this phase?
+   - **RESOLVED:** D-03 confirms: store SD on round document at save time in `saveNewRound()`. Existing rounds that lack SD get `scoreDifferential: null`. No backfill needed. CR and SR are stored on the round document alongside SD to avoid re-querying the course collection.
+
+3. **[Test data expected values]** — Do we have official WHS example calculations to validate against?
+   - **RESOLVED:** Test data uses standard WHS formula application with tolerance-based (0.1) matching. If official R&A/USGA examples become available, they can be added as additional test cases without changing the implementation.
+
+---
+
+## 14. Security Domain
+
+> security_enforcement not explicitly disabled — security section included.
+
+### Applicable ASVS Categories
+
+| ASVS Category | Applies | Standard Control |
+|---------------|---------|-----------------|
+| V2 Authentication | No | Simulator doesn't write data; reads public courses only |
+| V3 Session Management | No | Simulator runs inside existing ProtectedRoute |
+| V4 Access Control | No | Simulator is available to all authenticated users |
+| V5 Input Validation | Yes | Validate Stableford points (0-36 integer), validate course/teebox exist |
+| V6 Cryptography | No | No encryption needed for client-side calculation |
+
+### Known Threat Patterns for this Stack
+
+| Pattern | STRIDE | Standard Mitigation |
+|---------|--------|---------------------|
+| Stableford points out of range | Tampering | Client-side validation (0-36) |
+| Course/teebox selection invalid | Tampering | Validate selection exists in `courses` state before computing |
+| Firestore course read failure | DoS (secondary) | Error boundary on course fetch, show helpful message |
+
+---
+
+## 15. Environment Availability
+
+> Phase 2 has no new external dependencies. All dependencies already exist:
+> - Node v22.14.0 ✓ (from .nvmrc)
+> - npm ✓ (existing)
+> - Firebase SDK ✓ (existing dependency)
+> - MUI components ✓ (existing dependency)
+> - Zustand ✓ (existing dependency)
+> - Firestore (configured in existing project)
+
+**No new external dependencies required.**
+
+---
+
+## Sources
+
+### Primary (HIGH confidence)
+- [VERIFIED: codebase] `src/utils/calculator/TotalsCalculator.utils.tsx` — Pure function calculation pattern with typed Props, typed return, safeDivide
+- [VERIFIED: codebase] `src/utils/calculator/math.utils.tsx` — `safeDivide` with precision parameter, guards NaN/Infinity/zero
+- [VERIFIED: codebase] `src/utils/firestore/round.firestore.ts` — `saveNewRound()` pattern, batch writes to rounds
+- [VERIFIED: codebase] `src/utils/round/round.utils.tsx` — `prepareRoundSaveBatch()` — where SD field will be added
+- [VERIFIED: codebase] `src/utils/firestore/player.firestore.ts:24-26` — Rounds already fetched sorted by `roundDate` descending
+- [VERIFIED: codebase] `src/types/roundData.types.tsx` — `IBasicRoundData` already has `id, roundDate, roundCourse, roundTee, roundPar, totals`
+- [VERIFIED: codebase] `src/types/course.types.tsx` — `ITeebox` has `courseRating`, `slopeRating`, `par`
+- [VERIFIED: codebase] `src/utils/links/links.utils.tsx` — Nav items defined as array, rendered via `links.map()`
+- [VERIFIED: codebase] `src/components/layout/MainLayout2.component.tsx` — Drawer with admin links pattern and breadcrumbs
+- [VERIFIED: codebase] `src/App.tsx` — Route definition inside `/` layout
+- [VERIFIED: codebase] `src/store/zustand/app.store.ts` — Zustand store with persist pattern, async actions
+- [VERIFIED: codebase] `src/dev-tools/` — Full test infrastructure (testRunner, testDataGenerator, edgeCaseTests)
+- [VERIFIED: codebase] `src/enum/shots.enum.tsx` — `STABLEFORDPOINTS` enum with values 0-5
+
+### Secondary (MEDIUM confidence)
+- [CITED: CONTEXT.md canonical refs] WHS Rules 5.1, 5.2a — Formula and scaling table referenced from phase discussion
+- [ASSUMED] WHS scaling table for < 20 rounds (Rule 5.2a) — Verify against official WHS documentation
+- [ASSUMED] WHS rounds SD to 1 decimal place — Standard practice, verify against rules
+
+---
+
+## Metadata
+
+**Confidence breakdown:**
+- Standard stack: HIGH — No new dependencies needed; everything existing
+- Architecture: HIGH — Patterns well-established in codebase (TotalsCalculator, Zustand, Firestore services, nav)
+- Pitfalls: HIGH — Based on common WHS implementation errors and codebase-specific gotchas
+- WHS formula precision: MEDIUM — Core formulas are standard, but scaling table should be verified against official WHS docs
+
+**Research date:** 2026-06-01
+**Valid until:** 2026-07-01 (WHS rules change slowly; 30-day validity for the scaling table assumption)

--- a/.planning/phases/02-whs-engine-handicap-simulator/02-VALIDATION.md
+++ b/.planning/phases/02-whs-engine-handicap-simulator/02-VALIDATION.md
@@ -1,0 +1,78 @@
+---
+phase: 2
+slug: whs-engine-handicap-simulator
+status: draft
+nyquist_compliant: true
+wave_0_complete: false
+created: 2026-06-01
+---
+
+# Phase 2 — Validation Strategy
+
+> Per-phase validation contract for feedback sampling during execution.
+
+---
+
+## Test Infrastructure
+
+| Property | Value |
+|----------|-------|
+| **Framework** | Vitest 4.1.2 (existing) + Dev-tools custom runner (existing) |
+| **Config file** | `vitest.config.ts` (existing) |
+| **Quick run command** | `npm run test:calc:whs-quick` |
+| **Full suite command** | `npm run test:calc:whs` |
+| **Estimated runtime** | ~30 seconds |
+
+---
+
+## Sampling Rate
+
+- **After every task commit:** `npm run type-check` + `npm run test:calc:whs-quick`
+- **After every plan wave:** Full WHS test suite + `npm run test:calc:all` (existing)
+- **Before `/gsd-verify-work`:** Full suite must be green
+- **Max feedback latency:** 30 seconds
+
+---
+
+## Per-Task Verification Map
+
+| Task ID | Plan | Wave | Requirement | Threat Ref | Secure Behavior | Test Type | Automated Command | File Exists | Status |
+|---------|------|------|-------------|------------|-----------------|-----------|-------------------|-------------|--------|
+| 02-01-01 | 01 | 1 | CALC-01, CALC-02 | T-02-01-01 / T-02-01-02 | Input validation guards against out-of-range Stableford values | unit | `npm run test:calc:whs-quick` | ❌ W0 | ⬜ pending |
+| 02-01-02 | 01 | 1 | CALC-02 | — | N/A | unit | `npm run type-check` | ✅ | ⬜ pending |
+| 02-01-03 | 01 | 1 | CALC-01 | T-02-01-03 | SD field written only with valid course data | integration | `npm run test:calc:whs` | ❌ W0 | ⬜ pending |
+| 02-02-01 | 02 | 2 | SIM-01, SIM-02 | T-02-02-01 / T-02-02-02 | Course/teebox selection validated against loaded data | integration | Manual (no test DB) | — | ⬜ pending |
+| 02-02-02 | 02 | 2 | SIM-03 | T-02-02-03 | No Firestore write operations in simulator code | code review | Manual inspection | — | ⬜ pending |
+
+*Status: ⬜ pending · ✅ green · ❌ red · ⚠️ flaky*
+
+---
+
+## Wave 0 Requirements
+
+- [ ] `src/dev-tools/whsTestRunner.ts` — WHS-specific test scenarios (or extend existing testRunner)
+- [ ] `src/dev-tools/whsTestData.ts` — WHS test data with known expected values
+- [ ] New npm scripts in `package.json`: `test:calc:whs-quick` and `test:calc:whs`
+
+---
+
+## Manual-Only Verifications
+
+| Behavior | Requirement | Why Manual | Test Instructions |
+|----------|-------------|------------|-------------------|
+| Simulator loads courses from Firestore | SIM-01 | Requires live Firestore data — no test DB in CI | Run app, navigate to /simulator, confirm courses dropdown populates |
+| Simulator does not write to Firestore | SIM-03 | Cannot assert absence of writes in automated tests | Inspect code — verify no `.firestore.` calls exist in Simulator components |
+| Nav integration | SIM-01 | UI rendering assertion | Run app, confirm Simulator nav item appears in DrawerAppBar |
+
+---
+
+## Validation Sign-Off
+
+- [ ] All tasks have `<automated>` verify or Wave 0 dependencies
+- [ ] Sampling continuity: no 3 consecutive tasks without automated verify
+- [ ] Wave 0 covers all MISSING references
+- [ ] No watch-mode flags
+- [ ] Feedback latency < 30s
+- [ ] `nyquist_compliant: true` set in frontmatter
+
+**Approval:** pending

--- a/.planning/phases/03-navigation-and-sidebar-reorg/03-02-SUMMARY.md
+++ b/.planning/phases/03-navigation-and-sidebar-reorg/03-02-SUMMARY.md
@@ -1,0 +1,116 @@
+---
+phase: 03-navigation-and-sidebar-reorg
+plan: 02
+subsystem: ui
+tags: [drawer, sidebar, responsive, navigation, mui, useMediaQuery, routerlink]
+
+requires:
+  - phase: 03-01
+    provides: SidebarHCP component, simplified User avatar
+provides:
+  - Responsive sidebar drawer (temporary on mobile, persistent on desktop)
+  - Restructured drawer content with filtered links, compact HCP, Settings, admin section, ThemeSwitcher, Logout
+  - SPA navigation via RouterLink (no full-page reloads)
+affects: []
+
+tech-stack:
+  added: []
+  patterns:
+    - useMediaQuery + useTheme for responsive drawer variant switching
+    - component={RouterLink} to={path} for SPA nav links in drawer
+    - Conditional side-effect onClick for drawer close (mobile only)
+    - CSS transition on main content margin for drawer push effect
+
+key-files:
+  created: []
+  modified:
+    - src/components/layout/MainLayout2.component.tsx
+
+key-decisions:
+  - "Renamed `mobileOpen` state to `drawerOpen` — the drawer now opens/closes on all screen sizes, not just mobile"
+  - "Drawer variant switches via `useMediaQuery(theme.breakpoints.up('md'))` — single drawer component handles both modes"
+  - "On desktop nav link click does NOT close drawer — consistent with Research Pitfall 2 guidance"
+
+patterns-established:
+  - "Responsive drawer: conditional variant + conditional wrapper onClick + conditional main content margin"
+  - "Nav link filtering: `links.filter(l => l.show === true)` as single source of truth"
+
+requirements-completed: [NAV-02, NAV-03, NAV-04, NAV-05]
+
+duration: 2 min
+completed: 2026-06-01
+---
+
+# Phase 3 Plan 2: Sidebar Drawer Restructure & Responsive Variant Switching
+
+**Restructured the sidebar drawer as the primary navigation hub on all screen sizes — filtered nav links (show===true), compact HCP badge, Settings/admin/ThemeSwitcher/Logout in correct ordering, and responsive variant switching (temporary on mobile, persistent/toggleable on desktop).**
+
+## Performance
+
+- **Duration:** 2 min
+- **Started:** 2026-06-01T07:32:07Z
+- **Completed:** 2026-06-01T07:34:07Z
+- **Tasks:** 2
+- **Files modified:** 1
+
+## Accomplishments
+
+- Replaced `links.map()` with `links.filter(l => l.show === true).map()` — Dashboard, Courses, Users excluded from main nav loop
+- Removed hardcoded duplicate Profile/Clubs/Statistics ListItem blocks (single source of truth)
+- Removed old admin block inside `links.map()` — replaced with NEW admin section after Settings (single render, isAdmin-gated)
+- Changed ALL nav `href` attributes to `component={RouterLink} to={path}` for SPA navigation
+- Added `SidebarHCP` compact badge display in drawer
+- Added Settings ListItemButton navigating to `/settings`
+- Added Logout ListItemButton with Logout icon, calling `handleLogout`
+- Moved ThemeSwitcher to correct position between admin section and Logout
+- Removed obsolete `AccountCircleIcon` and `Avatar` imports
+- Added `useMediaQuery` + `useTheme` for responsive breakpoint detection
+- Changed Drawer variant to `persistent` on desktop (md+), `temporary` on mobile
+- Removed the `display: { xs: 'block', sm: 'none' }` constraint — drawer now opens on ALL screen sizes
+- Made drawer wrapper `onClick` conditional — only closes drawer on nav click on mobile
+- Added CSS transition with conditional `ml` on main content for desktop drawer push effect
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Restructure drawer contents** — `8d3ad82` (feat)
+2. **Task 2: Add responsive drawer variant switching** — `27eff44` (feat)
+
+**Plan metadata:** Pending on next step
+
+## Files Created/Modified
+
+- `src/components/layout/MainLayout2.component.tsx` — Restructured drawer content (~60 lines changed): filtered nav links, RouterLink, SidebarHCP compact HCP, Settings/admin/ThemeSwitcher/Logout correct ordering, responsive variant switching with useMediaQuery, conditional main content margin with CSS transition
+
+## Decisions Made
+
+- Renamed `mobileOpen` → `drawerOpen` to reflect that the drawer opens on all screen sizes, not just mobile
+- Single Drawer component with variant switching via `useMediaQuery` (not two separate Drawers) — cleaner, less code
+- On desktop, clicking nav links does NOT close the drawer — only the hamburger toggle controls it (per Research resolution)
+- Removed `Avatar` import from MainLayout2 — no longer needed since Profile block removed; `User` component handles its own avatar rendering
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+
+None
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+
+- All Phase 3 plans complete (03-01: Avatar simplification + SidebarHCP, 03-02: Sidebar drawer restructure + responsive variant)
+- Sidebar drawer is now the primary navigation hub on all screen sizes
+- Admin links render only for admin users, in a dedicated section — no duplicate rendering
+- SPA navigation via RouterLink — no full-page reloads on sidebar link click
+- Phase complete, ready for next phase
+
+---
+
+*Phase: 03-navigation-and-sidebar-reorg*
+*Completed: 2026-06-01*

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
 		"test:calc:quick": "tsx src/dev-tools/testRunner.ts quick",
 		"test:calc:edge": "tsx src/dev-tools/testRunner.ts edge",
 		"test:calc:all": "tsx src/dev-tools/testRunner.ts all",
+		"test:calc:whs": "tsx src/dev-tools/whsTestRunner.ts all",
+		"test:calc:whs-quick": "tsx src/dev-tools/whsTestRunner.ts quick",
 		"release": "release-it"
 	},
 	"eslintConfig": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import ProtectedRoute from './pages/ProtectedRoute.page';
 import RoundsData from './pages/RoundsData.page';
 import SettingsPage from './pages/Settings.page';
 import SharedLayout from './pages/SharedLayout.page';
+import SimulatorPage from './pages/Simulator.page';
 import Statistics from './pages/Statistics.page';
 import ThemeSetup from './styles/ThemeSetup.styles';
 
@@ -46,6 +47,7 @@ const App: React.FC = () => {
               <Route path="/round/:roundID" element={<RoundsData />} />
               <Route path='/addNewRound' element={<AddNewRound />} />
               <Route path='/statistics' element={<Statistics />} />
+              <Route path='/simulator' element={<SimulatorPage />} />
               <Route path='/settings' element={<SettingsPage />} />
               <Route path="/admin/courses" element={<AdminRoute><AdminCoursesPage /></AdminRoute>} />
               <Route path="/admin/users" element={<AdminRoute><AdminUsersPage /></AdminRoute>} />

--- a/src/components/Admin/CoursesTable.component.tsx
+++ b/src/components/Admin/CoursesTable.component.tsx
@@ -5,17 +5,36 @@ import {
 	GridToolbar,
 	GridRenderCellParams,
 	GridRowModel,
-	GridRowId,
 } from '@mui/x-data-grid';
-import { IconButton, Button, Tooltip, Box, Typography, Alert } from '@mui/material';
+import {
+	IconButton,
+	Button,
+	Tooltip,
+	Box,
+	Typography,
+	Alert,
+	Dialog,
+	DialogTitle,
+	DialogContent,
+	DialogContentText,
+	DialogActions,
+	LinearProgress,
+	List,
+	ListItem,
+	ListItemText,
+	Chip,
+	Grid,
+} from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
+import CloudDownloadIcon from '@mui/icons-material/CloudDownload';
 import { ICourse } from '@/types/course.types';
 import {
 	getAllCourses,
 	updateCourse,
 	deleteCourse,
 } from '@/utils/firestore/course.firestore';
+import { importFromFedergolf, fetchFedergolfPreview } from '@/utils/firestore/federgolf-import.utils';
 import { useSnackbar } from './SnackbarProvider.component';
 import CourseFormDialog from './CourseFormDialog.component';
 import ConfirmDeleteDialog from './ConfirmDeleteDialog.component';
@@ -32,6 +51,17 @@ const CoursesTable: React.FC = () => {
 	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 	const [deletingCourse, setDeletingCourse] = useState<ICourse | undefined>(undefined);
 	const [isDeleting, setIsDeleting] = useState(false);
+
+	// Import state
+	const [importDialogOpen, setImportDialogOpen] = useState(false);
+	const [isImporting, setIsImporting] = useState(false);
+	const [preview, setPreview] = useState<{
+		clubCount: number;
+		courseCount: number;
+		sampleCourses: string[];
+	} | null>(null);
+	const [previewLoading, setPreviewLoading] = useState(false);
+	const [previewError, setPreviewError] = useState<string | null>(null);
 
 	const loadCourses = useCallback(async () => {
 		setIsLoading(true);
@@ -106,6 +136,46 @@ const CoursesTable: React.FC = () => {
 		} catch (err: any) {
 			showSnackbar('Failed to save. Please try again.', 'error');
 			throw err;
+		}
+	};
+
+	// Import handlers
+	const handleOpenImportDialog = async () => {
+		setImportDialogOpen(true);
+		setPreviewLoading(true);
+		setPreviewError(null);
+		try {
+			const data = await fetchFedergolfPreview();
+			setPreview(data);
+		} catch (err: any) {
+			setPreviewError(err.message || 'Failed to fetch preview.');
+		} finally {
+			setPreviewLoading(false);
+		}
+	};
+
+	const handleCloseImportDialog = () => {
+		if (isImporting) return;
+		setImportDialogOpen(false);
+		setPreview(null);
+		setPreviewError(null);
+	};
+
+	const handleConfirmImport = async () => {
+		setIsImporting(true);
+		try {
+			const result = await importFromFedergolf();
+			showSnackbar(
+				`Imported ${result.total} courses (${result.created} new, ${result.updated} updated)`,
+				'success'
+			);
+			setImportDialogOpen(false);
+			setPreview(null);
+			loadCourses();
+		} catch (err: any) {
+			showSnackbar(err.message || 'Import failed.', 'error');
+		} finally {
+			setIsImporting(false);
 		}
 	};
 
@@ -189,6 +259,18 @@ const CoursesTable: React.FC = () => {
 
 	return (
 		<Box>
+			<Box sx={{ mb: 2, display: 'flex', gap: 2 }}>
+				<Button variant="contained" onClick={handleAdd}>
+					Add Course
+				</Button>
+				<Button
+					variant="outlined"
+					startIcon={<CloudDownloadIcon />}
+					onClick={handleOpenImportDialog}
+				>
+					Import from Federgolf
+				</Button>
+			</Box>
 			<DataGrid
 				rows={courses}
 				columns={columns}
@@ -237,8 +319,128 @@ const CoursesTable: React.FC = () => {
 				}
 				isDeleting={isDeleting}
 			/>
+
+			<ImportDialog
+				open={importDialogOpen}
+				onClose={handleCloseImportDialog}
+				onImport={handleConfirmImport}
+				isImporting={isImporting}
+				preview={preview}
+				previewLoading={previewLoading}
+				previewError={previewError}
+			/>
 		</Box>
 	);
 };
+
+interface ImportDialogProps {
+	open: boolean;
+	onClose: () => void;
+	onImport: () => void;
+	isImporting: boolean;
+	preview: {
+		clubCount: number;
+		courseCount: number;
+		sampleCourses: string[];
+	} | null;
+	previewLoading: boolean;
+	previewError: string | null;
+}
+
+const ImportDialog: React.FC<ImportDialogProps> = ({
+	open,
+	onClose,
+	onImport,
+	isImporting,
+	preview,
+	previewLoading,
+	previewError,
+}) => (
+	<Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+		<DialogTitle>Import from Federgolf</DialogTitle>
+		<DialogContent>
+			{previewLoading && (
+				<Box sx={{ py: 3 }}>
+					<LinearProgress />
+					<Typography variant="body" color="text.secondary" sx={{ mt: 2, textAlign: 'center' }}>
+						Fetching course data from Federgolf...
+					</Typography>
+				</Box>
+			)}
+			{previewError && (
+				<Alert severity="error" sx={{ mt: 1 }}>
+					{previewError}
+				</Alert>
+			)}
+			{preview && !previewLoading && (
+				<>
+					<DialogContentText>
+						Found the following data from the Italian Golf Federation database:
+					</DialogContentText>
+					<Box sx={{ mt: 2, mb: 2 }}>
+						<Grid container spacing={2}>
+							<Grid size={{ xs: 6 }}>
+								<Chip
+									label={`${preview.clubCount} clubs`}
+									color="primary"
+									variant="outlined"
+								/>
+							</Grid>
+							<Grid size={{ xs: 6 }}>
+								<Chip
+									label={`${preview.courseCount} courses`}
+									color="primary"
+									variant="outlined"
+								/>
+							</Grid>
+						</Grid>
+					</Box>
+					<Typography variant="title2" sx={{ mt: 2 }}>
+						Sample courses:
+					</Typography>
+					<List dense>
+						{preview.sampleCourses.map((name, i) => (
+							<ListItem key={i} disablePadding>
+								<ListItemText primary={name} />
+							</ListItem>
+						))}
+						{preview.courseCount > 5 && (
+							<ListItem disablePadding>
+								<ListItemText
+									primary={`...and ${preview.courseCount - 5} more`}
+									primaryTypographyProps={{ color: 'text.secondary' }}
+								/>
+							</ListItem>
+						)}
+					</List>
+					{isImporting && (
+						<Box sx={{ mt: 2 }}>
+							<LinearProgress />
+							<Typography
+								variant="body"
+								color="text.secondary"
+								sx={{ mt: 1, textAlign: 'center' }}
+							>
+								Importing courses to Firestore...
+							</Typography>
+						</Box>
+					)}
+				</>
+			)}
+		</DialogContent>
+		<DialogActions>
+			<Button onClick={onClose} disabled={isImporting}>
+				Cancel
+			</Button>
+			<Button
+				variant="contained"
+				onClick={onImport}
+				disabled={!preview || previewLoading || isImporting}
+			>
+				{isImporting ? 'Importing...' : `Import ${preview?.courseCount ?? 0} Courses`}
+			</Button>
+		</DialogActions>
+	</Dialog>
+);
 
 export default CoursesTable;

--- a/src/components/Rounds/Rounds.component.tsx
+++ b/src/components/Rounds/Rounds.component.tsx
@@ -31,7 +31,9 @@ const RoundCompactRow = styled(Box)(({ theme }) => ({
   },
 }));
 
-const ScoreChip = styled(Typography)<{ $isGood: boolean }>(({ theme, $isGood }) => ({
+const ScoreChip = styled(Typography, {
+  shouldForwardProp: (prop) => prop !== '$isGood',
+})<{ $isGood: boolean }>(({ theme, $isGood }) => ({
   padding: '2px 8px',
   borderRadius: '4px',
   fontWeight: 'bold',
@@ -41,7 +43,9 @@ const ScoreChip = styled(Typography)<{ $isGood: boolean }>(({ theme, $isGood }) 
   textAlign: 'center',
 }));
 
-const PointsChip = styled(Typography)<{ $isGood: boolean }>(({ theme, $isGood }) => ({
+const PointsChip = styled(Typography, {
+  shouldForwardProp: (prop) => prop !== '$isGood',
+})<{ $isGood: boolean }>(({ theme, $isGood }) => ({
   padding: '2px 8px',
   borderRadius: '4px',
   fontWeight: 'bold',

--- a/src/components/RoundsData/components/roundData/RoundsDataHeader.component.tsx
+++ b/src/components/RoundsData/components/roundData/RoundsDataHeader.component.tsx
@@ -26,7 +26,9 @@ const StatLabel = styled(Typography)(({ theme }) => ({
   color: theme.palette.text.secondary,
 }));
 
-const ScoreChip = styled(Typography)<{ $isGood: boolean }>(({ theme, $isGood }) => ({
+const ScoreChip = styled(Typography, {
+  shouldForwardProp: (prop) => prop !== '$isGood',
+})<{ $isGood: boolean }>(({ theme, $isGood }) => ({
   padding: '4px 12px',
   borderRadius: '8px',
   fontWeight: 'bold',
@@ -37,7 +39,9 @@ const ScoreChip = styled(Typography)<{ $isGood: boolean }>(({ theme, $isGood }) 
   backgroundColor: $isGood ? theme.palette.success.main : theme.palette.error.main,
 }));
 
-const PointsChip = styled(Typography)<{ $isGood: boolean }>(({ theme, $isGood }) => ({
+const PointsChip = styled(Typography, {
+  shouldForwardProp: (prop) => prop !== '$isGood',
+})<{ $isGood: boolean }>(({ theme, $isGood }) => ({
   padding: '4px 12px',
   borderRadius: '8px',
   fontWeight: 'bold',

--- a/src/components/Simulator/Simulator.component.tsx
+++ b/src/components/Simulator/Simulator.component.tsx
@@ -1,0 +1,591 @@
+import { useState, useEffect, useMemo } from 'react';
+import {
+	Card,
+	CardContent,
+	Typography,
+	TextField,
+	Select,
+	MenuItem,
+	FormControl,
+	InputLabel,
+	Grid,
+	Box,
+	Divider,
+	Alert,
+	CircularProgress,
+	Tooltip,
+	Table,
+	TableBody,
+	TableCell,
+	TableContainer,
+	TableHead,
+	TableRow,
+} from '@mui/material';
+import AutoGraphIcon from '@mui/icons-material/AutoGraph';
+import { getAllCourses } from '@/utils/firestore/course.firestore';
+import { useAppStore } from '@/store/zustand';
+import { ICourse, ITeebox } from '@/types/course.types';
+import { calculateScoreDifferential, calculatePlayingHandicap } from '@/utils/whs/whs.utils';
+import { calculateHandicapIndex, calculateProjectedHandicapIndex } from '@/utils/whs/hi.utils';
+
+/**
+ * Get the number of lowest Score Differentials to display/average
+ * based on available rounds count (WHS Rule 5.2a scaling).
+ */
+const getScalingCount = (count: number): number => {
+	if (count < 3) return 0;
+	if (count <= 5) return 1;
+	if (count <= 8) return 2;
+	if (count <= 11) return 3;
+	if (count <= 14) return 4;
+	if (count <= 16) return 5;
+	if (count <= 18) return 6;
+	if (count === 19) return 7;
+	return 8;
+};
+
+const Simulator = () => {
+	// --- Transient state (per D-08: no Zustand persist) ---
+	const [courses, setCourses] = useState<ICourse[]>([]);
+	const [selectedCourse, setSelectedCourse] = useState<ICourse | null>(null);
+	const [selectedTeebox, setSelectedTeebox] = useState<ITeebox | null>(null);
+	const [stablefordPoints, setStablefordPoints] = useState<number>(36);
+	const [manualPlayingHCP, setManualPlayingHCP] = useState<string>('');
+	const [loading, setLoading] = useState(true);
+	const [courseError, setCourseError] = useState<string | null>(null);
+	const [stablefordError, setStablefordError] = useState<string | null>(null);
+
+	// --- Computed values from Zustand store ---
+	const roundsList = useAppStore((state) => state.roundsList);
+	const isLoadingRounds = useAppStore((state) => state.isLoadingRounds);
+
+	// Load courses on mount
+	useEffect(() => {
+		getAllCourses()
+			.then((all) => {
+				setCourses(all.filter((c) => c.status === 'Active'));
+				setLoading(false);
+			})
+			.catch((err) => {
+				console.error('Simulator: Failed to load courses:', err);
+				setCourseError('Unable to load courses. Please try again later.');
+				setLoading(false);
+			});
+	}, []);
+
+	// --- Derived values ---
+
+	// Current Handicap Index from existing rounds (D-04)
+	const currentHI = useMemo(() => {
+		if (isLoadingRounds) return null;
+		const sds = roundsList
+			.filter((r) => r.scoreDifferential != null)
+			.map((r) => r.scoreDifferential as number);
+		return calculateHandicapIndex(sds);
+	}, [roundsList, isLoadingRounds]);
+
+	// Auto-calculated Playing Handicap (D-09)
+	const autoPlayingHCP = useMemo(() => {
+		if (!selectedTeebox || currentHI == null) return null;
+		return calculatePlayingHandicap(
+			currentHI,
+			selectedTeebox.courseRating,
+			selectedTeebox.slopeRating,
+			selectedTeebox.par
+		);
+	}, [selectedTeebox, currentHI]);
+
+	// Effective Playing Handicap — auto-calc with manual override (D-10)
+	const effectivePlayingHCP = useMemo(() => {
+		const manual = manualPlayingHCP.trim();
+		if (manual !== '') {
+			const parsed = Number(manual);
+			if (!isNaN(parsed) && parsed >= 0) {
+				return parsed;
+			}
+		}
+		return autoPlayingHCP;
+	}, [autoPlayingHCP, manualPlayingHCP]);
+
+	// Validate Stableford input
+	const isStablefordValid = useMemo(() => {
+		if (stablefordPoints < 0 || stablefordPoints > 36) {
+			if (!stablefordError) setStablefordError('Stableford points must be between 0 and 36');
+			return false;
+		}
+		if (stablefordError) setStablefordError(null);
+		return true;
+	}, [stablefordPoints, stablefordError]);
+
+	// Validate selectedTeebox exists in selectedCourse.teeboxes (T-02-05)
+	const isTeeboxValid = useMemo(() => {
+		if (!selectedCourse || !selectedTeebox) return false;
+		return selectedCourse.teeboxes.some(
+			(t) => t.name === selectedTeebox.name
+		);
+	}, [selectedCourse, selectedTeebox]);
+
+	// Simulated Score Differential
+	const simulatedResult = useMemo(() => {
+		if (
+			!selectedTeebox ||
+			effectivePlayingHCP == null ||
+			!isStablefordValid ||
+			!isTeeboxValid
+		) {
+			return null;
+		}
+		return calculateScoreDifferential({
+			par: selectedTeebox.par,
+			courseRating: selectedTeebox.courseRating,
+			slopeRating: selectedTeebox.slopeRating,
+			stablefordPoints,
+			playingHCP: effectivePlayingHCP,
+		});
+	}, [
+		selectedTeebox,
+		effectivePlayingHCP,
+		stablefordPoints,
+		isStablefordValid,
+		isTeeboxValid,
+	]);
+
+	// Projected Handicap Index (SIM-03: virtual array, no DB writes)
+	const projectedHI = useMemo(() => {
+		if (!simulatedResult) return null;
+		const sds = roundsList
+			.filter((r) => r.scoreDifferential != null)
+			.map((r) => r.scoreDifferential as number);
+		// Virtual array: simulated SD + last 19 real SDs
+		return calculateProjectedHandicapIndex(sds, simulatedResult.scoreDifferential);
+	}, [simulatedResult, roundsList]);
+
+	// Delta: projected - current
+	const delta = useMemo(() => {
+		if (projectedHI == null || currentHI == null) return null;
+		return projectedHI - currentHI;
+	}, [projectedHI, currentHI]);
+
+	// Best score differentials — current (lowest N)
+	const best8CurrentSDs = useMemo(() => {
+		const sds = roundsList
+			.filter((r) => r.scoreDifferential != null)
+			.map((r) => r.scoreDifferential as number);
+		if (sds.length < 3) return [];
+		const count = Math.min(sds.length, 20);
+		const toUse = getScalingCount(count);
+		const sorted = [...sds.slice(0, count)].sort((a, b) => a - b);
+		return sorted.slice(0, toUse);
+	}, [roundsList]);
+
+	// Best score differentials — projected (lowest N including simulated)
+	const best8ProjectedSDs = useMemo(() => {
+		if (!simulatedResult) return [];
+		const sds = roundsList
+			.filter((r) => r.scoreDifferential != null)
+			.map((r) => r.scoreDifferential as number);
+		const virtual = [simulatedResult.scoreDifferential, ...sds.slice(0, 19)];
+		const count = Math.min(virtual.length, 20);
+		if (count < 3) return [];
+		const toUse = getScalingCount(count);
+		const sorted = [...virtual.slice(0, count)].sort((a, b) => a - b);
+		return sorted.slice(0, toUse);
+	}, [simulatedResult, roundsList]);
+
+	// --- Handlers ---
+
+	const handleCourseChange = (courseId: string) => {
+		const course = courses.find((c) => c.id === courseId) || null;
+		setSelectedCourse(course);
+		setSelectedTeebox(null);
+	};
+
+	const handleTeeboxChange = (teeboxName: string) => {
+		if (!selectedCourse) return;
+		const teebox =
+			selectedCourse.teeboxes.find((t) => t.name === teeboxName) || null;
+		setSelectedTeebox(teebox);
+	};
+
+	const handleStablefordChange = (value: string) => {
+		const num = value === '' ? 0 : Number(value);
+		if (isNaN(num)) return;
+		setStablefordPoints(num);
+	};
+
+	const handlePlayingHCPChange = (value: string) => {
+		// Allow empty string for auto-calc (D-10)
+		if (value === '') {
+			setManualPlayingHCP('');
+			return;
+		}
+		const num = Number(value);
+		if (isNaN(num)) return;
+		if (num < 0) return;
+		setManualPlayingHCP(value);
+	};
+
+	// --- Edge case checks ---
+
+	const hasNoRounds = !isLoadingRounds && roundsList.length === 0;
+	const hasFewRounds = !isLoadingRounds && roundsList.length > 0 && roundsList.length < 3;
+	const hasNoCourses = !loading && courses.length === 0 && !courseError;
+
+	// --- Rendering ---
+
+	if (loading) {
+		return (
+			<Box sx={{ display: 'flex', justifyContent: 'center', mt: 4 }}>
+				<CircularProgress />
+			</Box>
+		);
+	}
+
+	if (courseError) {
+		return (
+			<Box sx={{ p: 2 }}>
+				<Alert severity="error">{courseError}</Alert>
+			</Box>
+		);
+	}
+
+	if (hasNoCourses) {
+		return (
+			<Box sx={{ p: 2 }}>
+				<Alert severity="warning">
+					No courses available. Contact an administrator.
+				</Alert>
+			</Box>
+		);
+	}
+
+	return (
+		<Box sx={{ p: 2 }}>
+			{/* Header */}
+			<Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 3 }}>
+				<AutoGraphIcon sx={{ fontSize: 32 }} />
+				<Typography variant="headline2">Handicap Simulator</Typography>
+			</Box>
+
+			{/* No rounds state */}
+			{hasNoRounds && (
+				<Alert severity="info" sx={{ mb: 2 }}>
+					No rounds recorded yet. Play some rounds first!
+				</Alert>
+			)}
+
+			{hasFewRounds && (
+				<Alert severity="info" sx={{ mb: 2 }}>
+					Need at least 3 rounds to calculate a Handicap Index. You currently have{' '}
+					{roundsList.length} round{roundsList.length !== 1 ? 's' : ''}.
+				</Alert>
+			)}
+
+			<Grid container spacing={3}>
+				{/* Left column: Course Selection + Score Input */}
+				<Grid size={{ xs: 12, md: 7 }}>
+					{/* Course Selection Card */}
+					<Card sx={{ mb: 3 }}>
+						<CardContent>
+							<Typography variant="title6" gutterBottom>
+								Course Selection
+							</Typography>
+
+							{/* Course dropdown */}
+							<FormControl fullWidth sx={{ mb: 2 }}>
+								<InputLabel id="course-label">Course</InputLabel>
+								<Select
+									labelId="course-label"
+									value={selectedCourse?.id ?? ''}
+									label="Course"
+									onChange={(e) => handleCourseChange(e.target.value)}
+								>
+									{courses.map((course) => (
+										<MenuItem key={course.id} value={course.id}>
+											{course.name}
+											{course.city ? ` (${course.city})` : ''}
+										</MenuItem>
+									))}
+								</Select>
+							</FormControl>
+
+							{/* Teebox dropdown */}
+							{selectedCourse && selectedCourse.teeboxes.length === 0 && (
+								<Alert severity="warning" sx={{ mb: 2 }}>
+									No teeboxes defined for this course.
+								</Alert>
+							)}
+
+							<FormControl
+								fullWidth
+								disabled={!selectedCourse || selectedCourse.teeboxes.length === 0}
+							>
+								<InputLabel id="teebox-label">Teebox</InputLabel>
+								<Select
+									labelId="teebox-label"
+									value={selectedTeebox?.name ?? ''}
+									label="Teebox"
+									onChange={(e) => handleTeeboxChange(e.target.value)}
+								>
+									{selectedCourse?.teeboxes.map((teebox) => (
+										<MenuItem key={teebox.name} value={teebox.name}>
+											{teebox.name} — Par {teebox.par}, CR{' '}
+											{teebox.courseRating}, SR {teebox.slopeRating}
+										</MenuItem>
+									))}
+								</Select>
+							</FormControl>
+						</CardContent>
+					</Card>
+
+					{/* Score Input Card */}
+					<Card>
+						<CardContent>
+							<Typography variant="title6" gutterBottom>
+								Score Input
+							</Typography>
+
+							{/* Stableford points */}
+							<TextField
+								fullWidth
+								type="number"
+								label="Total Stableford Points"
+								value={stablefordPoints}
+								onChange={(e) => handleStablefordChange(e.target.value)}
+								error={!!stablefordError}
+								helperText={
+									stablefordError || 'Enter total Stableford points (0-36)'
+								}
+								inputProps={{
+									min: 0,
+									max: 36,
+									step: 1,
+								}}
+								sx={{ mb: 2 }}
+							/>
+
+							{/* Playing Handicap */}
+							<TextField
+								fullWidth
+								type="number"
+								label="Playing Handicap"
+								value={manualPlayingHCP}
+								onChange={(e) => handlePlayingHCPChange(e.target.value)}
+								helperText={
+									autoPlayingHCP != null
+										? `Auto-calculated from HI: ${autoPlayingHCP}`
+										: 'Select a teebox with a valid Handicap Index for auto-calculation'
+								}
+								inputProps={{
+									min: 0,
+								}}
+								sx={{ mb: 1 }}
+							/>
+
+							<Typography variant="caption" color="text.secondary">
+								Playing Handicap formula:{' '}
+								<code>HI × (SR / 113) + (CR - PAR)</code>. Leave empty to
+								auto-calculate.
+							</Typography>
+						</CardContent>
+					</Card>
+				</Grid>
+
+				{/* Right column: Results */}
+				<Grid size={{ xs: 12, md: 5 }}>
+					{/* Results Card — only visible when simulatedResult is computed */}
+					{simulatedResult && (
+						<Card>
+							<CardContent>
+								<Typography variant="title6" gutterBottom>
+									Simulation Results
+								</Typography>
+
+								{/* Current Handicap Index */}
+								<Box sx={{ mb: 1.5 }}>
+									<Typography variant="body" color="text.secondary">
+										Current Handicap Index
+									</Typography>
+									<Typography variant="title4">
+										{currentHI != null
+											? currentHI.toFixed(1)
+											: '\u2014 (need at least 3 rounds)'}
+									</Typography>
+								</Box>
+
+								<Divider sx={{ my: 1.5 }} />
+
+								{/* Simulated Score Differential */}
+								<Box sx={{ mb: 1.5 }}>
+									<Typography variant="body" color="text.secondary">
+										Simulated Score Differential
+									</Typography>
+									<Tooltip
+										title={`AGS: ${simulatedResult.adjustedGrossScore}`}
+									>
+										<Typography variant="title4">
+											{simulatedResult.scoreDifferential.toFixed(1)}
+										</Typography>
+									</Tooltip>
+									<Typography variant="caption" color="text.secondary">
+										AGS: {simulatedResult.adjustedGrossScore}
+									</Typography>
+								</Box>
+
+								<Divider sx={{ my: 1.5 }} />
+
+								{/* Projected Handicap Index */}
+								<Box sx={{ mb: 1.5 }}>
+									<Typography variant="body" color="text.secondary">
+										Projected Handicap Index
+									</Typography>
+									<Typography variant="title4">
+										{projectedHI != null
+											? projectedHI.toFixed(1)
+											: '\u2014'}
+									</Typography>
+								</Box>
+
+								<Divider sx={{ my: 1.5 }} />
+
+								{/* Delta */}
+								<Box sx={{ mb: 1.5 }}>
+									<Typography variant="body" color="text.secondary">
+										Delta
+									</Typography>
+									<Typography
+										variant="title4"
+										sx={{
+											color:
+												delta == null
+													? 'text.primary'
+													: delta <= 0
+														? 'success.main'
+														: 'error.main',
+										}}
+									>
+										{delta != null
+											? `${delta > 0 ? '+' : ''}${delta.toFixed(1)}`
+											: '\u2014'}
+									</Typography>
+									{delta != null && (
+										<Typography variant="caption" color="text.secondary">
+											{delta <= 0
+												? 'Improvement (HI decreases)'
+												: 'Worsening (HI increases)'}
+										</Typography>
+									)}
+								</Box>
+
+								{/* Best score differentials breakdown */}
+								{best8CurrentSDs.length > 0 && (
+									<>
+										<Divider sx={{ my: 1.5 }} />
+										<Box sx={{ mt: 2 }}>
+											<Typography variant="title6" gutterBottom>
+												Best Score Differentials
+											</Typography>
+											<TableContainer>
+												<Table size="small">
+													<TableHead>
+														<TableRow>
+															<TableCell>#</TableCell>
+															<TableCell align="right">
+																Current SDs
+															</TableCell>
+															<TableCell align="right">
+																Projected SDs
+															</TableCell>
+														</TableRow>
+													</TableHead>
+													<TableBody>
+														{Array.from({
+															length: Math.max(
+																best8CurrentSDs.length,
+																best8ProjectedSDs.length
+															),
+														}).map((_, index) => {
+															const currentVal =
+																best8CurrentSDs[index];
+															const projectedVal =
+																best8ProjectedSDs[index];
+															const isSimulated =
+																projectedVal != null &&
+																projectedVal ===
+																	simulatedResult
+																		.scoreDifferential;
+
+															return (
+																<TableRow
+																	key={index}
+																	sx={{
+																		...(isSimulated && {
+																			backgroundColor:
+																				'action.selected',
+																		}),
+																	}}
+																>
+																	<TableCell>
+																		{index + 1}
+																	</TableCell>
+																	<TableCell align="right">
+																		{currentVal != null
+																			? currentVal.toFixed(1)
+																			: '\u2014'}
+																	</TableCell>
+																	<TableCell
+																		align="right"
+																		sx={{
+																			...(isSimulated && {
+																				fontWeight:
+																					'bold',
+																			}),
+																		}}
+																	>
+																		{projectedVal != null
+																			? `${projectedVal.toFixed(1)}${isSimulated ? ' *' : ''}`
+																			: '\u2014'}
+																	</TableCell>
+																</TableRow>
+															);
+														})}
+													</TableBody>
+												</Table>
+											</TableContainer>
+											<Typography
+												variant="caption"
+												color="text.secondary"
+												sx={{ mt: 1, display: 'block' }}
+											>
+												* Simulated round included in projected
+												SDs
+											</Typography>
+										</Box>
+									</>
+								)}
+							</CardContent>
+						</Card>
+					)}
+
+					{/* Placeholder when no results yet */}
+					{!simulatedResult && !hasNoRounds && (
+						<Card>
+							<CardContent>
+								<Typography
+									variant="body"
+									color="text.secondary"
+									sx={{ textAlign: 'center', py: 4 }}
+								>
+									Select a course, teebox, and enter Stableford points to see
+									simulation results.
+								</Typography>
+							</CardContent>
+						</Card>
+					)}
+				</Grid>
+			</Grid>
+		</Box>
+	);
+};
+
+export default Simulator;

--- a/src/components/layout/MainLayout2.component.tsx
+++ b/src/components/layout/MainLayout2.component.tsx
@@ -1,19 +1,17 @@
 import { TLinkSidebar } from '@/types/general.types';
-import { IBoxProps, IMainLayoutProps } from '@/types/props.types';
+import { IMainLayoutProps } from '@/types/props.types';
 import links from '@/utils/links/links.utils';
 import { deleteUserLocalStorage, readUserLocalStorage } from '@/utils/storage/localStorage.utils';
 import GolfCourseIcon from '@mui/icons-material/GolfCourse';
 import Logout from '@mui/icons-material/Logout';
 import PeopleIcon from '@mui/icons-material/People';
 import Settings from '@mui/icons-material/Settings';
-import SvgIcon, { default as MenuIcon } from '@mui/icons-material/Menu';
+import SvgIcon from '@mui/material/SvgIcon';
+import MenuIcon from '@mui/icons-material/Menu';
 import HomeIcon from '@mui/icons-material/Home';
 import NavigateNextIcon from '@mui/icons-material/NavigateNext';
-import { ListItemIcon, ListItemText, styled, Typography, Breadcrumbs, Link } from '@mui/material';
-import useMediaQuery from '@mui/material/useMediaQuery';
+import { ListItemIcon, ListItemText, Typography, Breadcrumbs, Link, Avatar } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import AppBar from '@mui/material/AppBar';
-import { SidebarHCP } from '@/styles/stack/StackPlayerMenu.styles';
 import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
 import Drawer from '@mui/material/Drawer';
@@ -21,22 +19,21 @@ import IconButton from '@mui/material/IconButton';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemButton from '@mui/material/ListItemButton';
-import Toolbar from '@mui/material/Toolbar';
 import { getAuth, signOut } from 'firebase/auth';
 import _ from 'lodash';
 import * as React from 'react';
 import { Outlet, useNavigate, useLocation, Link as RouterLink } from 'react-router-dom';
 import ThemeSwitcher from '../common/ThemeSwitcher.component';
 import Footer from './Footer.component';
-import User from './User.component';
 import { useAppStore } from '@/store/zustand';
 import { SnackbarProvider } from '@/components/Admin/SnackbarProvider.component';
 
-export default function DrawerAppBar(props: IMainLayoutProps) {
-  const { window } = props;
+const collapsedWidth = 57;
+const drawerWidth = 240;
+
+export default function DrawerAppBar(_props: IMainLayoutProps) {
   const [drawerOpen, setDrawerOpen] = React.useState(false);
   const theme = useTheme();
-  const isDesktop = useMediaQuery(theme.breakpoints.up('md'));
   const uid = readUserLocalStorage();
   const auth = getAuth();
   const player = useAppStore((state) => state.player);
@@ -67,13 +64,13 @@ export default function DrawerAppBar(props: IMainLayoutProps) {
       resetUser();
       navigate('/login');
     }).catch((error) => {
-      console.error("Logout error:", error);
+      console.error('Logout error:', error);
     });
   };
 
   const getBreadcrumbs = () => {
     const path = location.pathname;
-    
+
     interface BreadcrumbItem {
       label: string;
       path: string;
@@ -81,7 +78,7 @@ export default function DrawerAppBar(props: IMainLayoutProps) {
     }
 
     const breadcrumbs: BreadcrumbItem[] = [
-      { label: 'Home', path: '/dashboard', icon: <HomeIcon fontSize="small" /> }
+      { label: 'Home', path: '/dashboard', icon: <HomeIcon fontSize="small" /> },
     ];
 
     if (path === '/dashboard' || path === '/') {
@@ -99,63 +96,14 @@ export default function DrawerAppBar(props: IMainLayoutProps) {
     } else if (path === '/settings') {
       breadcrumbs.push({ label: 'Settings', path: '/settings' });
     } else if (path === '/simulator') {
-      breadcrumbs.push({ label: 'Simulator', path: '/simulator' });
-    } else if (path.startsWith('/round/')) {
-      // Check if roundDetailsData is already loaded
-      if (roundDetailsData?.roundCourse) {
-        breadcrumbs.push({ label: 'All Rounds', path: '/all-rounds' });
-        breadcrumbs.push({ label: roundDetailsData.roundCourse, path: path });
-      } else {
-        // If not loaded yet, show "All Rounds" and "Loading..."
-        breadcrumbs.push({ label: 'All Rounds', path: '/all-rounds' });
-        breadcrumbs.push({ label: 'Loading...', path: path });
-      }
-    } else if (path === '/admin/courses') {
-      breadcrumbs.push({ label: 'Admin', path: '/admin/courses' });
-    } else if (path === '/admin/users') {
-      breadcrumbs.push({ label: 'Admin', path: '/admin/users' });
-    }
-
-    return breadcrumbs;
-  };
-
-  const getMobileBreadcrumbs = () => {
-    const path = location.pathname;
-    
-    interface BreadcrumbItem {
-      label: string;
-      path: string;
-      icon?: React.ReactNode;
-    }
-
-    const breadcrumbs: BreadcrumbItem[] = [];
-
-    if (path === '/dashboard' || path === '/') {
-      return [];
-    }
-
-    // Always show Home icon first on mobile
-    breadcrumbs.push({ label: 'Home', path: '/dashboard', icon: <HomeIcon fontSize="small" /> });
-
-    if (path === '/clubs') {
-      breadcrumbs.push({ label: 'Clubs', path: '/clubs' });
-    } else if (path === '/all-rounds') {
-      breadcrumbs.push({ label: 'All Rounds', path: '/all-rounds' });
-    } else if (path === '/addNewRound') {
-      breadcrumbs.push({ label: 'Add Round', path: '/addNewRound' });
-    } else if (path === '/statistics') {
-      breadcrumbs.push({ label: 'Statistics', path: '/statistics' });
-    } else if (path === '/settings') {
-      breadcrumbs.push({ label: 'Settings', path: '/settings' });
-    } else if (path === '/simulator') {
-      breadcrumbs.push({ label: 'Simulator', path: '/simulator' });
+      breadcrumbs.push({ label: 'HCP Simulator', path: '/simulator' });
     } else if (path.startsWith('/round/')) {
       if (roundDetailsData?.roundCourse) {
         breadcrumbs.push({ label: 'All Rounds', path: '/all-rounds' });
-        breadcrumbs.push({ label: roundDetailsData.roundCourse, path: path });
+        breadcrumbs.push({ label: roundDetailsData.roundCourse, path });
       } else {
         breadcrumbs.push({ label: 'All Rounds', path: '/all-rounds' });
-        breadcrumbs.push({ label: 'Loading...', path: path });
+        breadcrumbs.push({ label: 'Loading...', path });
       }
     } else if (path === '/admin/courses') {
       breadcrumbs.push({ label: 'Admin', path: '/admin/courses' });
@@ -167,232 +115,224 @@ export default function DrawerAppBar(props: IMainLayoutProps) {
   };
 
   const breadcrumbs = getBreadcrumbs();
-  const mobileBreadcrumbs = getMobileBreadcrumbs();
 
   const drawer = (
-    <Box onClick={!isDesktop ? handleDrawerToggle : undefined} sx={{ textAlign: 'center' }}>
-      <Typography variant="headline6" sx={{ my: 2, color: 'text.primary' }}>
-        {player?.displayName ? player.displayName.split(' ')[0] : 'Menu'}
-      </Typography>
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0, overflow: 'hidden' }}>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: drawerOpen ? 'flex-start' : 'center',
+          px: drawerOpen ? 1.5 : 1,
+          minHeight: 64,
+        }}
+      >
+        <IconButton onClick={handleDrawerToggle}>
+          <MenuIcon />
+        </IconButton>
+      </Box>
       <Divider />
-      <List>
-        {links.filter(l => l.show === true).map((link: TLinkSidebar, index: number) => {
-          return (
-            <ListItem key={index} disablePadding sx={{ display: 'flex' }}>
+      <Box sx={{ flexGrow: 1, overflow: 'hidden', minHeight: 0 }}>
+        <List sx={{ overflowY: 'auto', height: '100%' }}>
+          {links.filter((l) => l.show === true).map((link: TLinkSidebar, index: number) => (
+            <ListItem key={index} disablePadding sx={{ display: 'block' }}>
               <ListItemButton
-                sx={{
-                  minHeight: 48,
-                  px: 2.5,
-                }}
                 component={RouterLink}
                 to={link.link}
+                onClick={drawerOpen ? handleDrawerToggle : undefined}
+                sx={{
+                  minHeight: 48,
+                  justifyContent: drawerOpen ? 'initial' : 'center',
+                  px: 2.5,
+                }}
               >
                 <ListItemIcon
                   sx={{
                     minWidth: 0,
                     justifyContent: 'center',
-                    marginRight: '10px',
-                    color: 'text.primary'
+                    mr: drawerOpen ? 1.5 : 'auto',
                   }}
                 >
                   <SvgIcon component={link.icon} inheritViewBox />
                 </ListItemIcon>
-                <ListItemText primary={link.name} sx={{ color: 'text.primary' }} />
+                <ListItemText
+                  primary={link.name}
+                  sx={{ opacity: drawerOpen ? 1 : 0 }}
+                />
               </ListItemButton>
             </ListItem>
-          );
-        })}
-        <Divider sx={{ my: 1 }} />
-        <ListItem sx={{ display: 'flex', justifyContent: 'center', py: 0.5 }}>
-          <SidebarHCP value={player?.HCP ?? 0} name={player?.displayName ?? ''} />
-        </ListItem>
-        <ListItem disablePadding>
-          <ListItemButton component={RouterLink} to="/settings" sx={{ minHeight: 48, px: 2.5 }}>
-            <ListItemIcon sx={{ minWidth: 0, justifyContent: 'center', marginRight: '10px', color: 'text.primary' }}>
-              <Settings fontSize="small" />
-            </ListItemIcon>
-            <ListItemText primary="Settings" sx={{ color: 'text.primary' }} />
-          </ListItemButton>
-        </ListItem>
-        <Divider sx={{ my: 1 }} />
-        {player?.isAdmin && (
+          ))}
+          {player?.isAdmin && (
+            <>
+              <Divider sx={{ my: 1 }} />
+              {drawerOpen && (
+                <ListItem disablePadding sx={{ px: 2.5, py: 0.5 }}>
+                  <Typography variant="caption" sx={{ color: 'text.secondary', fontWeight: 600 }}>
+                    Admin
+                  </Typography>
+                </ListItem>
+              )}
+              <ListItem disablePadding sx={{ display: 'block' }}>
+                <ListItemButton
+                  component={RouterLink}
+                  to="/admin/courses"
+                  onClick={drawerOpen ? handleDrawerToggle : undefined}
+                  sx={{
+                    minHeight: 48,
+                    justifyContent: drawerOpen ? 'initial' : 'center',
+                    px: 2.5,
+                  }}
+                >
+                  <ListItemIcon
+                    sx={{
+                      minWidth: 0,
+                      justifyContent: 'center',
+                      mr: drawerOpen ? 1.5 : 'auto',
+                    }}
+                  >
+                    <SvgIcon component={GolfCourseIcon} inheritViewBox />
+                  </ListItemIcon>
+                  <ListItemText primary="Courses" sx={{ opacity: drawerOpen ? 1 : 0 }} />
+                </ListItemButton>
+              </ListItem>
+              <ListItem disablePadding sx={{ display: 'block' }}>
+                <ListItemButton
+                  component={RouterLink}
+                  to="/admin/users"
+                  onClick={drawerOpen ? handleDrawerToggle : undefined}
+                  sx={{
+                    minHeight: 48,
+                    justifyContent: drawerOpen ? 'initial' : 'center',
+                    px: 2.5,
+                  }}
+                >
+                  <ListItemIcon
+                    sx={{
+                      minWidth: 0,
+                      justifyContent: 'center',
+                      mr: drawerOpen ? 1.5 : 'auto',
+                    }}
+                  >
+                    <SvgIcon component={PeopleIcon} inheritViewBox />
+                  </ListItemIcon>
+                  <ListItemText primary="Users" sx={{ opacity: drawerOpen ? 1 : 0 }} />
+                </ListItemButton>
+              </ListItem>
+            </>
+          )}
+        </List>
+      </Box>
+      <Divider />
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: drawerOpen ? 'space-between' : 'center',
+          px: drawerOpen ? 1.5 : 0.5,
+          py: drawerOpen ? 1.5 : 1,
+        }}
+      >
+        {drawerOpen ? (
           <>
-            <ListItem disablePadding sx={{ px: 2.5, py: 0.5 }}>
-              <Typography variant="caption" sx={{ color: 'text.secondary', fontWeight: 600 }}>
-                Admin
-              </Typography>
-            </ListItem>
-            <ListItem disablePadding>
-              <ListItemButton component={RouterLink} to="/admin/courses" sx={{ minHeight: 48, px: 2.5 }}>
-                <ListItemIcon sx={{ minWidth: 0, justifyContent: 'center', marginRight: '10px', color: 'text.primary' }}>
-                  <SvgIcon component={GolfCourseIcon} inheritViewBox />
-                </ListItemIcon>
-                <ListItemText primary="Courses" sx={{ color: 'text.primary' }} />
-              </ListItemButton>
-            </ListItem>
-            <ListItem disablePadding>
-              <ListItemButton component={RouterLink} to="/admin/users" sx={{ minHeight: 48, px: 2.5 }}>
-                <ListItemIcon sx={{ minWidth: 0, justifyContent: 'center', marginRight: '10px', color: 'text.primary' }}>
-                  <SvgIcon component={PeopleIcon} inheritViewBox />
-                </ListItemIcon>
-                <ListItemText primary="Users" sx={{ color: 'text.primary' }} />
-              </ListItemButton>
-            </ListItem>
-          </>
-        )}
-        <Divider sx={{ my: 1 }} />
-        <ListItem sx={{ justifyContent: 'center', display: 'flex', py: 1 }}>
-          <ThemeSwitcher />
-        </ListItem>
-        <Divider sx={{ my: 1 }} />
-        <ListItem disablePadding>
-          <ListItemButton onClick={handleLogout} sx={{ minHeight: 48, px: 2.5 }}>
-            <ListItemIcon sx={{ minWidth: 0, justifyContent: 'center', marginRight: '10px', color: 'text.primary' }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, minWidth: 0 }}>
+              <Avatar
+                sx={{ bgcolor: 'primary.main', width: 36, height: 36, fontSize: '0.875rem' }}
+                alt={player?.displayName ?? ''}
+                src={player?.photoURL || undefined}
+              >
+                {player?.displayName ? `${player.displayName[0]}${player.displayName.split(' ')[1]?.[0] ?? ''}`.toUpperCase() : '?'}
+              </Avatar>
+              <Box>
+                <Typography noWrap sx={{ fontSize: '0.875rem' }}>
+                  {player?.displayName ?? ''}
+                </Typography>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.5 }}>
+                  <IconButton size="small" component={RouterLink} to="/settings">
+                    <Settings fontSize="small" />
+                  </IconButton>
+                  <ThemeSwitcher />
+                </Box>
+              </Box>
+            </Box>
+            <IconButton size="small" onClick={handleLogout}>
               <Logout fontSize="small" />
-            </ListItemIcon>
-            <ListItemText primary="Logout" sx={{ color: 'text.primary' }} />
-          </ListItemButton>
-        </ListItem>
-      </List>
+            </IconButton>
+          </>
+        ) : (
+          <Avatar
+            sx={{ bgcolor: 'primary.main', width: 32, height: 32, fontSize: '0.75rem' }}
+            alt={player?.displayName ?? ''}
+            src={player?.photoURL || undefined}
+          >
+            {player?.displayName ? `${player.displayName[0]}${player.displayName.split(' ')[1]?.[0] ?? ''}`.toUpperCase() : '?'}
+          </Avatar>
+        )}
+      </Box>
     </Box>
   );
 
-  const container = window !== undefined ? () => window().document.body : undefined;
-
-  const renderBreadcrumbs = (isMobile: boolean) => {
-    const crumbs = isMobile ? mobileBreadcrumbs : breadcrumbs;
-    
-    if (crumbs.length === 0) {
-      return null;
-    }
-
-    return (
-      <Breadcrumbs
-        separator={<NavigateNextIcon fontSize="small" />}
-        sx={{ 
-          display: 'flex', 
-          alignItems: 'center',
-          '& .MuiBreadcrumbs-separator': { mx: 0.5 }
-        }}
-      >
-        {crumbs.map((crumb, index) => {
-          const isLast = index === crumbs.length - 1;
-          return isLast ? (
-            <Typography 
-              key={crumb.path} 
-              color="inherit" 
-              fontWeight="bold"
-              sx={{ 
-                fontSize: isMobile ? '0.875rem' : '0.875rem',
-                maxWidth: isMobile ? '120px' : 'none',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap'
-              }}
-            >
-              {crumb.label}
-            </Typography>
-          ) : (
-            <Link
-              key={crumb.path}
-              component={RouterLink}
-              to={crumb.path}
-              color="inherit"
-              underline="hover"
-              sx={{ 
-                display: 'flex', 
-                alignItems: 'center', 
-                cursor: 'pointer',
-                fontSize: '0.875rem'
-              }}
-            >
-              {crumb.icon}
-            </Link>
-          );
-        })}
-      </Breadcrumbs>
-    );
-  };
-
   return (
     <SnackbarProvider>
-    <BoxFooter>
-      <Box>
-        <AppBar component="nav">
-          <Toolbar sx={{ display: 'flex', flexWrap: 'nowrap' }}>
-            <IconButton
-              color="inherit"
-              aria-label="open drawer"
-              edge="start"
-              onClick={handleDrawerToggle}
-              sx={{ mr: 1 }}
-            >
-              <MenuIcon />
-            </IconButton>
-            <Typography
-              component="div"
-              variant="mainAppTitle"
-              sx={{ flexGrow: 0, whiteSpace: 'nowrap' }}
-              color="inherit"
-            >
+      <Box sx={{ display: 'flex', height: '100vh', overflow: 'hidden' }}>
+        <Drawer
+          variant="permanent"
+          open={drawerOpen}
+          sx={{
+            width: drawerOpen ? drawerWidth : collapsedWidth,
+            transition: theme.transitions.create('width', {
+              easing: theme.transitions.easing.sharp,
+              duration: drawerOpen
+                ? theme.transitions.duration.enteringScreen
+                : theme.transitions.duration.leavingScreen,
+            }),
+            '& .MuiDrawer-paper': {
+              width: drawerOpen ? drawerWidth : collapsedWidth,
+              transition: theme.transitions.create('width', {
+                easing: theme.transitions.easing.sharp,
+                duration: drawerOpen
+                  ? theme.transitions.duration.enteringScreen
+                  : theme.transitions.duration.leavingScreen,
+              }),
+              overflowX: 'hidden',
+              overflowY: 'hidden',
+            },
+          }}
+        >
+          {drawer}
+        </Drawer>
+        <Box sx={{ display: 'flex', flexDirection: 'column', flexGrow: 1, minWidth: 0, height: '100vh' }}>
+          <Box component="main" sx={{ flexGrow: 1, overflowY: 'auto', p: 2 }}>
+            <Typography sx={{ fontSize: '1.25rem', fontWeight: 500, mb: 0.5 }}>
               PGS
             </Typography>
-            
-            <Box sx={{ flexGrow: 1, display: 'flex', justifyContent: 'flex-start', mx: 1, minWidth: 0 }}>
-              {renderBreadcrumbs(false)}
-            </Box>
-            
-            <Box sx={{ flexGrow: 0 }}>
-              <User />
-            </Box>
-          </Toolbar>
-        </AppBar>
-        <nav>
-          <Drawer
-            container={container}
-            variant={isDesktop ? 'persistent' : 'temporary'}
-            open={drawerOpen}
-            onClose={handleDrawerToggle}
-            ModalProps={{
-              keepMounted: true,
-            }}
-            sx={{
-              '& .MuiDrawer-paper': { boxSizing: 'border-box', width: 240 },
-            }}
-          >
-            {drawer}
-          </Drawer>
-        </nav>
-        <Box component="main" sx={{
-          p: 1,
-          width: '100%',
-          transition: theme.transitions.create('margin', {
-            easing: theme.transitions.easing.sharp,
-            duration: theme.transitions.duration.leavingScreen,
-          }),
-          ml: isDesktop && drawerOpen ? '240px' : 0,
-        }}>
-          <Toolbar />
-          <Box sx={{ display: { xs: 'block', sm: 'none' }, mb: 1 }}>
-            {renderBreadcrumbs(true)}
+            {breadcrumbs.length > 0 && (
+              <Breadcrumbs separator={<NavigateNextIcon fontSize="small" />} sx={{ mb: 2 }}>
+                {breadcrumbs.map((crumb, index) => {
+                  const isLast = index === breadcrumbs.length - 1;
+                  return isLast ? (
+                    <Typography key={crumb.path} color="text.primary" fontWeight="bold" sx={{ fontSize: '0.875rem' }}>
+                      {crumb.label}
+                    </Typography>
+                  ) : (
+                    <Link
+                      key={crumb.path}
+                      component={RouterLink}
+                      to={crumb.path}
+                      color="inherit"
+                      underline="hover"
+                      sx={{ display: 'flex', alignItems: 'center', fontSize: '0.875rem' }}
+                    >
+                      {crumb.icon}
+                    </Link>
+                  );
+                })}
+              </Breadcrumbs>
+            )}
+            <Outlet />
           </Box>
-          <Outlet />
+          <Footer />
         </Box>
       </Box>
-      <Footer />
-    </BoxFooter>
     </SnackbarProvider>
   );
 }
-
-const StyledBox = styled(Box)<IBoxProps>((props) => (({
-  display: 'flex',
-  flexDirection: 'column',
-  justifyContent: 'space-between', height: '100vh'
-})));
-
-const BoxFooter: React.FC<IBoxProps> = props => {
-  return (
-    <StyledBox {...props}>{props.children}</StyledBox>
-  )
-};

--- a/src/components/layout/MainLayout2.component.tsx
+++ b/src/components/layout/MainLayout2.component.tsx
@@ -2,15 +2,16 @@ import { TLinkSidebar } from '@/types/general.types';
 import { IBoxProps, IMainLayoutProps } from '@/types/props.types';
 import links from '@/utils/links/links.utils';
 import { deleteUserLocalStorage, readUserLocalStorage } from '@/utils/storage/localStorage.utils';
-import AccountCircleIcon from '@mui/icons-material/AccountCircle';
 import GolfCourseIcon from '@mui/icons-material/GolfCourse';
+import Logout from '@mui/icons-material/Logout';
 import PeopleIcon from '@mui/icons-material/People';
+import Settings from '@mui/icons-material/Settings';
 import SvgIcon, { default as MenuIcon } from '@mui/icons-material/Menu';
 import HomeIcon from '@mui/icons-material/Home';
 import NavigateNextIcon from '@mui/icons-material/NavigateNext';
 import { ListItemIcon, ListItemText, styled, Typography, Breadcrumbs, Link } from '@mui/material';
 import AppBar from '@mui/material/AppBar';
-import Avatar from '@mui/material/Avatar';
+import { SidebarHCP } from '@/styles/stack/StackPlayerMenu.styles';
 import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
 import Drawer from '@mui/material/Drawer';
@@ -171,7 +172,7 @@ export default function DrawerAppBar(props: IMainLayoutProps) {
       </Typography>
       <Divider />
       <List>
-        {links.map((link: TLinkSidebar, index: number) => {
+        {links.filter(l => l.show === true).map((link: TLinkSidebar, index: number) => {
           return (
             <ListItem key={index} disablePadding sx={{ display: 'flex' }}>
               <ListItemButton
@@ -179,7 +180,8 @@ export default function DrawerAppBar(props: IMainLayoutProps) {
                   minHeight: 48,
                   px: 2.5,
                 }}
-                href={link.link}
+                component={RouterLink}
+                to={link.link}
               >
                 <ListItemIcon
                   sx={{
@@ -196,16 +198,28 @@ export default function DrawerAppBar(props: IMainLayoutProps) {
             </ListItem>
           );
         })}
+        <Divider sx={{ my: 1 }} />
+        <ListItem sx={{ display: 'flex', justifyContent: 'center', py: 0.5 }}>
+          <SidebarHCP value={player?.HCP ?? 0} name={player?.displayName ?? ''} />
+        </ListItem>
+        <ListItem disablePadding>
+          <ListItemButton component={RouterLink} to="/settings" sx={{ minHeight: 48, px: 2.5 }}>
+            <ListItemIcon sx={{ minWidth: 0, justifyContent: 'center', marginRight: '10px', color: 'text.primary' }}>
+              <Settings fontSize="small" />
+            </ListItemIcon>
+            <ListItemText primary="Settings" sx={{ color: 'text.primary' }} />
+          </ListItemButton>
+        </ListItem>
+        <Divider sx={{ my: 1 }} />
         {player?.isAdmin && (
           <>
-            <Divider sx={{ my: 1 }} />
             <ListItem disablePadding sx={{ px: 2.5, py: 0.5 }}>
               <Typography variant="caption" sx={{ color: 'text.secondary', fontWeight: 600 }}>
                 Admin
               </Typography>
             </ListItem>
             <ListItem disablePadding>
-              <ListItemButton sx={{ minHeight: 48, px: 2.5 }} href="/admin/courses">
+              <ListItemButton component={RouterLink} to="/admin/courses" sx={{ minHeight: 48, px: 2.5 }}>
                 <ListItemIcon sx={{ minWidth: 0, justifyContent: 'center', marginRight: '10px', color: 'text.primary' }}>
                   <SvgIcon component={GolfCourseIcon} inheritViewBox />
                 </ListItemIcon>
@@ -213,7 +227,7 @@ export default function DrawerAppBar(props: IMainLayoutProps) {
               </ListItemButton>
             </ListItem>
             <ListItem disablePadding>
-              <ListItemButton sx={{ minHeight: 48, px: 2.5 }} href="/admin/users">
+              <ListItemButton component={RouterLink} to="/admin/users" sx={{ minHeight: 48, px: 2.5 }}>
                 <ListItemIcon sx={{ minWidth: 0, justifyContent: 'center', marginRight: '10px', color: 'text.primary' }}>
                   <SvgIcon component={PeopleIcon} inheritViewBox />
                 </ListItemIcon>
@@ -223,37 +237,17 @@ export default function DrawerAppBar(props: IMainLayoutProps) {
           </>
         )}
         <Divider sx={{ my: 1 }} />
-        <ListItem disablePadding>
-          <ListItemButton href="/settings">
-            <ListItemIcon sx={{ minWidth: 0, justifyContent: 'center', marginRight: '10px', color: 'text.primary' }}>
-              {player?.photoURL ? <Avatar src={player.photoURL} sx={{ width: 24, height: 24 }} /> : <AccountCircleIcon />}
-            </ListItemIcon>
-            <ListItemText primary="Profile" sx={{ color: 'text.primary' }} />
-          </ListItemButton>
-        </ListItem>
-        <ListItem disablePadding>
-          <ListItemButton href="/clubs">
-            <ListItemIcon sx={{ minWidth: 0, justifyContent: 'center', marginRight: '10px', color: 'text.primary' }}>
-              <GolfCourseIcon />
-            </ListItemIcon>
-            <ListItemText primary="Clubs" sx={{ color: 'text.primary' }} />
-          </ListItemButton>
-        </ListItem>
-        <ListItem disablePadding>
-          <ListItemButton href="/statistics">
-            <ListItemIcon sx={{ minWidth: 0, justifyContent: 'center', marginRight: '10px', color: 'text.primary' }}>
-              <SvgIcon component={links.find(l => l.name === 'Statistics')?.icon || links[0].icon} inheritViewBox />
-            </ListItemIcon>
-            <ListItemText primary="Statistics" sx={{ color: 'text.primary' }} />
-          </ListItemButton>
-        </ListItem>
-        <Divider sx={{ my: 1 }} />
         <ListItem sx={{ justifyContent: 'center', display: 'flex', py: 1 }}>
           <ThemeSwitcher />
         </ListItem>
         <Divider sx={{ my: 1 }} />
         <ListItem disablePadding>
-          <ListItemButton onClick={handleLogout} sx={{ color: 'text.primary', justifyContent: 'center' }}>Logout</ListItemButton>
+          <ListItemButton onClick={handleLogout} sx={{ minHeight: 48, px: 2.5 }}>
+            <ListItemIcon sx={{ minWidth: 0, justifyContent: 'center', marginRight: '10px', color: 'text.primary' }}>
+              <Logout fontSize="small" />
+            </ListItemIcon>
+            <ListItemText primary="Logout" sx={{ color: 'text.primary' }} />
+          </ListItemButton>
         </ListItem>
       </List>
     </Box>

--- a/src/components/layout/MainLayout2.component.tsx
+++ b/src/components/layout/MainLayout2.component.tsx
@@ -93,6 +93,8 @@ export default function DrawerAppBar(props: IMainLayoutProps) {
       breadcrumbs.push({ label: 'Statistics', path: '/statistics' });
     } else if (path === '/settings') {
       breadcrumbs.push({ label: 'Settings', path: '/settings' });
+    } else if (path === '/simulator') {
+      breadcrumbs.push({ label: 'Simulator', path: '/simulator' });
     } else if (path.startsWith('/round/')) {
       // Check if roundDetailsData is already loaded
       if (roundDetailsData?.roundCourse) {
@@ -140,6 +142,8 @@ export default function DrawerAppBar(props: IMainLayoutProps) {
       breadcrumbs.push({ label: 'Statistics', path: '/statistics' });
     } else if (path === '/settings') {
       breadcrumbs.push({ label: 'Settings', path: '/settings' });
+    } else if (path === '/simulator') {
+      breadcrumbs.push({ label: 'Simulator', path: '/simulator' });
     } else if (path.startsWith('/round/')) {
       if (roundDetailsData?.roundCourse) {
         breadcrumbs.push({ label: 'All Rounds', path: '/all-rounds' });

--- a/src/components/layout/MainLayout2.component.tsx
+++ b/src/components/layout/MainLayout2.component.tsx
@@ -10,6 +10,8 @@ import SvgIcon, { default as MenuIcon } from '@mui/icons-material/Menu';
 import HomeIcon from '@mui/icons-material/Home';
 import NavigateNextIcon from '@mui/icons-material/NavigateNext';
 import { ListItemIcon, ListItemText, styled, Typography, Breadcrumbs, Link } from '@mui/material';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { useTheme } from '@mui/material/styles';
 import AppBar from '@mui/material/AppBar';
 import { SidebarHCP } from '@/styles/stack/StackPlayerMenu.styles';
 import Box from '@mui/material/Box';
@@ -32,7 +34,9 @@ import { SnackbarProvider } from '@/components/Admin/SnackbarProvider.component'
 
 export default function DrawerAppBar(props: IMainLayoutProps) {
   const { window } = props;
-  const [mobileOpen, setMobileOpen] = React.useState(false);
+  const [drawerOpen, setDrawerOpen] = React.useState(false);
+  const theme = useTheme();
+  const isDesktop = useMediaQuery(theme.breakpoints.up('md'));
   const uid = readUserLocalStorage();
   const auth = getAuth();
   const player = useAppStore((state) => state.player);
@@ -44,7 +48,7 @@ export default function DrawerAppBar(props: IMainLayoutProps) {
   const roundDetailsData = useAppStore((state) => state.roundDetailsData);
 
   const handleDrawerToggle = () => {
-    setMobileOpen((prevState) => !prevState);
+    setDrawerOpen((prevState) => !prevState);
   };
 
   React.useEffect(() => {
@@ -166,7 +170,7 @@ export default function DrawerAppBar(props: IMainLayoutProps) {
   const mobileBreadcrumbs = getMobileBreadcrumbs();
 
   const drawer = (
-    <Box onClick={handleDrawerToggle} sx={{ textAlign: 'center' }}>
+    <Box onClick={!isDesktop ? handleDrawerToggle : undefined} sx={{ textAlign: 'center' }}>
       <Typography variant="headline6" sx={{ my: 2, color: 'text.primary' }}>
         {player?.displayName ? player.displayName.split(' ')[0] : 'Menu'}
       </Typography>
@@ -346,21 +350,28 @@ export default function DrawerAppBar(props: IMainLayoutProps) {
         <nav>
           <Drawer
             container={container}
-            variant="temporary"
-            open={mobileOpen}
+            variant={isDesktop ? 'persistent' : 'temporary'}
+            open={drawerOpen}
             onClose={handleDrawerToggle}
             ModalProps={{
               keepMounted: true,
             }}
             sx={{
-              display: { xs: 'block', sm: 'none' },
               '& .MuiDrawer-paper': { boxSizing: 'border-box', width: 240 },
             }}
           >
             {drawer}
           </Drawer>
         </nav>
-        <Box component="main" sx={{ p: 1, width: '100%' }}>
+        <Box component="main" sx={{
+          p: 1,
+          width: '100%',
+          transition: theme.transitions.create('margin', {
+            easing: theme.transitions.easing.sharp,
+            duration: theme.transitions.duration.leavingScreen,
+          }),
+          ml: isDesktop && drawerOpen ? '240px' : 0,
+        }}>
           <Toolbar />
           <Box sx={{ display: { xs: 'block', sm: 'none' }, mb: 1 }}>
             {renderBreadcrumbs(true)}

--- a/src/components/layout/User.component.tsx
+++ b/src/components/layout/User.component.tsx
@@ -1,137 +1,28 @@
-import StackPlayerMenu from "@/styles/stack/StackPlayerMenu.styles";
-import { deleteUserLocalStorage } from "@/utils/storage/localStorage.utils";
 import { stringAvatar } from "@/utils/user/user.utils";
-import { Logout, Settings } from "@mui/icons-material";
-import { Avatar, Box, Divider, IconButton, ListItemIcon, Menu, MenuItem, Skeleton, Tooltip } from "@mui/material";
-import { getAuth, signOut } from "firebase/auth";
+import { Avatar, Box, IconButton, Skeleton } from "@mui/material";
 import _ from "lodash";
-import React, { useState } from "react";
-import { useNavigate } from "react-router-dom";
 import { useAppStore } from "@/store/zustand";
 
-
 const User = () => {
-  const navigate = useNavigate();
   const user = useAppStore((state) => state.user);
   const { player, isLoadingPlayer: isLoading } = useAppStore();
-  const resetUser = useAppStore((state) => state.resetUser);
-
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const open = Boolean(anchorEl);
-
-  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(event.currentTarget);
-  };
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
-  const handleSettings = () => {
-    setAnchorEl(null);
-    navigate('/settings');
-  }
-
-  const handleLogout = () => {
-    const auth = getAuth();
-
-    setAnchorEl(null);
-    signOut(auth).then(() => {
-      deleteUserLocalStorage();
-      resetUser();
-    }).catch((error) => {
-    });
-  };
 
   return (
     !!isLoading || _.isUndefined(player.photoURL)
       ?
       <Box sx={{ display: 'flex' }}>
-        <IconButton size="small"
-          sx={{ ml: 2 }}
-          aria-controls={open ? 'account-menu' : undefined}
-          aria-haspopup="true"
-          aria-expanded={open ? 'true' : undefined}>
+        <IconButton size="small" sx={{ ml: 2 }}>
           <Skeleton variant="circular" width={40} height={40} sx={{ backgroundColor: 'white' }} />
         </IconButton>
       </Box>
       : <Box sx={{ display: 'flex' }}>
-        <Tooltip title="Account settings">
-          <IconButton
-            onClick={handleClick}
-            size="small"
-            sx={{ ml: 2 }}
-            aria-controls={open ? 'account-menu' : undefined}
-            aria-haspopup="true"
-            aria-expanded={open ? 'true' : undefined}
-          >
-            {
-
-              user?.photoURL === '' || _.isUndefined(player.photoURL)
-                ? <Avatar alt={player.displayName ?? ''}{...stringAvatar(player.displayName ?? '')} />
-                : <Avatar alt={player.displayName ?? ''} src={player.photoURL ?? undefined} />
-            }
-          </IconButton>
-        </Tooltip>
-        <Menu
-          anchorEl={anchorEl}
-          id="account-menu"
-          open={open}
-          onClose={handleClose}
-          onClick={handleClose}
-          slotProps={{
-            paper: {
-              elevation: 0,
-              sx: {
-                overflow: 'visible',
-                filter: 'drop-shadow(0px 2px 8px rgba(0,0,0,0.32))',
-                mt: 1.5,
-                '& .MuiAvatar-root': {
-                  width: 32,
-                  height: 32,
-                  ml: -0.5,
-                  mr: 1,
-                },
-                '&::before': {
-                  content: '""',
-                  display: 'block',
-                  position: 'absolute',
-                  top: 0,
-                  right: 14,
-                  width: 10,
-                  height: 10,
-                  bgcolor: 'background.paper',
-                  transform: 'translateY(-50%) rotate(45deg)',
-                  zIndex: 0,
-                },
-              },
-            },
-          }}
-          transformOrigin={{ horizontal: 'right', vertical: 'top' }}
-          anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
-        >
-          <MenuItem onClick={handleClose}>
-            <StackPlayerMenu name={player?.displayName ?? ''} value={player?.HCP ?? 0} />
-          </MenuItem>
-
-          <Divider />
-
-          {/* Settings MenuItem */}
-          <MenuItem onClick={handleSettings}
-            sx={{ display: 'flex', flexDirection: 'row', width: '100%', justifyContent: 'flex-start' }}>
-            <ListItemIcon sx={{ marginLeft: '-10px' }}>
-              <Settings fontSize="small" />
-            </ListItemIcon>
-            Settings
-          </MenuItem>
-
-          {/* Logout MenuItem */}
-          <MenuItem onClick={handleLogout}
-            sx={{ display: 'flex', flexDirection: 'row', width: '100%', justifyContent: 'flex-start' }}>
-            <ListItemIcon sx={{ marginLeft: '-10px' }}>
-              <Logout fontSize="small" />
-            </ListItemIcon>
-            Logout
-          </MenuItem>
-        </Menu>
+        <IconButton size="small" sx={{ ml: 2 }}>
+          {
+            user?.photoURL === '' || _.isUndefined(player.photoURL)
+              ? <Avatar alt={player.displayName ?? ''} {...stringAvatar(player.displayName ?? '')} />
+              : <Avatar alt={player.displayName ?? ''} src={player.photoURL ?? undefined} />
+          }
+        </IconButton>
       </Box>
   )
 }

--- a/src/dev-tools/whsTestData.ts
+++ b/src/dev-tools/whsTestData.ts
@@ -154,11 +154,12 @@ export const WHSHandicapIndexTestCases: IHandicapIndexTestCase[] = [
  */
 export const WHSProjectedHITestCases: IProjectedHITestCase[] = [
 	{
-		name: '5 current SDs + simulated SD (lowest score)',
+		name: '5 current SDs + simulated SD (virtual has 6 entries)',
 		currentSDs: [14.6, 10.2, 12.1, 15.0, 9.8],
 		simulatedSD: 4.6,
-		// Virtual: [4.6, 14.6, 10.2, 12.1, 15.0] → 5 entries, lowest 1 → 4.6
-		expectedHI: 4.6,
+		// Virtual: [4.6, 14.6, 10.2, 12.1, 15.0, 9.8] → 6 entries
+		// WHS scaling for 6 rounds = lowest 2 → [4.6, 9.8] = avg 7.2
+		expectedHI: 7.2,
 	},
 	{
 		name: '20 current SDs + simulated SD (drops oldest)',
@@ -168,16 +169,17 @@ export const WHSProjectedHITestCases: IProjectedHITestCase[] = [
 			23.0, 24.0, 25.0, 26.0,
 		],
 		simulatedSD: 5.0,
-		// Virtual: [5.0, 15.0, ..., 25.0] (drops index 19 = 26.0)
+		// Virtual: [5.0, 15.0, ..., 25.0] (drops index 19 = 26.0) → 20 entries
+		// WHS scaling for 20 rounds = lowest 8
 		// Best 8: 5.0, 10.0, 11.0, 12.0, 12.0, 13.0, 13.0, 14.0 = 90/8 = 11.25 → 11.3
 		expectedHI: 11.3,
 	},
 	{
-		name: 'Fewer than 3 rounds returns null',
-		currentSDs: [14.6, 10.2],
+		name: 'Only 1 current SD — virtual has 2 entries, returns null',
+		currentSDs: [14.6],
 		simulatedSD: 4.6,
-		// Virtual: [4.6, 14.6, 10.2] → 3 entries, lowest 1 → 10.2
-		expectedHI: 10.2,
+		// Virtual: [4.6, 14.6] → 2 entries → < 3 rounds → null
+		expectedHI: null,
 	},
 ];
 

--- a/src/dev-tools/whsTestData.ts
+++ b/src/dev-tools/whsTestData.ts
@@ -1,0 +1,222 @@
+/**
+ * WHS (World Handicap System) test data definitions.
+ *
+ * Test cases for Score Differential, Handicap Index, and Playing Handicap
+ * calculations following WHS Rules 5.1 and 5.2a.
+ *
+ * [CITED: CONTEXT.md canonical refs — WHS formulas]
+ */
+
+export interface IScoreDifferentialTestCase {
+	name: string;
+	input: {
+		par: number;
+		courseRating: number;
+		slopeRating: number;
+		stablefordPoints: number;
+		playingHCP: number;
+	};
+	expectedAGS: number;
+	expectedSD: number;
+}
+
+export interface IHandicapIndexTestCase {
+	name: string;
+	scoreDifferentials: number[];
+	expectedHI: number | null;
+}
+
+export interface IProjectedHITestCase {
+	name: string;
+	currentSDs: number[];
+	simulatedSD: number;
+	expectedHI: number | null;
+}
+
+export interface IPlayingHCPTestCase {
+	name: string;
+	handicapIndex: number;
+	courseRating: number;
+	slopeRating: number;
+	par: number;
+	expectedPlayingHCP: number;
+}
+
+/**
+ * Score Differential test cases — WHS Rule 5.1
+ *
+ * SD = (AGS - CR - PCC) × (113 / SR), PCC = 0
+ * AGS = PAR + Playing HCP + (36 - Stableford points)
+ *
+ * NOTE: The "good round" uses playingHCP=12 to produce the expected AGS=78 / SD=4.6.
+ * The plan's acceptance criteria reference playingHCP=18 but the correct WHS formula
+ * yields AGS=78 only with playingHCP=12. This is tracked as a plan deviation.
+ */
+export const WHSScoreDifferentialTestCases: IScoreDifferentialTestCase[] = [
+	{
+		name: 'Good round - Standard Course',
+		input: { par: 72, courseRating: 72.5, slopeRating: 135, stablefordPoints: 42, playingHCP: 12 },
+		expectedAGS: 78,
+		expectedSD: 4.6,
+	},
+	{
+		name: 'Average round - Standard Course',
+		input: { par: 72, courseRating: 72.5, slopeRating: 135, stablefordPoints: 36, playingHCP: 18 },
+		expectedAGS: 90,
+		expectedSD: 14.6,
+	},
+	{
+		name: 'Poor round - Standard Course',
+		input: { par: 72, courseRating: 72.5, slopeRating: 135, stablefordPoints: 24, playingHCP: 18 },
+		expectedAGS: 102,
+		expectedSD: 24.7,
+	},
+	{
+		name: 'Different course - easier layout',
+		input: { par: 70, courseRating: 68.5, slopeRating: 125, stablefordPoints: 38, playingHCP: 14 },
+		expectedAGS: 82,
+		expectedSD: 12.2,
+	},
+	{
+		name: 'High slope course',
+		input: { par: 72, courseRating: 74.0, slopeRating: 145, stablefordPoints: 30, playingHCP: 20 },
+		expectedAGS: 98,
+		expectedSD: 18.7,
+	},
+	{
+		name: 'Zero Stableford points (worst possible)',
+		input: { par: 72, courseRating: 72.5, slopeRating: 135, stablefordPoints: 0, playingHCP: 18 },
+		expectedAGS: 126,
+		expectedSD: 44.7,
+	},
+];
+
+/**
+ * Handicap Index test cases — WHS Rule 5.2a
+ *
+ * With 20 rounds: average lowest 8 of most recent 20 SDs.
+ * With < 20 rounds: use WHS scaling table.
+ * Returns null if fewer than 3 rounds.
+ */
+export const WHSHandicapIndexTestCases: IHandicapIndexTestCase[] = [
+	{
+		name: '20 rounds - best 8',
+		// Best 8: [10.0, 11.0, 12.0, 12.0, 13.0, 13.0, 14.0, 14.0] — avg = 99/8 = 12.4
+		scoreDifferentials: [
+			15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, // indices 0-7 (most recent, worst)
+			10.0, 11.0, 12.0, 12.0, 13.0, 13.0, 14.0, 14.0, // indices 8-15 (best 8)
+			23.0, 24.0, 25.0, 26.0, // indices 16-19 (oldest)
+		],
+		expectedHI: 12.4,
+	},
+	{
+		name: '5 rounds - lowest 1 (scaling)',
+		scoreDifferentials: [14.6, 10.2, 12.1, 15.0, 9.8],
+		expectedHI: 9.8,
+	},
+	{
+		name: '3 rounds - lowest 1 (minimum)',
+		scoreDifferentials: [14.6, 10.2, 12.1],
+		expectedHI: 10.2,
+	},
+	{
+		name: '2 rounds - returns null (< 3 rounds)',
+		scoreDifferentials: [14.6, 10.2],
+		expectedHI: null,
+	},
+	{
+		name: '1 round - returns null (< 3 rounds)',
+		scoreDifferentials: [14.6],
+		expectedHI: null,
+	},
+	{
+		name: 'Empty array - returns null (< 3 rounds)',
+		scoreDifferentials: [],
+		expectedHI: null,
+	},
+	{
+		name: '8 rounds - lowest 2 (scaling)',
+		scoreDifferentials: [15.0, 14.5, 13.0, 12.5, 20.0, 18.0, 11.0, 10.5],
+		expectedHI: 10.8, // lowest 2: 10.5 + 11.0 = 21.5 / 2 = 10.75 → 10.8
+	},
+	{
+		name: '15 rounds - lowest 5 (scaling)',
+		scoreDifferentials: [
+			20.0, 19.0, 18.0, 17.0, 16.0, 15.0, 14.0, 13.0,
+			12.0, 11.0, 10.0, 9.0, 8.0, 7.0, 6.0,
+		],
+		expectedHI: 8.0, // lowest 5: 6+7+8+9+10 = 40/5 = 8.0
+	},
+];
+
+/**
+ * Projected Handicap Index test cases — virtual array pattern (SIM-03)
+ */
+export const WHSProjectedHITestCases: IProjectedHITestCase[] = [
+	{
+		name: '5 current SDs + simulated SD (lowest score)',
+		currentSDs: [14.6, 10.2, 12.1, 15.0, 9.8],
+		simulatedSD: 4.6,
+		// Virtual: [4.6, 14.6, 10.2, 12.1, 15.0] → 5 entries, lowest 1 → 4.6
+		expectedHI: 4.6,
+	},
+	{
+		name: '20 current SDs + simulated SD (drops oldest)',
+		currentSDs: [
+			15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0,
+			10.0, 11.0, 12.0, 12.0, 13.0, 13.0, 14.0, 14.0,
+			23.0, 24.0, 25.0, 26.0,
+		],
+		simulatedSD: 5.0,
+		// Virtual: [5.0, 15.0, ..., 25.0] (drops index 19 = 26.0)
+		// Best 8: 5.0, 10.0, 11.0, 12.0, 12.0, 13.0, 13.0, 14.0 = 90/8 = 11.25 → 11.3
+		expectedHI: 11.3,
+	},
+	{
+		name: 'Fewer than 3 rounds returns null',
+		currentSDs: [14.6, 10.2],
+		simulatedSD: 4.6,
+		// Virtual: [4.6, 14.6, 10.2] → 3 entries, lowest 1 → 10.2
+		expectedHI: 10.2,
+	},
+];
+
+/**
+ * Playing Handicap test cases — D-09 formula
+ *
+ * Playing HCP = HI × (SR / 113) + (CR - PAR)
+ */
+export const WHSPlayingHCPTestCases: IPlayingHCPTestCase[] = [
+	{
+		name: 'Standard calculation',
+		handicapIndex: 12.4,
+		courseRating: 72.5,
+		slopeRating: 135,
+		par: 72,
+		expectedPlayingHCP: 15, // Math.round(12.4 * 135/113 + (72.5 - 72)) = Math.round(15.31) = 15
+	},
+	{
+		name: 'High handicap index',
+		handicapIndex: 26.4,
+		courseRating: 72.5,
+		slopeRating: 135,
+		par: 72,
+		expectedPlayingHCP: 32, // Math.round(26.4 * 135/113 + 0.5) = Math.round(32.03) = 32
+	},
+	{
+		name: 'Low slope course',
+		handicapIndex: 10.0,
+		courseRating: 68.0,
+		slopeRating: 113, // Standard slope
+		par: 70,
+		expectedPlayingHCP: 8, // Math.round(10 * 113/113 + (68 - 70)) = Math.round(10 - 2) = 8
+	},
+	{
+		name: 'Zero handicap index',
+		handicapIndex: 0.0,
+		courseRating: 72.0,
+		slopeRating: 125,
+		par: 72,
+		expectedPlayingHCP: 0, // Math.round(0 * 125/113 + 0) = Math.round(0) = 0
+	},
+];

--- a/src/dev-tools/whsTestRunner.ts
+++ b/src/dev-tools/whsTestRunner.ts
@@ -1,0 +1,274 @@
+#!/usr/bin/env node
+
+/**
+ * WHS (World Handicap System) test runner.
+ *
+ * CLI test runner specifically for WHS Score Differential and Handicap Index
+ * calculations. Follows the pattern established by testRunner.ts.
+ *
+ * Usage:
+ *   npm run test:calc:whs        # Run all WHS test cases
+ *   npm run test:calc:whs-quick  # Run a representative subset
+ *
+ * [CITED: CONTEXT.md — WHS test strategy]
+ */
+
+import {
+	WHSScoreDifferentialTestCases,
+	WHSHandicapIndexTestCases,
+	WHSProjectedHITestCases,
+	WHSPlayingHCPTestCases,
+} from './whsTestData';
+
+// NOTE: Relative imports used because `tsx` does not resolve `@/` path aliases.
+// The implementation files do not exist yet — this is expected for the TDD RED phase.
+// They will be created in Task 2 (GREEN phase).
+import { calculateScoreDifferential, calculatePlayingHandicap } from '../utils/whs/whs.utils';
+import { calculateHandicapIndex, calculateProjectedHandicapIndex } from '../utils/whs/hi.utils';
+
+const TOLERANCE = 0.1;
+const PASS_SYMBOL = '✅';
+const FAIL_SYMBOL = '❌';
+
+interface TestResult {
+	name: string;
+	passed: boolean;
+	expected: unknown;
+	actual: unknown;
+	error?: string;
+}
+
+/**
+ * Run all Score Differential test cases.
+ */
+function runSDTests(): TestResult[] {
+	return WHSScoreDifferentialTestCases.map((tc) => {
+		try {
+			const result = calculateScoreDifferential(tc.input);
+			const agsPassed = Math.abs(result.adjustedGrossScore - tc.expectedAGS) <= TOLERANCE;
+			const sdPassed = Math.abs(result.scoreDifferential - tc.expectedSD) <= TOLERANCE;
+			const passed = agsPassed && sdPassed;
+
+			return {
+				name: `SD: ${tc.name}`,
+				passed,
+				expected: `AGS=${tc.expectedAGS}, SD=${tc.expectedSD}`,
+				actual: `AGS=${result.adjustedGrossScore}, SD=${result.scoreDifferential}`,
+			};
+		} catch (err: any) {
+			return {
+				name: `SD: ${tc.name}`,
+				passed: false,
+				expected: `AGS=${tc.expectedAGS}, SD=${tc.expectedSD}`,
+				actual: 'ERROR',
+				error: err.message ?? String(err),
+			};
+		}
+	});
+}
+
+/**
+ * Run all Handicap Index test cases.
+ */
+function runHITests(): TestResult[] {
+	return WHSHandicapIndexTestCases.map((tc) => {
+		try {
+			const result = calculateHandicapIndex(tc.scoreDifferentials);
+			const passed =
+				tc.expectedHI === null
+					? result === null
+					: result !== null && Math.abs(result - tc.expectedHI) <= TOLERANCE;
+
+			return {
+				name: `HI: ${tc.name}`,
+				passed,
+				expected: tc.expectedHI,
+				actual: result,
+			};
+		} catch (err: any) {
+			return {
+				name: `HI: ${tc.name}`,
+				passed: false,
+				expected: tc.expectedHI,
+				actual: 'ERROR',
+				error: err.message ?? String(err),
+			};
+		}
+	});
+}
+
+/**
+ * Run all Projected Handicap Index test cases.
+ */
+function runProjectedHITests(): TestResult[] {
+	return WHSProjectedHITestCases.map((tc) => {
+		try {
+			const result = calculateProjectedHandicapIndex(tc.currentSDs, tc.simulatedSD);
+			const passed =
+				tc.expectedHI === null
+					? result === null
+					: result !== null && Math.abs(result - tc.expectedHI) <= TOLERANCE;
+
+			return {
+				name: `Projected HI: ${tc.name}`,
+				passed,
+				expected: tc.expectedHI,
+				actual: result,
+			};
+		} catch (err: any) {
+			return {
+				name: `Projected HI: ${tc.name}`,
+				passed: false,
+				expected: tc.expectedHI,
+				actual: 'ERROR',
+				error: err.message ?? String(err),
+			};
+		}
+	});
+}
+
+/**
+ * Run all Playing Handicap test cases.
+ */
+function runPlayingHCPTests(): TestResult[] {
+	return WHSPlayingHCPTestCases.map((tc) => {
+		try {
+			const result = calculatePlayingHandicap(
+				tc.handicapIndex,
+				tc.courseRating,
+				tc.slopeRating,
+				tc.par,
+			);
+			const passed = result === tc.expectedPlayingHCP;
+
+			return {
+				name: `Playing HCP: ${tc.name}`,
+				passed,
+				expected: tc.expectedPlayingHCP,
+				actual: result,
+			};
+		} catch (err: any) {
+			return {
+				name: `Playing HCP: ${tc.name}`,
+				passed: false,
+				expected: tc.expectedPlayingHCP,
+				actual: 'ERROR',
+				error: err.message ?? String(err),
+			};
+		}
+	});
+}
+
+/**
+ * Log a single test result to the console.
+ */
+function logResult(result: TestResult): void {
+	if (result.passed) {
+		console.log(`${PASS_SYMBOL} ${result.name}`);
+	} else {
+		console.log(`${FAIL_SYMBOL} ${result.name}`);
+		console.log(`   Expected: ${JSON.stringify(result.expected)}`);
+		console.log(`   Actual:   ${JSON.stringify(result.actual)}`);
+		if (result.error) {
+			console.log(`   Error:    ${result.error}`);
+		}
+	}
+}
+
+/**
+ * Run a set of tests and return summary stats.
+ */
+function runTestSuite(
+	name: string,
+	results: TestResult[],
+): { total: number; passed: number } {
+	console.log(`\n--- ${name} ---\n`);
+	let passedCount = 0;
+	for (const r of results) {
+		logResult(r);
+		if (r.passed) passedCount++;
+	}
+	const total = results.length;
+	console.log(`\n${passedCount}/${total} passed`);
+	return { total, passed: passedCount };
+}
+
+export class WHSTestRunner {
+	/**
+	 * Run all WHS test cases (full suite).
+	 */
+	static runAll(): void {
+		console.log('🏌️  WHS Calculation Test Suite\n');
+		console.log('=== Full Suite ===');
+
+		const sdResults = runSDTests();
+		const hiResults = runHITests();
+		const projectedResults = runProjectedHITests();
+		const playingHCPResults = runPlayingHCPTests();
+
+		const sd = runTestSuite('Score Differential (WHS Rule 5.1)', sdResults);
+		const hi = runTestSuite('Handicap Index (WHS Rule 5.2a)', hiResults);
+		const proj = runTestSuite('Projected Handicap Index', projectedResults);
+		const phcp = runTestSuite('Playing Handicap (D-09)', playingHCPResults);
+
+		const total = sd.total + hi.total + proj.total + phcp.total;
+		const passed = sd.passed + hi.passed + proj.passed + phcp.passed;
+		const allPassed = total === passed;
+
+		console.log('\n=== Summary ===');
+		console.log(`SD:                  ${sd.passed}/${sd.total}`);
+		console.log(`HI:                  ${hi.passed}/${hi.total}`);
+		console.log(`Projected HI:        ${proj.passed}/${proj.total}`);
+		console.log(`Playing HCP:         ${phcp.passed}/${phcp.total}`);
+		console.log(`\nTotal: ${passed}/${total}`);
+
+		if (allPassed) {
+			console.log(`\n🎉 All WHS tests passed!\n`);
+		} else {
+			console.log(`\n🚨 ${total - passed} test(s) FAILED\n`);
+		}
+
+		// Exit with non-zero code on failure for CI/script usage
+		if (!allPassed) {
+			process.exit(1);
+		}
+	}
+
+	/**
+	 * Run a representative subset of WHS tests (quick mode).
+	 */
+	static runQuick(): void {
+		console.log('🏌️  WHS Quick Test\n');
+
+		// Representative subset: 2 SD, 2 HI, 1 projected, 1 playing HCP
+		const sdQuick = runSDTests().slice(0, 2);
+		const hiQuick = runHITests().slice(0, 2);
+		const projectedQuick = runProjectedHITests().slice(0, 1);
+		const playingHCPQuick = runPlayingHCPTests().slice(0, 1);
+
+		const sd = runTestSuite('Score Differential (quick)', sdQuick);
+		const hi = runTestSuite('Handicap Index (quick)', hiQuick);
+		const proj = runTestSuite('Projected HI (quick)', projectedQuick);
+		const phcp = runTestSuite('Playing HCP (quick)', playingHCPQuick);
+
+		const total = sd.total + hi.total + proj.total + phcp.total;
+		const passed = sd.passed + hi.passed + proj.passed + phcp.passed;
+		const allPassed = total === passed;
+
+		console.log(`\nQuick test: ${passed}/${total} passed`);
+
+		if (!allPassed) {
+			process.exit(1);
+		}
+	}
+}
+
+// CLI entry point
+const args = process.argv.slice(2);
+const mode = args[0] || 'quick';
+
+if (mode === 'all') {
+	WHSTestRunner.runAll();
+} else {
+	WHSTestRunner.runQuick();
+}

--- a/src/pages/Simulator.page.tsx
+++ b/src/pages/Simulator.page.tsx
@@ -1,0 +1,7 @@
+import Simulator from '../components/Simulator/Simulator.component';
+
+const SimulatorPage = () => {
+	return <Simulator />;
+};
+
+export default SimulatorPage;

--- a/src/styles/stack/StackPlayerMenu.styles.tsx
+++ b/src/styles/stack/StackPlayerMenu.styles.tsx
@@ -79,3 +79,62 @@ const StackPlayerMenu: React.FC<BoxProps> = props => {
 };
 
 export default StackPlayerMenu;
+
+// ── SidebarHCP: compact ~40px color-coded HCP badge for sidebar use ──────────
+
+interface SidebarHCPProps {
+  value?: number;
+  name: string;
+}
+
+const getHCPColors = (hcpValue?: number) => {
+  if (hcpValue === undefined) return { bg: 'transparent', text: '#999999' };
+  if (hcpValue >= 20) return { bg: 'red', text: 'white' };
+  if (hcpValue >= 10) return { bg: 'orange', text: '#494949' };
+  return { bg: 'green', text: 'white' };
+};
+
+const CompactHCPBox = styled(BoxMui, {
+  shouldForwardProp: (prop) => prop !== 'hcpValue',
+})<{ hcpValue?: number }>(({ hcpValue }) => ({
+  width: 40,
+  height: 40,
+  borderRadius: '50%',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  backgroundColor: getHCPColors(hcpValue).bg,
+}));
+
+const CompactHCPLabel = styled(Typography, {
+  shouldForwardProp: (prop) => prop !== 'hcpValue',
+})<{ hcpValue?: number }>(({ hcpValue }) => ({
+  fontSize: '9px',
+  lineHeight: '9px',
+  color: getHCPColors(hcpValue).text,
+}));
+
+const CompactHCPNumber = styled(Typography, {
+  shouldForwardProp: (prop) => prop !== 'hcpValue',
+})<{ hcpValue?: number }>(({ hcpValue }) => ({
+  fontSize: '16px',
+  fontWeight: 'bold',
+  lineHeight: '16px',
+  color: getHCPColors(hcpValue).text,
+}));
+
+export const SidebarHCP: React.FC<SidebarHCPProps> = ({ value, name }) => {
+  return (
+    <CompactHCPBox hcpValue={value}>
+      {value !== undefined ? (
+        <>
+          <CompactHCPLabel hcpValue={value}>HCP</CompactHCPLabel>
+          <CompactHCPNumber hcpValue={value}>{value}</CompactHCPNumber>
+        </>
+      ) : (
+        <CompactHCPLabel hcpValue={undefined}>-</CompactHCPLabel>
+      )}
+    </CompactHCPBox>
+  );
+};

--- a/src/types/roundData.types.tsx
+++ b/src/types/roundData.types.tsx
@@ -169,6 +169,7 @@ export interface IBasicRoundData {
   roundStrokes?: number,
   userId?: string
   createdAt: number,
+  scoreDifferential?: number | null,
   totals: IRoundTotals
 }
 

--- a/src/utils/firestore/course.firestore.ts
+++ b/src/utils/firestore/course.firestore.ts
@@ -13,6 +13,8 @@ import {
 	serverTimestamp,
 	query,
 	orderBy,
+	where,
+	limit,
 	Timestamp,
 } from 'firebase/firestore';
 
@@ -69,6 +71,37 @@ export const getCourseById = async (id: string): Promise<ICourse | null> => {
 		} as ICourse;
 	} catch (error: any) {
 		console.error('course.firestore: Error fetching course by ID:', error);
+		throw error;
+	}
+};
+
+export const getCourseByName = async (name: string): Promise<ICourse | null> => {
+	if (!name) {
+		console.error('getCourseByName: Course name is required.');
+		throw new Error('Course name not provided.');
+	}
+
+	try {
+		const coursesRef = collection(db, COURSES_COLLECTION);
+		const nameQuery = query(
+			coursesRef,
+			where('name', '==', name),
+			limit(1)
+		);
+		const snapshot = await getDocs(nameQuery);
+
+		if (snapshot.empty) {
+			return null;
+		}
+
+		const docSnap = snapshot.docs[0];
+		const data = docSnap.data();
+		return {
+			...convertTimestamps(data),
+			id: docSnap.id,
+		} as ICourse;
+	} catch (error: any) {
+		console.error('course.firestore: Error fetching course by name:', error);
 		throw error;
 	}
 };

--- a/src/utils/firestore/federgolf-import.utils.ts
+++ b/src/utils/firestore/federgolf-import.utils.ts
@@ -1,0 +1,215 @@
+import { ICourse, ITeebox } from '@/types/course.types';
+import { db } from '@/utils/firebase/firebase.utils';
+import {
+	collection,
+	getDocs,
+	writeBatch,
+	doc,
+	serverTimestamp,
+} from 'firebase/firestore';
+
+const FEDERGOAL_URL = 'https://areariservata.federgolf.it/SlopeAndCourseRating/Index';
+const COURSES_COLLECTION = 'golf_courses';
+
+const TEE_CONFIGS: { name: string; color: string; gender: 'M' | 'F'; colIndex: number }[] = [
+	{ name: 'Nero', color: '#000000', gender: 'M', colIndex: 0 },
+	{ name: 'Bianco', color: '#ffffff', gender: 'M', colIndex: 2 },
+	{ name: 'Giallo', color: '#ffd700', gender: 'M', colIndex: 4 },
+	{ name: 'Verde', color: '#2e7d32', gender: 'M', colIndex: 6 },
+	{ name: 'Blu', color: '#1976d2', gender: 'F', colIndex: 8 },
+	{ name: 'Rosso', color: '#d32f2f', gender: 'F', colIndex: 10 },
+	{ name: 'Arancio', color: '#ff9800', gender: 'F', colIndex: 12 },
+];
+
+interface ParsedRow {
+	club: string;
+	course: string;
+	par: number;
+	teeData: (string | null)[]; // 14 values: CR/Slope for 7 tees
+}
+
+function parseFedergolfHtml(html: string): ParsedRow[] {
+	const rows: ParsedRow[] = [];
+	const tbodyMatch = html.match(/<tbody>([\s\S]*?)<\/tbody>/i);
+	if (!tbodyMatch) return rows;
+
+	const tbody = tbodyMatch[1];
+	const trRegex = /<tr>([\s\S]*?)<\/tr>/gi;
+	let trMatch: RegExpExecArray | null;
+
+	while ((trMatch = trRegex.exec(tbody)) !== null) {
+		const trContent = trMatch[1];
+		const tdRegex = /<td[^>]*>([\s\S]*?)<\/td>/gi;
+		const cells: string[] = [];
+		let tdMatch: RegExpExecArray | null;
+
+		while ((tdMatch = tdRegex.exec(trContent)) !== null) {
+			const val = tdMatch[1].trim();
+			cells.push(val);
+		}
+
+		if (cells.length < 17) continue;
+
+		const club = cells[0].trim();
+		const courseName = cells[1].trim();
+		const par = parseInt(cells[2], 10);
+		if (!club || !courseName || isNaN(par)) continue;
+
+		const teeData: (string | null)[] = [];
+		for (let i = 3; i < cells.length && i < 17; i++) {
+			const val = cells[i].trim();
+			teeData.push(val || null);
+		}
+
+		rows.push({ club, course: courseName, par, teeData });
+	}
+
+	return rows;
+}
+
+function parseNumber(val: string | null): number | null {
+	if (!val) return null;
+	const n = parseFloat(val);
+	return isNaN(n) ? null : n;
+}
+
+function rowsToCourseData(rows: ParsedRow[]): Omit<ICourse, 'id' | 'createdAt' | 'updatedAt'>[] {
+	return rows.map((row) => {
+		const teeboxes: ITeebox[] = [];
+
+		for (const tee of TEE_CONFIGS) {
+			const cr = parseNumber(row.teeData[tee.colIndex]);
+			const sr = parseNumber(row.teeData[tee.colIndex + 1]);
+			if (cr !== null && sr !== null && cr > 0 && sr > 0) {
+				teeboxes.push({
+					name: tee.name,
+					color: tee.color,
+					gender: tee.gender,
+					par: row.par,
+					courseRating: cr,
+					slopeRating: sr,
+					length: 0,
+				});
+			}
+		}
+
+		const holes: 9 | 18 = row.par <= 36 ? 9 : 18;
+
+		return {
+			name: `${row.club} - ${row.course}`,
+			city: '',
+			country: 'IT',
+			holes,
+			status: 'Active' as const,
+			teeboxes,
+		};
+	});
+}
+
+async function fetchWithFallback(url: string): Promise<string> {
+	try {
+		const response = await fetch(url, { signal: AbortSignal.timeout(15000) });
+		if (response.ok) return await response.text();
+	} catch {
+		// Direct fetch failed — try CORS proxy
+	}
+
+	const proxies = [
+		`https://api.allorigins.win/raw?url=${encodeURIComponent(url)}`,
+		`https://corsproxy.io/?${encodeURIComponent(url)}`,
+	];
+
+	for (const proxy of proxies) {
+		try {
+			const response = await fetch(proxy, { signal: AbortSignal.timeout(20000) });
+			if (response.ok) return await response.text();
+		} catch {
+			continue;
+		}
+	}
+
+	throw new Error(
+		'Unable to fetch data from Federgolf. The server may be blocking cross-origin requests. ' +
+			'Try running the seed script instead: npx tsx src/scripts/seed-federgolf.ts'
+	);
+}
+
+export interface ImportResult {
+	total: number;
+	created: number;
+	updated: number;
+	errors: string[];
+}
+
+export async function importFromFedergolf(): Promise<ImportResult> {
+	const result: ImportResult = { total: 0, created: 0, updated: 0, errors: [] };
+
+	const html = await fetchWithFallback(FEDERGOAL_URL);
+
+	const parsed = parseFedergolfHtml(html);
+	if (parsed.length === 0) {
+		throw new Error('No course data found in Federgolf response. The page structure may have changed.');
+	}
+
+	const courses = rowsToCourseData(parsed);
+	result.total = courses.length;
+
+	const coursesRef = collection(db, COURSES_COLLECTION);
+
+	const existingSnap = await getDocs(coursesRef);
+	const existingMap = new Map<string, string>();
+	existingSnap.forEach((docSnap) => {
+		const data = docSnap.data();
+		if (data.name) existingMap.set(data.name, docSnap.id);
+	});
+
+	const BATCH_SIZE = 500;
+	let batch = writeBatch(db);
+	let ops = 0;
+
+	for (const course of courses) {
+		const existingId = existingMap.get(course.name);
+
+		if (existingId) {
+			batch.update(doc(db, COURSES_COLLECTION, existingId), {
+				...course,
+				updatedAt: serverTimestamp(),
+			});
+			result.updated++;
+		} else {
+			batch.set(doc(collection(db, COURSES_COLLECTION)), {
+				...course,
+				createdAt: serverTimestamp(),
+				updatedAt: serverTimestamp(),
+			});
+			result.created++;
+		}
+
+		ops++;
+		if (ops >= BATCH_SIZE) {
+			await batch.commit();
+			batch = writeBatch(db);
+			ops = 0;
+		}
+	}
+
+	if (ops > 0) {
+		await batch.commit();
+	}
+
+	return result;
+}
+
+export async function fetchFedergolfPreview(): Promise<{ clubCount: number; courseCount: number; sampleCourses: string[] }> {
+	const html = await fetchWithFallback(FEDERGOAL_URL);
+	const parsed = parseFedergolfHtml(html);
+
+	const uniqueClubs = new Set(parsed.map((r) => r.club));
+	const sampleNames = parsed.slice(0, 5).map((r) => `${r.club} - ${r.course} (Par ${r.par})`);
+
+	return {
+		clubCount: uniqueClubs.size,
+		courseCount: parsed.length,
+		sampleCourses: sampleNames,
+	};
+}

--- a/src/utils/firestore/round.firestore.ts
+++ b/src/utils/firestore/round.firestore.ts
@@ -14,6 +14,8 @@ import {
   prepareOverallTotalsUpdateBatch,
   prepareRoundSaveBatch
 } from '../../utils/round/round.utils';
+import { getCourseByName } from '@/utils/firestore/course.firestore';
+import { calculateScoreDifferential } from '@/utils/whs/whs.utils';
 
 export const getRoundDetails = async (
   { playerId, roundId }: IFetchParams
@@ -77,6 +79,32 @@ export const saveNewRound = async (): Promise<{ success: boolean; roundId: strin
       throw new Error('User not authenticated');
     }
 
+    // Compute Score Differential before saving (per D-03)
+    let scoreDifferential: number | null = null;
+    try {
+      const course = await getCourseByName(general.roundCourse);
+      const teebox = course?.teeboxes.find(t => t.name === general.roundTee);
+      if (teebox && general.roundPar && general.roundPlayingHCP) {
+        const sdResult = calculateScoreDifferential({
+          par: general.roundPar,
+          courseRating: teebox.courseRating,
+          slopeRating: teebox.slopeRating,
+          stablefordPoints: currentTotals.points.totals,
+          playingHCP: general.roundPlayingHCP,
+        });
+        scoreDifferential = sdResult.scoreDifferential;
+      } else {
+        console.warn(
+          'saveNewRound: Could not compute Score Differential — ' +
+          `course="${general.roundCourse}", tee="${general.roundTee}", ` +
+          `par=${general.roundPar}, playingHCP=${general.roundPlayingHCP}`
+        );
+      }
+    } catch (sdError: any) {
+      console.error('saveNewRound: Error computing Score Differential:', sdError);
+      // Round save continues without SD — non-blocking
+    }
+
     const batchSaveRound = writeBatch(db);
     savedRoundId = prepareRoundSaveBatch(
       batchSaveRound,
@@ -84,7 +112,8 @@ export const saveNewRound = async (): Promise<{ success: boolean; roundId: strin
       general,
       currentTotals,
       currentRoundDistances,
-      holes
+      holes,
+      scoreDifferential
     );
     await batchSaveRound.commit();
 

--- a/src/utils/links/links.utils.tsx
+++ b/src/utils/links/links.utils.tsx
@@ -3,6 +3,7 @@ import HomeWorkIcon from '@mui/icons-material/HomeWork';
 import SportsGolfIcon from '@mui/icons-material/SportsGolf';
 import GolfCourseIcon from '@mui/icons-material/GolfCourse';
 import PeopleIcon from '@mui/icons-material/People';
+import AutoGraphIcon from '@mui/icons-material/AutoGraph';
 
 const navbar_items: TLinkSidebar[] = [
   {
@@ -32,6 +33,13 @@ const navbar_items: TLinkSidebar[] = [
     link: "/admin/users",
     icon: PeopleIcon,
     show: false,
+  },
+  {
+    id: 5,
+    name: "Simulator",
+    link: "/simulator",
+    icon: AutoGraphIcon,
+    show: true,
   },
 ];
 

--- a/src/utils/links/links.utils.tsx
+++ b/src/utils/links/links.utils.tsx
@@ -36,7 +36,7 @@ const navbar_items: TLinkSidebar[] = [
   },
   {
     id: 5,
-    name: "Simulator",
+    name: "HCP Simulator",
     link: "/simulator",
     icon: AutoGraphIcon,
     show: true,

--- a/src/utils/round/round.utils.tsx
+++ b/src/utils/round/round.utils.tsx
@@ -87,7 +87,8 @@ export const prepareRoundSaveBatch = (
   general: INewRound,
   totals: IRoundTotals,
   currentRoundDistances: IDistance[],
-  holes: IShots[]
+  holes: IShots[],
+  scoreDifferential?: number | null
 ): string => {
   const playerRoundsCollectionRef = collection(db, 'players', userId, 'rounds');
   const roundRef = doc(playerRoundsCollectionRef);
@@ -98,6 +99,7 @@ export const prepareRoundSaveBatch = (
     totals: totals,
     distances: currentRoundDistances,
     userId: userId,
+    scoreDifferential: scoreDifferential ?? null,
     roundDate: general.roundDate ? Timestamp.fromDate(new Date(general.roundDate)) : serverTimestamp(),
     createdAt: serverTimestamp(),
   });

--- a/src/utils/whs/hi.utils.tsx
+++ b/src/utils/whs/hi.utils.tsx
@@ -1,0 +1,100 @@
+/**
+ * WHS Handicap Index calculation utilities.
+ *
+ * WHS Rule 5.2a: Handicap Index = average of lowest N Score Differentials
+ * from the most recent 20 rounds, where N depends on the number of rounds
+ * available (see HI_SCALING table).
+ *
+ * D-04: HI is computed on-the-fly — never stored as a single persisted value.
+ * SIM-03: Projected HI uses a virtual array — no database writes.
+ *
+ * Pattern: Pure functions, no side effects, typed parameters and returns.
+ * Uses safeDivide for all division.
+ *
+ * [CITED: CONTEXT.md canonical refs — WHS Rule 5.2a]
+ */
+
+import { safeDivide } from '@/utils/calculator/math.utils';
+
+/**
+ * WHS Handicap Index scaling table (Rule 5.2a).
+ *
+ * Maps the number of available Score Differentials to the number of
+ * lowest SDs to average.
+ *
+ * | Rounds | SDs to Avg |
+ * |--------|-----------|
+ * | 3-5    | 1         |
+ * | 6-8    | 2         |
+ * | 9-11   | 3         |
+ * | 12-14  | 4         |
+ * | 15-16  | 5         |
+ * | 17-18  | 6         |
+ * | 19     | 7         |
+ * | 20     | 8         |
+ */
+const HI_SCALING: Record<number, number> = {
+	3: 1, 4: 1, 5: 1,
+	6: 2, 7: 2, 8: 2,
+	9: 3, 10: 3, 11: 3,
+	12: 4, 13: 4, 14: 4,
+	15: 5, 16: 5,
+	17: 6, 18: 6,
+	19: 7,
+	20: 8,
+};
+
+/**
+ * Calculate Handicap Index from an array of Score Differentials.
+ *
+ * The input array MUST be sorted with most recent first (descending date),
+ * which matches the existing `roundsList` ordering from Firestore queries.
+ *
+ * @param scoreDifferentials - Array of Score Differentials, most recent first
+ * @returns Handicap Index rounded to 1 decimal place, or null if < 3 valid SDs
+ */
+export const calculateHandicapIndex = (
+	scoreDifferentials: number[]
+): number | null => {
+	const count = Math.min(scoreDifferentials.length, 20);
+
+	if (count < 3) {
+		return null;
+	}
+
+	const toUse = HI_SCALING[count] ?? 1;
+
+	// Take the most recent `count` entries (already in desc date order)
+	const recent = scoreDifferentials.slice(0, count);
+
+	// Sort ascending to find the lowest N SDs
+	const sorted = [...recent].sort((a, b) => a - b);
+	const bestN = sorted.slice(0, toUse);
+
+	return safeDivide(
+		bestN.reduce((sum, sd) => sum + sd, 0),
+		bestN.length,
+		1 // WHS standard: 1 decimal place
+	);
+};
+
+/**
+ * Calculate projected Handicap Index with a simulated Score Differential.
+ *
+ * Creates a virtual array where the simulated SD is placed as the most recent
+ * round, followed by the last 19 real SDs. Delegates to calculateHandicapIndex.
+ *
+ * Per SIM-03: operates entirely in memory — no database writes.
+ *
+ * @param currentSDs - Current Score Differentials, most recent first
+ * @param simulatedSD - The simulated Score Differential to project
+ * @returns Projected Handicap Index, or null if the virtual array has < 3 SDs
+ */
+export const calculateProjectedHandicapIndex = (
+	currentSDs: number[],
+	simulatedSD: number
+): number | null => {
+	// Virtual array: simulated SD as most recent + up to 19 real SDs
+	const virtual = [simulatedSD, ...currentSDs.slice(0, 19)];
+	return calculateHandicapIndex(virtual);
+};

--- a/src/utils/whs/whs.utils.tsx
+++ b/src/utils/whs/whs.utils.tsx
@@ -1,0 +1,83 @@
+/**
+ * WHS Score Differential and Playing Handicap utilities.
+ *
+ * WHS Rule 5.1: Score Differential = (AGS - CR - PCC) × (113 / SR)
+ *   - AGS = PAR + Playing HCP + (36 - Stableford points)
+ *   - PCC = 0 (Playing Conditions Calculation — always 0 per project scope)
+ *
+ * D-09: Playing HCP = HI × (SR / 113) + (CR - PAR)
+ *
+ * Pattern: Typed Props interface → pure function → typed return.
+ * Uses safeDivide from the existing math utilities.
+ *
+ * [CITED: CONTEXT.md canonical refs]
+ */
+
+import { safeDivide } from '@/utils/calculator/math.utils';
+
+export interface IScoreDifferentialProps {
+	par: number;
+	courseRating: number;
+	slopeRating: number;
+	stablefordPoints: number;
+	playingHCP: number;
+}
+
+export interface IScoreDifferentialResult {
+	adjustedGrossScore: number;
+	scoreDifferential: number;
+}
+
+/**
+ * Calculate WHS Score Differential per Rule 5.1.
+ *
+ * SD = Math.max(0, (AGS - CR) × 113 / SR)
+ * AGS = PAR + Playing HCP + (36 - Stableford points)
+ * PCC = 0 (always)
+ *
+ * @param props - Input parameters (par, courseRating, slopeRating, stablefordPoints, playingHCP)
+ * @returns Object with adjustedGrossScore and scoreDifferential (1 decimal place)
+ */
+export const calculateScoreDifferential = (
+	props: IScoreDifferentialProps
+): IScoreDifferentialResult => {
+	const { par, courseRating, slopeRating, stablefordPoints, playingHCP } = props;
+
+	const adjustedGrossScore = par + playingHCP + (36 - stablefordPoints);
+
+	const rawSD = safeDivide(
+		(adjustedGrossScore - courseRating) * 113,
+		slopeRating,
+		1 // WHS standard: 1 decimal place
+	);
+
+	const scoreDifferential = Math.max(0, rawSD);
+
+	return {
+		adjustedGrossScore,
+		scoreDifferential,
+	};
+};
+
+/**
+ * Calculate Playing Handicap per D-09 formula.
+ *
+ * Playing HCP = HI × (SR / 113) + (CR - PAR)
+ * Result is rounded to the nearest integer.
+ *
+ * @param handicapIndex - The player's Handicap Index
+ * @param courseRating - Course Rating of the selected teebox
+ * @param slopeRating - Slope Rating of the selected teebox
+ * @param par - Par of the course/teebox
+ * @returns Rounded Playing Handicap as an integer
+ */
+export const calculatePlayingHandicap = (
+	handicapIndex: number,
+	courseRating: number,
+	slopeRating: number,
+	par: number
+): number => {
+	return Math.round(
+		handicapIndex * (slopeRating / 113) + (courseRating - par)
+	);
+};


### PR DESCRIPTION
## Summary

Complete restructure of the app layout and navigation:

### Layout Changes
- **Removed AppBar** — replaced with permanent mini variant drawer
- **Collapsed drawer** (default): shows hamburger + nav icons + avatar
- **Expanded drawer** (toggle): shows icons + labels; auto-closes on nav click
- **Drawer footer**: avatar + name + settings/theme on left, logout on right — always visible, no scrolling
- **Main content**: PGS title + breadcrumbs stacked above page content; scrolls independently
- Fixed drawer overflow behavior — page scrolls, drawer stays fixed

### Bugfixes
- Fixed `$isGood` DOM prop warning in ScoreChip/PointsChip (Rounds + RoundsDataHeader)
- Fixed avatar not appearing due to sx prop ordering

### Federgolf Import (admin)
- HTML parser for Federgolf course search results
- CORS proxy fallback chain
- Firestore batch upsert with preview dialog
- Import button in CoursesTable admin panel

### Other
- "Simulator" renamed to "HCP Simulator" in nav + breadcrumbs
- Added `federgolf-import.utils.ts` import utility