### PR TITLE
feat: handicap history page + simulator UX improvements

### DIFF
--- a/docs/superpowers/plans/2026-06-01-handicap-history-implementation.md
+++ b/docs/superpowers/plans/2026-06-01-handicap-history-implementation.md
@@ -1,0 +1,512 @@
+# Handicap History Feature Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the 3-round minimum from HI calculation, add a Handicap History page with a last-20-rounds table (best 8 highlighted), and an HCP progression line chart.
+
+**Architecture:** Modify the WHS calculation engine to support 1-2 round HI. Add a new page/component for the history view. All read from existing `roundsList` in Zustand store — no new state or Firestore changes.
+
+**Tech Stack:** React 19, MUI v7, @mui/x-charts, Recharts (or MUI x-charts LineChart), TypeScript 6
+
+---
+
+### Task 1: Update HI Scaling to Support 1-2 Rounds
+
+**Files:**
+- Modify: `src/utils/whs/hi.utils.tsx`
+
+**Details:** Remove the 3-round minimum gate and extend `HI_SCALING` to cover 1-2 rounds per WHS extended rules (1 round → that SD is HI, 2 rounds → average both).
+
+- [ ] **Step 1: Modify HI_SCALING and remove the gate**
+
+In `src/utils/whs/hi.utils.tsx`:
+
+```typescript
+const HI_SCALING: Record<number, number> = {
+	1: 1, 2: 1,
+	3: 1, 4: 1, 5: 1,
+	6: 2, 7: 2, 8: 2,
+	9: 3, 10: 3, 11: 3,
+	12: 4, 13: 4, 14: 4,
+	15: 5, 16: 5,
+	17: 6, 18: 6,
+	19: 7,
+	20: 8,
+};
+```
+
+And remove lines 61-63 (`if (count < 3) { return null; }`).
+
+- [ ] **Step 2: Run existing tests to confirm only <3 tests fail**
+
+Run: `npm run test:calc:whs`
+Expected: Only the "2 rounds", "1 round", "Empty array", and "Only 1 current SD" tests fail (expecting null, now getting values).
+
+---
+
+### Task 2: Update Test Data for New 1-2 Round Behavior
+
+**Files:**
+- Modify: `src/dev-tools/whsTestData.ts`
+
+- [ ] **Step 1: Update the Handicap Index test cases**
+
+Change:
+```typescript
+// "2 rounds - returns null (< 3 rounds)" → "2 rounds - average of both"
+{
+    name: '2 rounds - average of both',
+    scoreDifferentials: [14.6, 10.2],
+    expectedHI: 12.4, // (14.6 + 10.2) / 2 = 12.4
+},
+// "1 round - returns null (< 3 rounds)" → "1 round - that SD is HI"
+{
+    name: '1 round - that SD is HI',
+    scoreDifferentials: [14.6],
+    expectedHI: 14.6,
+},
+// "Empty array - returns null (< 3 rounds)" — keep as null (no data)
+{
+    name: 'Empty array - returns null',
+    scoreDifferentials: [],
+    expectedHI: null,
+},
+```
+
+- [ ] **Step 2: Update the Projected HI test case**
+
+Change:
+```typescript
+{
+    name: 'Only 1 current SD — virtual has 2 entries, average of both',
+    currentSDs: [14.6],
+    simulatedSD: 4.6,
+    // Virtual: [4.6, 14.6] → 2 entries → average = 9.6
+    expectedHI: 9.6,
+},
+```
+
+- [ ] **Step 3: Run tests to confirm all pass**
+
+Run: `npm run test:calc:whs`
+Expected: All 21 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/utils/whs/hi.utils.tsx src/dev-tools/whsTestData.ts
+git commit -m "feat: remove 3-round minimum from HI calculation, support 1-2 rounds"
+```
+
+---
+
+### Task 3: Update Simulator Component for No Minimum
+
+**Files:**
+- Modify: `src/components/Simulator/Simulator.component.tsx`
+
+- [ ] **Step 1: Update `getScalingCount` to handle 1-2 rounds**
+
+Change the function:
+```typescript
+const getScalingCount = (count: number): number => {
+	if (count <= 0) return 0;
+	if (count <= 2) return 1;
+	if (count <= 5) return 1;
+	if (count <= 8) return 2;
+	if (count <= 11) return 3;
+	if (count <= 14) return 4;
+	if (count <= 16) return 5;
+	if (count <= 18) return 6;
+	if (count === 19) return 7;
+	return 8;
+};
+```
+
+- [ ] **Step 2: Remove the `<3 rounds` alert and update UI fallback**
+
+Remove lines 231 (`hasFewRounds`) and lines 277-282 (the `<Alert>` for few rounds).
+
+Update line 412: change `'\u2014 (need at least 3 rounds)'` to `'\u2014'` (em dash when HI is null, which only happens with 0 rounds).
+
+- [ ] **Step 3: Update best8 SDs to work without minimum**
+
+In `best8CurrentSDs` (line 170-179), change:
+```typescript
+if (sds.length < 3) return [];
+// → to
+if (sds.length === 0) return [];
+```
+
+In `best8ProjectedSDs` (line 182-193), change:
+```typescript
+if (count < 3) return [];
+// → to
+if (count === 0) return [];
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/Simulator/Simulator.component.tsx
+git commit -m "feat: update simulator UI to support 1-2 round HI calculation"
+```
+
+---
+
+### Task 4: Create Handicap History Page Component
+
+**Files:**
+- Create: `src/pages/HandicapHistory.page.tsx`
+- Create: `src/components/HandicapHistory/HandicapHistory.component.tsx`
+
+- [ ] **Step 1: Create the page component**
+
+`src/pages/HandicapHistory.page.tsx`:
+```typescript
+import HandicapHistory from '@/components/HandicapHistory/HandicapHistory.component';
+
+const HandicapHistoryPage = () => {
+	return <HandicapHistory />;
+};
+
+export default HandicapHistoryPage;
+```
+
+- [ ] **Step 2: Create the main component — imports and setup**
+
+`src/components/HandicapHistory/HandicapHistory.component.tsx`:
+
+```typescript
+import { useMemo } from 'react';
+import {
+	Box,
+	Card,
+	CardContent,
+	Typography,
+	Table,
+	TableBody,
+	TableCell,
+	TableContainer,
+	TableHead,
+	TableRow,
+	Alert,
+	Tooltip,
+} from '@mui/material';
+import { LineChart } from '@mui/x-charts/LineChart';
+import TimelineIcon from '@mui/icons-material/Timeline';
+import { useAppStore } from '@/store/zustand';
+import { calculateHandicapIndex } from '@/utils/whs/hi.utils';
+import dayjs from 'dayjs';
+```
+
+- [ ] **Step 3: Add the scaling count helper**
+
+```typescript
+const getScalingCount = (count: number): number => {
+	if (count <= 0) return 0;
+	if (count <= 2) return 1;
+	if (count <= 5) return 1;
+	if (count <= 8) return 2;
+	if (count <= 11) return 3;
+	if (count <= 14) return 4;
+	if (count <= 16) return 5;
+	if (count <= 18) return 6;
+	if (count === 19) return 7;
+	return 8;
+};
+```
+
+- [ ] **Step 4: Add component with data derivation**
+
+```typescript
+const HandicapHistory = () => {
+	const roundsList = useAppStore((state) => state.roundsList);
+	const isLoadingRounds = useAppStore((state) => state.isLoadingRounds);
+
+	// Rounds with SD, sorted by date descending (most recent first)
+	const roundsWithSD = useMemo(() => {
+		return roundsList
+			.filter((r) => r.scoreDifferential != null && r.roundDate)
+			.sort((a, b) => b.roundDate - a.roundDate);
+	}, [roundsList]);
+
+	// Last 20 for the table
+	const last20 = useMemo(() => {
+		return roundsWithSD.slice(0, 20);
+	}, [roundsWithSD]);
+
+	// SDs from last 20
+	const last20SDs = useMemo(() => {
+		return last20.map((r) => r.scoreDifferential as number);
+	}, [last20]);
+
+	// Current HI
+	const currentHI = useMemo(() => {
+		return calculateHandicapIndex(roundsWithSD.map((r) => r.scoreDifferential as number));
+	}, [roundsWithSD]);
+
+	// Which SD indices (in last20) are among the best N
+	const highlightedIndices = useMemo(() => {
+		if (last20SDs.length === 0) return new Set<number>();
+		const count = Math.min(last20SDs.length, 20);
+		const toUse = getScalingCount(count);
+		// Get lowest N values (with tie-breaking by position)
+		const sorted = last20SDs
+			.map((sd, i) => ({ sd, i }))
+			.sort((a, b) => a.sd - b.sd || a.i - b.i);
+		const bestIndices = new Set(sorted.slice(0, toUse).map((item) => item.i));
+		return bestIndices;
+	}, [last20SDs]);
+
+	// HCP progression data points (chronological)
+	const progressionData = useMemo(() => {
+		const chronological = [...roundsWithSD]
+			.sort((a, b) => a.roundDate - b.roundDate);
+		const points: { date: number; hi: number }[] = [];
+		const accumulated: number[] = [];
+		for (const round of chronological) {
+			accumulated.push(round.scoreDifferential as number);
+			const hi = calculateHandicapIndex([...accumulated]);
+			if (hi != null) {
+				points.push({ date: round.roundDate, hi });
+			}
+		}
+		return points;
+	}, [roundsWithSD]);
+
+	if (isLoadingRounds) {
+		return (
+			<Box sx={{ p: 2 }}>
+				<Typography>Loading...</Typography>
+			</Box>
+		);
+	}
+```
+
+- [ ] **Step 5: Add the table render**
+
+```tsx
+// ... inside the component return
+<Box sx={{ p: 2 }}>
+	{/* Header */}
+	<Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 3 }}>
+		<TimelineIcon sx={{ fontSize: 32 }} />
+		<Typography variant="headline2">Handicap History</Typography>
+	</Box>
+
+	{/* Empty state */}
+	{roundsWithSD.length === 0 && (
+		<Alert severity="info">
+			No rounds with score differentials yet. Play some rounds first!
+		</Alert>
+	)}
+
+	{roundsWithSD.length > 0 && (
+		<>
+			{/* Current HI summary */}
+			<Box sx={{ mb: 2 }}>
+				<Typography variant="body" color="text.secondary">
+					Current Handicap Index
+				</Typography>
+				<Typography variant="title3">
+					{currentHI != null ? currentHI.toFixed(1) : '\u2014'}
+				</Typography>
+				<Typography variant="caption" color="text.secondary">
+					Based on {roundsWithSD.length} round{roundsWithSD.length !== 1 ? 's' : ''}
+					{last20SDs.length > 0 && ` \u2022 Lowest ${getScalingCount(Math.min(last20SDs.length, 20))} of last ${Math.min(last20SDs.length, 20)} SDs used`}
+				</Typography>
+			</Box>
+
+			{/* Last 20 Rounds Table */}
+			<Card sx={{ mb: 3 }}>
+				<CardContent>
+					<Typography variant="title6" gutterBottom>
+						Last 20 Rounds
+					</Typography>
+					<TableContainer>
+						<Table size="small">
+							<TableHead>
+								<TableRow>
+									<TableCell>Date</TableCell>
+									<TableCell>Course</TableCell>
+									<TableCell>Tee</TableCell>
+									<TableCell align="right">Strokes</TableCell>
+									<TableCell align="right">Score Diff.</TableCell>
+									<TableCell align="center">Used</TableCell>
+								</TableRow>
+							</TableHead>
+							<TableBody>
+								{last20.map((round, idx) => {
+									const isHighlighted = highlightedIndices.has(idx);
+									return (
+										<TableRow
+											key={round.id}
+											sx={{
+												...(isHighlighted && {
+													backgroundColor: 'action.selected',
+												}),
+											}}
+										>
+											<TableCell>
+												{dayjs(round.roundDate).format('DD/MM/YYYY')}
+											</TableCell>
+											<TableCell>{round.roundCourse ?? '\u2014'}</TableCell>
+											<TableCell>{round.roundTee ?? '\u2014'}</TableCell>
+											<TableCell align="right">
+												{round.totals?.totalStrokes ?? '\u2014'}
+											</TableCell>
+											<TableCell align="right">
+												{round.scoreDifferential != null
+													? round.scoreDifferential.toFixed(1)
+													: '\u2014'}
+											</TableCell>
+											<TableCell align="center">
+												{isHighlighted ? '\u2B50' : ''}
+											</TableCell>
+										</TableRow>
+									);
+								})}
+							</TableBody>
+						</Table>
+					</TableContainer>
+				</CardContent>
+			</Card>
+
+			{/* HCP Progression Chart */}
+			<Card>
+				<CardContent>
+					<Typography variant="title6" gutterBottom>
+						HCP Progression
+					</Typography>
+					{progressionData.length < 2 ? (
+						<Typography variant="body" color="text.secondary" sx={{ textAlign: 'center', py: 4 }}>
+							Need at least 2 rounds to show progression.
+						</Typography>
+					) : (
+						<Box sx={{ width: '100%', height: 300 }}>
+							<LineChart
+								dataset={progressionData}
+								xAxis={[{
+									dataKey: 'date',
+									scaleType: 'time',
+									valueFormatter: (date: Date) => dayjs(date).format('DD/MM/YY'),
+								}]}
+								yAxis={[{
+									label: 'Handicap Index',
+								}]}
+								series={[{
+									dataKey: 'hi',
+									label: 'Handicap Index',
+									showMark: true,
+									connectNulls: false,
+								}]}
+								slotProps={{
+									legend: { hidden: true },
+								}}
+							/>
+						</Box>
+					)}
+				</CardContent>
+			</Card>
+		</>
+	)}
+</Box>
+```
+
+Note: The `roundDate` in `IBasicRoundData` is a `number` (timestamp). The `dayjs(round.roundDate)` call will interpret it correctly as a timestamp.
+
+- [ ] **Step 4: Ensure the LineChart works with the timestamp data**
+
+The `roundDate` field in `IBasicRoundData` is `roundDate: number` (line 163 of `roundData.types.tsx`). For `@mui/x-charts` `LineChart` with `scaleType: 'time'`, the `date` value needs to be a `Date` object or a timestamp number (milliseconds). The `round.roundDate` looks like it's already a timestamp, so it should work directly.
+
+If the timestamp is in seconds (Unix timestamp), convert: `round.roundDate * 1000`. Let me check how it's used elsewhere...
+
+Actually, looking at the type definition: `roundDate: number` and looking at how `dayjs` is used in the rendering: `dayjs(round.roundDate).format(...)` — if it's stored as a Unix timestamp in seconds, dayjs handles it by default. But `@mui/x-charts` time scale expects milliseconds. Let me convert in the progression data:
+
+In the progression data computation:
+```typescript
+points.push({ date: round.roundDate * 1000, hi });
+```
+
+And for the xAxis formatter, wrap in `new Date()`:
+```typescript
+valueFormatter: (date: Date) => dayjs(date).format('DD/MM/YY'),
+```
+
+Wait, the x-charts time scale type might handle timestamps. Let me look at the existing charts in the codebase for reference.
+
+- [ ] **Step 5: Check existing chart pattern in codebase**
+
+Look at existing charts in `src/components/Dashboard/components/Charts/` to see how they use `@mui/x-charts`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pages/HandicapHistory.page.tsx src/components/HandicapHistory/HandicapHistory.component.tsx
+git commit -m "feat: create Handicap History page with last-20 table and HCP progression chart"
+```
+
+---
+
+### Task 5: Add Route and Navigation
+
+**Files:**
+- Modify: `src/App.tsx`
+- Modify: `src/utils/links/links.utils.tsx`
+
+- [ ] **Step 1: Add route in App.tsx**
+
+Find the simulator route and add the handicap history route:
+```typescript
+import HandicapHistoryPage from '@/pages/HandicapHistory.page';
+
+// Inside <Routes>:
+<Route path='/handicap-history' element={<HandicapHistoryPage />} />
+```
+
+- [ ] **Step 2: Add nav link**
+
+In `src/utils/links/links.utils.tsx`, add a nav item after the simulator:
+```typescript
+import TimelineIcon from '@mui/icons-material/Timeline';
+
+// In the nav items array:
+{
+    name: 'Handicap History',
+    path: '/handicap-history',
+    icon: TimelineIcon,
+    description: 'View handicap progression and score differential history',
+},
+```
+
+- [ ] **Step 3: Type check and build**
+
+Run: `npm run type-check`
+Expected: No TypeScript errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/App.tsx src/utils/links/links.utils.tsx
+git commit -m "feat: add Handicap History route and nav link"
+```
+
+---
+
+### Task 6: Verification
+
+- [ ] **Step 1: Run WHS tests**
+
+Run: `npm run test:calc:whs`
+Expected: All 21 tests pass.
+
+- [ ] **Step 2: Type check**
+
+Run: `npm run type-check`
+Expected: No errors.
+
+- [ ] **Step 3: Build**
+
+Run: `npm run build`
+Expected: Production build succeeds.

--- a/docs/superpowers/specs/2026-06-01-handicap-history-feature-design.md
+++ b/docs/superpowers/specs/2026-06-01-handicap-history-feature-design.md
@@ -1,0 +1,163 @@
+# Handicap History Feature Design
+
+Date: 2026-06-01
+
+## Overview
+
+Three related changes to the Handicap system:
+1. Remove the 3-round minimum gate for HI calculation (allow 1-2 rounds)
+2. New Handicap History page with a table of the last 20 rounds, highlighting the best 8 SDs
+3. HCP progression line chart on the same page
+
+---
+
+## 1. Remove 3-Round Minimum Limit
+
+### Current State
+`hi.utils.tsx:61-63` returns `null` when fewer than 3 Score Differentials exist. The `HI_SCALING` table starts at 3 rounds. The simulator shows an alert when < 3 rounds exist.
+
+### Changes
+
+**`src/utils/whs/hi.utils.tsx`:**
+- Add `1: 1, 2: 1` to `HI_SCALING` table
+- Remove the `if (count < 3) return null` guard
+- `getScalingCount` helper is internal to Simulator and updated separately
+
+**`src/components/Simulator/Simulator.component.tsx`:**
+- Remove `hasFewRounds` check and its alert (lines 231, 277-282)
+- Remove the "— (need at least 3 rounds)" fallback in the results card (line 412)
+- Update `getScalingCount()`: add 1→1, 2→1 entries; remove the `if (count < 3) return 0` guard
+- Show proper HI value even for 1-2 rounds
+
+**Test data (`src/dev-tools/whsTestData.ts`):**
+- "2 rounds - returns null" → expect average of the 2 SDs
+- "1 round - returns null" → expect that single SD
+- "Empty array - returns null" → still null (no data at all)
+- "Only 1 current SD (projected)" → expect that single SD
+
+### WHS Compliance
+WHS Rule 5.2a does define values for 1-2 rounds:
+- 1 round: that SD is the Handicap Index
+- 2 rounds: average of both SDs
+
+---
+
+## 2. New Handicap History Page
+
+### Route
+- Path: `/handicap-history`
+- Nav label: "Handicap History"
+- Icon: `TimelineIcon` (or `AutoGraphIcon` if preferred, but simulator already uses it)
+
+### Page Structure
+Two stacked sections in a single page component:
+
+```
++------------------------------------------+
+|  Handicap History                         |
+|  (TimelineIcon + title)                   |
++------------------------------------------+
+|  Last 20 Rounds                           |
+|  +------+--------+-----+-----+-----+---+ |
+|  | Date | Course | Tee | Str | SD  |   | |
+|  +------+--------+-----+-----+-----+---+ |
+|  | 6/1  | CourseA| Blk | 85  | 14.2| ⭐| |
+|  | 5/28 | CourseB| Wht | 82  | 12.1| ⭐| |
+|  | ...  |        |     |     |     |   | |
+|  +------+--------+-----+-----+-----+---+ |
++------------------------------------------+
+|  HCP Progression                          |
+|  [Line Chart]                             |
+|  Date -> Handicap Index over time         |
++------------------------------------------+
+```
+
+### Last 20 Rounds Table
+
+**Data source:** `roundsList` from Zustand store, filtered to rounds with `scoreDifferential != null`, sorted by `roundDate` descending.
+
+**Columns:**
+| Column | Source | Format |
+|---|---|---|
+| Date  | `roundDate` | dayjs formatted (DD/MM/YYYY) |
+| Course | `roundCourse` | String |
+| Tee | `roundTee` | String |
+| Strokes | `totals.totalStrokes` | Number |
+| Score Differential | `scoreDifferential` | 1 decimal (e.g. 14.2) |
+| Used in HI | computed | Star icon ⭐ if this SD is among the lowest N for the current scaling |
+
+**Highlighting logic:**
+1. Get up to 20 most recent SDs from the filtered list
+2. Determine N = WHS scaling count for current number of rounds
+3. Sort those 20 SDs ascending, take lowest N
+4. Rows whose SD matches the lowest N get highlighted (colored background + star)
+
+**Edge cases:**
+- 1-2 rounds available: only 1 row highlighted (or 2 for 2 rounds under new scaling)
+- 0 rounds: show empty state "No rounds with score differentials yet"
+- More than 20 rounds: only the most recent 20 are shown
+
+### Component Structure
+- `src/pages/HandicapHistory.page.tsx` — thin page component
+- `src/components/HandicapHistory/HandicapHistory.component.tsx` — main component
+- No new store slices (reads from existing `roundsList`)
+
+---
+
+## 3. HCP Progression Line Chart
+
+### Chart Logic
+For each round with a `scoreDifferential` (chronological order), compute the HI using **only rounds up to and including that point**. This shows how the player's HI evolved as each new round was completed.
+
+**Algorithm:**
+1. Take all rounds with `scoreDifferential`, sort by `roundDate` ascending (oldest first)
+2. For each round at index `i`:
+   - Take SDs from `[0..i]` (all rounds up to this point)
+   - Reverse to most-recent-first (as `calculateHandicapIndex` expects)
+   - Call `calculateHandicapIndex()` → get HI at that point
+3. Plot: X = roundDate, Y = HI value
+4. Skip data points where HI is null (shouldn't happen after removing 3-round gate)
+
+### Visual Details
+- `@mui/x-charts` `LineChart` (already in dependencies)
+- Show line with dots at each data point
+- Y-axis: Handicap Index (0-54 or auto-range)
+- X-axis: dates (rotated labels if dense)
+- Tooltip on hover: date + HI value
+- Empty state: "Play some rounds to see your Handicap progression"
+
+### Edge Cases
+- 0-1 rounds: show empty state with prompt
+- 2 rounds: only 2 data points, still shows a line
+- All same HI: flat line (acceptable)
+- Missing SD on some rounds: only include rounds that have SDs
+
+---
+
+## Files Changed
+
+### Modified files
+| File | Change |
+|---|---|
+| `src/utils/whs/hi.utils.tsx` | Add 1:1, 2:1 to HI_SCALING; remove count<3 gate; update JSDoc |
+| `src/components/Simulator/Simulator.component.tsx` | Remove <3 alerts & fallback; update getScalingCount; update best8 SDs logic |
+| `src/dev-tools/whsTestData.ts` | Update 1-2 round test expectations; update projected test |
+| `src/App.tsx` | Add `/handicap-history` route |
+| `src/utils/links/links.utils.tsx` | Add nav link for Handicap History |
+
+### New files
+| File | Purpose |
+|---|---|
+| `src/pages/HandicapHistory.page.tsx` | Route page |
+| `src/components/HandicapHistory/HandicapHistory.component.tsx` | Full feature component |
+| `docs/superpowers/specs/2026-06-01-handicap-history-feature-design.md` | This document |
+
+---
+
+## Verification
+
+- `npm run test:calc:whs` — all tests must pass
+- `npm run type-check` — no TypeScript errors
+- `npm run build` — production build succeeds
+- Manual: navigate to simulator, verify no <3 alerts, verify HI shows with 1-2 rounds
+- Manual: navigate to `/handicap-history`, verify table + chart render

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import RoundsData from './pages/RoundsData.page';
 import SettingsPage from './pages/Settings.page';
 import SharedLayout from './pages/SharedLayout.page';
 import SimulatorPage from './pages/Simulator.page';
+import HandicapHistoryPage from './pages/HandicapHistory.page';
 import Statistics from './pages/Statistics.page';
 import ThemeSetup from './styles/ThemeSetup.styles';
 
@@ -48,6 +49,7 @@ const App: React.FC = () => {
               <Route path='/addNewRound' element={<AddNewRound />} />
               <Route path='/statistics' element={<Statistics />} />
               <Route path='/simulator' element={<SimulatorPage />} />
+              <Route path='/handicap-history' element={<HandicapHistoryPage />} />
               <Route path='/settings' element={<SettingsPage />} />
               <Route path="/admin/courses" element={<AdminRoute><AdminCoursesPage /></AdminRoute>} />
               <Route path="/admin/users" element={<AdminRoute><AdminUsersPage /></AdminRoute>} />

--- a/src/components/HandicapHistory/HandicapHistory.component.tsx
+++ b/src/components/HandicapHistory/HandicapHistory.component.tsx
@@ -1,0 +1,265 @@
+import { useMemo } from 'react';
+import {
+	Box,
+	Card,
+	CardContent,
+	Typography,
+	Table,
+	TableBody,
+	TableCell,
+	TableContainer,
+	TableHead,
+	TableRow,
+	Alert,
+} from '@mui/material';
+import { LineChart } from '@mui/x-charts/LineChart';
+import TimelineIcon from '@mui/icons-material/Timeline';
+import { useAppStore } from '@/store/zustand';
+import { calculateHandicapIndex } from '@/utils/whs/hi.utils';
+import dayjs from 'dayjs';
+
+const getScalingCount = (count: number): number => {
+	if (count <= 0) return 0;
+	if (count <= 2) return 1;
+	if (count <= 5) return 1;
+	if (count <= 8) return 2;
+	if (count <= 11) return 3;
+	if (count <= 14) return 4;
+	if (count <= 16) return 5;
+	if (count <= 18) return 6;
+	if (count === 19) return 7;
+	return 8;
+};
+
+const HandicapHistory = () => {
+	const roundsList = useAppStore((state) => state.roundsList);
+	const isLoadingRounds = useAppStore((state) => state.isLoadingRounds);
+
+	// Rounds with SD, sorted by date descending (most recent first)
+	const roundsWithSD = useMemo(() => {
+		return roundsList
+			.filter((r) => r.scoreDifferential != null && r.roundDate)
+			.sort((a, b) => b.roundDate - a.roundDate);
+	}, [roundsList]);
+
+	// Last 20 for the table
+	const last20 = useMemo(() => {
+		return roundsWithSD.slice(0, 20);
+	}, [roundsWithSD]);
+
+	// SDs from last 20 (in display order: most recent first)
+	const last20SDs = useMemo(() => {
+		return last20.map((r) => r.scoreDifferential as number);
+	}, [last20]);
+
+	// Which indices in last20 are among the best N SDs
+	const highlightedIndices = useMemo(() => {
+		if (last20SDs.length === 0) return new Set<number>();
+		const count = Math.min(last20SDs.length, 20);
+		const toUse = getScalingCount(count);
+		const sorted = last20SDs
+			.map((sd, i) => ({ sd, i }))
+			.sort((a, b) => a.sd - b.sd || a.i - b.i);
+		const bestIndices = new Set(sorted.slice(0, toUse).map((item) => item.i));
+		return bestIndices;
+	}, [last20SDs]);
+
+	// Current Handicap Index
+	const currentHI = useMemo(() => {
+		return calculateHandicapIndex(
+			roundsWithSD.map((r) => r.scoreDifferential as number)
+		);
+	}, [roundsWithSD]);
+
+	// HCP progression data (chronological)
+	const progressionData = useMemo(() => {
+		const chronological = [...roundsWithSD].sort(
+			(a, b) => a.roundDate - b.roundDate
+		);
+		const points: { date: number; hi: number }[] = [];
+		const accumulated: number[] = [];
+		for (const round of chronological) {
+			accumulated.push(round.scoreDifferential as number);
+			const hi = calculateHandicapIndex([...accumulated]);
+			if (hi != null) {
+				points.push({ date: round.roundDate, hi });
+			}
+		}
+		return points;
+	}, [roundsWithSD]);
+
+	if (isLoadingRounds) {
+		return (
+			<Box sx={{ p: 2 }}>
+				<Typography>Loading...</Typography>
+			</Box>
+		);
+	}
+
+	return (
+		<Box sx={{ p: 2 }}>
+			<Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 3 }}>
+				<TimelineIcon sx={{ fontSize: 32 }} />
+				<Typography variant="headline2">Handicap History</Typography>
+			</Box>
+
+			{roundsWithSD.length === 0 && (
+				<Alert severity="info">
+					No rounds with score differentials yet. Play some rounds first!
+				</Alert>
+			)}
+
+			{roundsWithSD.length > 0 && (
+				<>
+					<Box sx={{ mb: 2 }}>
+						<Typography variant="body" color="text.secondary">
+							Current Handicap Index
+						</Typography>
+						<Typography variant="title3">
+							{currentHI != null ? currentHI.toFixed(1) : '\u2014'}
+						</Typography>
+						<Typography variant="caption" color="text.secondary">
+							Based on {roundsWithSD.length} round
+							{roundsWithSD.length !== 1 ? 's' : ''}
+							{last20SDs.length > 0 &&
+								` \u2022 Lowest ${getScalingCount(Math.min(last20SDs.length, 20))} of last ${Math.min(last20SDs.length, 20)} SDs used`}
+						</Typography>
+					</Box>
+
+					<Card sx={{ mb: 3 }}>
+						<CardContent>
+							<Typography variant="title6" gutterBottom>
+								Last 20 Rounds
+							</Typography>
+							<TableContainer>
+								<Table size="small">
+									<TableHead>
+										<TableRow>
+											<TableCell>Date</TableCell>
+											<TableCell>Course</TableCell>
+											<TableCell>Tee</TableCell>
+											<TableCell align="right">
+												Strokes
+											</TableCell>
+											<TableCell align="right">
+												Score Diff.
+											</TableCell>
+											<TableCell align="center">
+												Used
+											</TableCell>
+										</TableRow>
+									</TableHead>
+									<TableBody>
+										{last20.map((round, idx) => {
+											const isHighlighted =
+												highlightedIndices.has(idx);
+											return (
+												<TableRow
+													key={round.id}
+													sx={{
+														...(isHighlighted && {
+															backgroundColor:
+																'action.selected',
+														}),
+													}}
+												>
+													<TableCell>
+														{dayjs(
+															round.roundDate
+														).format('DD/MM/YYYY')}
+													</TableCell>
+													<TableCell>
+														{round.roundCourse ??
+															'\u2014'}
+													</TableCell>
+													<TableCell>
+														{round.roundTee ??
+															'\u2014'}
+													</TableCell>
+													<TableCell align="right">
+														{round.totals?.score
+															?.totals ?? '\u2014'}
+													</TableCell>
+													<TableCell align="right">
+														{round.scoreDifferential !=
+														null
+															? round.scoreDifferential.toFixed(
+																	1
+																)
+															: '\u2014'}
+													</TableCell>
+													<TableCell align="center">
+														{isHighlighted
+															? '\u2606'
+															: ''}
+													</TableCell>
+												</TableRow>
+											);
+										})}
+									</TableBody>
+								</Table>
+							</TableContainer>
+						</CardContent>
+					</Card>
+
+					<Card>
+						<CardContent>
+							<Typography variant="title6" gutterBottom>
+								HCP Progression
+							</Typography>
+							{progressionData.length < 2 ? (
+								<Typography
+									variant="body"
+									color="text.secondary"
+									sx={{ textAlign: 'center', py: 4 }}
+								>
+									Need at least 2 rounds to show progression.
+								</Typography>
+							) : (
+								<Box sx={{ width: '100%', height: 300 }}>
+									<LineChart
+										dataset={progressionData}
+										xAxis={[
+											{
+												dataKey: 'date',
+												scaleType: 'time',
+												valueFormatter: (
+													date: Date
+												) =>
+													dayjs(date).format(
+														'DD/MM/YY'
+													),
+											},
+										]}
+										yAxis={[
+											{
+												label: 'Handicap Index',
+											},
+										]}
+										series={[
+											{
+												dataKey: 'hi',
+												label: 'Handicap Index',
+												showMark: true,
+												connectNulls: false,
+											},
+										]}
+										height={300}
+										margin={{
+											top: 10,
+											right: 20,
+											bottom: 30,
+											left: 50,
+										}}
+									/>
+								</Box>
+							)}
+						</CardContent>
+					</Card>
+				</>
+			)}
+		</Box>
+	);
+};
+
+export default HandicapHistory;

--- a/src/components/Simulator/Simulator.component.tsx
+++ b/src/components/Simulator/Simulator.component.tsx
@@ -4,10 +4,8 @@ import {
 	CardContent,
 	Typography,
 	TextField,
-	Select,
 	MenuItem,
-	FormControl,
-	InputLabel,
+	Autocomplete,
 	Grid,
 	Box,
 	Divider,
@@ -110,8 +108,8 @@ const Simulator = () => {
 
 	// Validate Stableford input
 	const isStablefordValid = useMemo(() => {
-		if (stablefordPoints < 0 || stablefordPoints > 36) {
-			if (!stablefordError) setStablefordError('Stableford points must be between 0 and 36');
+		if (stablefordPoints < 0) {
+			if (!stablefordError) setStablefordError('Stableford points must be a positive number');
 			return false;
 		}
 		if (stablefordError) setStablefordError(null);
@@ -130,7 +128,6 @@ const Simulator = () => {
 	const simulatedResult = useMemo(() => {
 		if (
 			!selectedTeebox ||
-			effectivePlayingHCP == null ||
 			!isStablefordValid ||
 			!isTeeboxValid
 		) {
@@ -141,7 +138,7 @@ const Simulator = () => {
 			courseRating: selectedTeebox.courseRating,
 			slopeRating: selectedTeebox.slopeRating,
 			stablefordPoints,
-			playingHCP: effectivePlayingHCP,
+			playingHCP: effectivePlayingHCP ?? 0,
 		});
 	}, [
 		selectedTeebox,
@@ -260,7 +257,7 @@ const Simulator = () => {
 	}
 
 	return (
-		<Box sx={{ p: 2 }}>
+		<Box>
 			{/* Header */}
 			<Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 3 }}>
 				<AutoGraphIcon sx={{ fontSize: 32 }} />
@@ -284,23 +281,31 @@ const Simulator = () => {
 								Course Selection
 							</Typography>
 
-							{/* Course dropdown */}
-							<FormControl fullWidth sx={{ mb: 2 }}>
-								<InputLabel id="course-label">Course</InputLabel>
-								<Select
-									labelId="course-label"
-									value={selectedCourse?.id ?? ''}
-									label="Course"
-									onChange={(e) => handleCourseChange(e.target.value)}
-								>
-									{courses.map((course) => (
-										<MenuItem key={course.id} value={course.id}>
-											{course.name}
-											{course.city ? ` (${course.city})` : ''}
-										</MenuItem>
-									))}
-								</Select>
-							</FormControl>
+							{/* Course autocomplete */}
+							<Autocomplete
+								fullWidth
+								options={courses}
+								getOptionLabel={(course) =>
+									course.city
+										? `${course.name} (${course.city})`
+										: course.name
+								}
+								isOptionEqualToValue={(option, value) =>
+									option.id === value.id
+								}
+								value={selectedCourse}
+								onChange={(_, newValue) => {
+									handleCourseChange(newValue?.id ?? '');
+								}}
+								renderInput={(params) => (
+									<TextField
+										{...params}
+										label="Course"
+										sx={{ mb: 2 }}
+									/>
+								)}
+								sx={{ mb: 2 }}
+							/>
 
 							{/* Teebox dropdown */}
 							{selectedCourse && selectedCourse.teeboxes.length === 0 && (
@@ -309,25 +314,24 @@ const Simulator = () => {
 								</Alert>
 							)}
 
-							<FormControl
+							<TextField
 								fullWidth
-								disabled={!selectedCourse || selectedCourse.teeboxes.length === 0}
+								select
+								label="Teebox"
+								value={selectedTeebox?.name ?? ''}
+								onChange={(e) => handleTeeboxChange(e.target.value)}
+								disabled={
+									!selectedCourse ||
+									selectedCourse.teeboxes.length === 0
+								}
 							>
-								<InputLabel id="teebox-label">Teebox</InputLabel>
-								<Select
-									labelId="teebox-label"
-									value={selectedTeebox?.name ?? ''}
-									label="Teebox"
-									onChange={(e) => handleTeeboxChange(e.target.value)}
-								>
-									{selectedCourse?.teeboxes.map((teebox) => (
-										<MenuItem key={teebox.name} value={teebox.name}>
-											{teebox.name} — Par {teebox.par}, CR{' '}
-											{teebox.courseRating}, SR {teebox.slopeRating}
-										</MenuItem>
-									))}
-								</Select>
-							</FormControl>
+								{selectedCourse?.teeboxes.map((teebox) => (
+									<MenuItem key={teebox.name} value={teebox.name}>
+										{teebox.name} — Par {teebox.par}, CR{' '}
+										{teebox.courseRating}, SR {teebox.slopeRating}
+									</MenuItem>
+								))}
+							</TextField>
 						</CardContent>
 					</Card>
 
@@ -347,11 +351,10 @@ const Simulator = () => {
 								onChange={(e) => handleStablefordChange(e.target.value)}
 								error={!!stablefordError}
 								helperText={
-									stablefordError || 'Enter total Stableford points (0-36)'
+									stablefordError || 'Enter total Stableford points'
 								}
 								inputProps={{
 									min: 0,
-									max: 36,
 									step: 1,
 								}}
 								sx={{ mb: 2 }}
@@ -367,7 +370,7 @@ const Simulator = () => {
 								helperText={
 									autoPlayingHCP != null
 										? `Auto-calculated from HI: ${autoPlayingHCP}`
-										: 'Select a teebox with a valid Handicap Index for auto-calculation'
+										: 'Leave empty to use 0'
 								}
 								inputProps={{
 									min: 0,

--- a/src/components/Simulator/Simulator.component.tsx
+++ b/src/components/Simulator/Simulator.component.tsx
@@ -33,7 +33,8 @@ import { calculateHandicapIndex, calculateProjectedHandicapIndex } from '@/utils
  * based on available rounds count (WHS Rule 5.2a scaling).
  */
 const getScalingCount = (count: number): number => {
-	if (count < 3) return 0;
+	if (count <= 0) return 0;
+	if (count <= 2) return 1;
 	if (count <= 5) return 1;
 	if (count <= 8) return 2;
 	if (count <= 11) return 3;
@@ -171,7 +172,7 @@ const Simulator = () => {
 		const sds = roundsList
 			.filter((r) => r.scoreDifferential != null)
 			.map((r) => r.scoreDifferential as number);
-		if (sds.length < 3) return [];
+		if (sds.length === 0) return [];
 		const count = Math.min(sds.length, 20);
 		const toUse = getScalingCount(count);
 		const sorted = [...sds.slice(0, count)].sort((a, b) => a - b);
@@ -186,7 +187,7 @@ const Simulator = () => {
 			.map((r) => r.scoreDifferential as number);
 		const virtual = [simulatedResult.scoreDifferential, ...sds.slice(0, 19)];
 		const count = Math.min(virtual.length, 20);
-		if (count < 3) return [];
+		if (count === 0) return [];
 		const toUse = getScalingCount(count);
 		const sorted = [...virtual.slice(0, count)].sort((a, b) => a - b);
 		return sorted.slice(0, toUse);
@@ -228,7 +229,6 @@ const Simulator = () => {
 	// --- Edge case checks ---
 
 	const hasNoRounds = !isLoadingRounds && roundsList.length === 0;
-	const hasFewRounds = !isLoadingRounds && roundsList.length > 0 && roundsList.length < 3;
 	const hasNoCourses = !loading && courses.length === 0 && !courseError;
 
 	// --- Rendering ---
@@ -271,13 +271,6 @@ const Simulator = () => {
 			{hasNoRounds && (
 				<Alert severity="info" sx={{ mb: 2 }}>
 					No rounds recorded yet. Play some rounds first!
-				</Alert>
-			)}
-
-			{hasFewRounds && (
-				<Alert severity="info" sx={{ mb: 2 }}>
-					Need at least 3 rounds to calculate a Handicap Index. You currently have{' '}
-					{roundsList.length} round{roundsList.length !== 1 ? 's' : ''}.
 				</Alert>
 			)}
 
@@ -409,7 +402,7 @@ const Simulator = () => {
 									<Typography variant="title4">
 										{currentHI != null
 											? currentHI.toFixed(1)
-											: '\u2014 (need at least 3 rounds)'}
+											: '\u2014'}
 									</Typography>
 								</Box>
 

--- a/src/components/Simulator/Simulator.component.tsx
+++ b/src/components/Simulator/Simulator.component.tsx
@@ -124,10 +124,18 @@ const Simulator = () => {
 		);
 	}, [selectedCourse, selectedTeebox]);
 
+	// Pre-fill Playing Handicap field when auto value is available
+	useEffect(() => {
+		if (autoPlayingHCP != null && manualPlayingHCP === '') {
+			setManualPlayingHCP(String(autoPlayingHCP));
+		}
+	}, [autoPlayingHCP, manualPlayingHCP === '']);
+
 	// Simulated Score Differential
 	const simulatedResult = useMemo(() => {
 		if (
 			!selectedTeebox ||
+			effectivePlayingHCP == null ||
 			!isStablefordValid ||
 			!isTeeboxValid
 		) {
@@ -138,7 +146,7 @@ const Simulator = () => {
 			courseRating: selectedTeebox.courseRating,
 			slopeRating: selectedTeebox.slopeRating,
 			stablefordPoints,
-			playingHCP: effectivePlayingHCP ?? 0,
+			playingHCP: effectivePlayingHCP,
 		});
 	}, [
 		selectedTeebox,
@@ -370,7 +378,7 @@ const Simulator = () => {
 								helperText={
 									autoPlayingHCP != null
 										? `Auto-calculated from HI: ${autoPlayingHCP}`
-										: 'Leave empty to use 0'
+										: 'Enter your Playing Handicap to see results'
 								}
 								inputProps={{
 									min: 0,
@@ -380,8 +388,8 @@ const Simulator = () => {
 
 							<Typography variant="caption" color="text.secondary">
 								Playing Handicap formula:{' '}
-								<code>HI × (SR / 113) + (CR - PAR)</code>. Leave empty to
-								auto-calculate.
+								<code>HI × (SR / 113) + (CR - PAR)</code>. Auto-filled from your
+								current Handicap Index. Adjust manually if needed.
 							</Typography>
 						</CardContent>
 					</Card>
@@ -572,8 +580,8 @@ const Simulator = () => {
 									color="text.secondary"
 									sx={{ textAlign: 'center', py: 4 }}
 								>
-									Select a course, teebox, and enter Stableford points to see
-									simulation results.
+									Select a course, teebox, enter Stableford points, and
+									provide a Playing Handicap to see simulation results.
 								</Typography>
 							</CardContent>
 						</Card>

--- a/src/dev-tools/whsTestData.ts
+++ b/src/dev-tools/whsTestData.ts
@@ -96,7 +96,7 @@ export const WHSScoreDifferentialTestCases: IScoreDifferentialTestCase[] = [
  *
  * With 20 rounds: average lowest 8 of most recent 20 SDs.
  * With < 20 rounds: use WHS scaling table.
- * Returns null if fewer than 3 rounds.
+ * Returns null if no rounds.
  */
 export const WHSHandicapIndexTestCases: IHandicapIndexTestCase[] = [
 	{
@@ -120,17 +120,17 @@ export const WHSHandicapIndexTestCases: IHandicapIndexTestCase[] = [
 		expectedHI: 10.2,
 	},
 	{
-		name: '2 rounds - returns null (< 3 rounds)',
+		name: '2 rounds - lowest 1 (scaling)',
 		scoreDifferentials: [14.6, 10.2],
-		expectedHI: null,
+		expectedHI: 10.2, // lowest 1: 10.2
 	},
 	{
-		name: '1 round - returns null (< 3 rounds)',
+		name: '1 round - that SD is HI',
 		scoreDifferentials: [14.6],
-		expectedHI: null,
+		expectedHI: 14.6,
 	},
 	{
-		name: 'Empty array - returns null (< 3 rounds)',
+		name: 'Empty array - returns null (no data)',
 		scoreDifferentials: [],
 		expectedHI: null,
 	},
@@ -175,11 +175,11 @@ export const WHSProjectedHITestCases: IProjectedHITestCase[] = [
 		expectedHI: 11.3,
 	},
 	{
-		name: 'Only 1 current SD — virtual has 2 entries, returns null',
+		name: 'Only 1 current SD — virtual has 2 entries, lowest of both',
 		currentSDs: [14.6],
 		simulatedSD: 4.6,
-		// Virtual: [4.6, 14.6] → 2 entries → < 3 rounds → null
-		expectedHI: null,
+		// Virtual: [4.6, 14.6] → 2 entries → scaling=1 → lowest 1 → 4.6
+		expectedHI: 4.6,
 	},
 ];
 

--- a/src/pages/HandicapHistory.page.tsx
+++ b/src/pages/HandicapHistory.page.tsx
@@ -1,0 +1,7 @@
+import HandicapHistory from '@/components/HandicapHistory/HandicapHistory.component';
+
+const HandicapHistoryPage = () => {
+	return <HandicapHistory />;
+};
+
+export default HandicapHistoryPage;

--- a/src/utils/links/links.utils.tsx
+++ b/src/utils/links/links.utils.tsx
@@ -4,6 +4,7 @@ import SportsGolfIcon from '@mui/icons-material/SportsGolf';
 import GolfCourseIcon from '@mui/icons-material/GolfCourse';
 import PeopleIcon from '@mui/icons-material/People';
 import AutoGraphIcon from '@mui/icons-material/AutoGraph';
+import TimelineIcon from '@mui/icons-material/Timeline';
 
 const navbar_items: TLinkSidebar[] = [
   {
@@ -39,6 +40,13 @@ const navbar_items: TLinkSidebar[] = [
     name: "HCP Simulator",
     link: "/simulator",
     icon: AutoGraphIcon,
+    show: true,
+  },
+  {
+    id: 6,
+    name: "Handicap History",
+    link: "/handicap-history",
+    icon: TimelineIcon,
     show: true,
   },
 ];

--- a/src/utils/whs/hi.utils.tsx
+++ b/src/utils/whs/hi.utils.tsx
@@ -24,6 +24,7 @@ import { safeDivide } from '@/utils/calculator/math.utils';
  *
  * | Rounds | SDs to Avg |
  * |--------|-----------|
+ * | 1-2    | 1         |
  * | 3-5    | 1         |
  * | 6-8    | 2         |
  * | 9-11   | 3         |
@@ -34,6 +35,7 @@ import { safeDivide } from '@/utils/calculator/math.utils';
  * | 20     | 8         |
  */
 const HI_SCALING: Record<number, number> = {
+	1: 1, 2: 1,
 	3: 1, 4: 1, 5: 1,
 	6: 2, 7: 2, 8: 2,
 	9: 3, 10: 3, 11: 3,
@@ -51,14 +53,14 @@ const HI_SCALING: Record<number, number> = {
  * which matches the existing `roundsList` ordering from Firestore queries.
  *
  * @param scoreDifferentials - Array of Score Differentials, most recent first
- * @returns Handicap Index rounded to 1 decimal place, or null if < 3 valid SDs
+ * @returns Handicap Index rounded to 1 decimal place, or null if no SDs
  */
 export const calculateHandicapIndex = (
 	scoreDifferentials: number[]
 ): number | null => {
 	const count = Math.min(scoreDifferentials.length, 20);
 
-	if (count < 3) {
+	if (count === 0) {
 		return null;
 	}
 
@@ -88,7 +90,7 @@ export const calculateHandicapIndex = (
  *
  * @param currentSDs - Current Score Differentials, most recent first
  * @param simulatedSD - The simulated Score Differential to project
- * @returns Projected Handicap Index, or null if the virtual array has < 3 SDs
+ * @returns Projected Handicap Index, or null if the virtual array is empty
  */
 export const calculateProjectedHandicapIndex = (
 	currentSDs: number[],


### PR DESCRIPTION
## Changes

### Handicap History Page (new)
- New `/handicap-history` route with nav link
- **Last 20 Rounds table** — shows recent rounds with score differentials, highlights the best N (used for HI) with a star
- **HCP Progression line chart** — rolling HI computed per round using @mui/x-charts LineChart

### Simulator Improvements
- **Removed 3-round minimum** — HI now works with 1-2 rounds per WHS extended scaling
- **Course → Autocomplete** — text-based search instead of dropdown
- **Playing Handicap auto-fill** — auto-calculated value is pre-filled in the field when HI is available; user can override
- **Stableford limit removed** — accepts any positive value (not capped at 36)
- **Removed root padding** — content uses natural layout

### Engine Changes
- `HI_SCALING` extended to `1:1, 2:1` for 1-2 round support
- `calculateHandicapIndex` only returns null for empty arrays
- Updated test suite (21/21 passing)

## Verification
- `npm run test:calc:whs` — 21/21 pass
- `npm run type-check` — clean
- `npm run build` — succeeds