### PR TITLE
feat: handicap history page, simulator improvements, course autocomplete in add round

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -9,6 +9,7 @@ This roadmap delivers WHS (World Handicap System) handicap calculation, a shared
 - [x] **Phase 1: Course Database & Admin Foundation** - Admin authentication, route protection, golf course CRUD, and the public `golf_courses` collection (completed 2026-05-31)
 - [x] **Phase 2: WHS Engine & Handicap Simulator** - WHS Score Differential and Handicap Index calculation engine plus a dedicated Simulator with course/teebox selection and projected HI display (completed 2026-06-01)
 - [x] **Phase 3: Navigation & Sidebar Reorg** - Move Avatar menu (HCP, settings, logout) to sidebar; fix admin link visibility; make sidebar responsive across all screen sizes (completed 2026-06-01)
+- [ ] **Phase 4: Import Rounds Verification** - Import Federgolf competition results via clipboard paste, match courses, save as real rounds in Firestore for handicap verification (pending)
 
 ## Phase Details
 
@@ -68,11 +69,11 @@ Plans:
 **Requirements**: NAV-01, NAV-02, NAV-03, NAV-04, NAV-05
 **Success Criteria** (what must be TRUE):
 
-  1. Avatar dropdown no longer shows HCP, Settings, or Logout — only the avatar image remains as a visual indicator
-  2. Sidebar drawer is accessible from both mobile and desktop (responsive: temporary on mobile, persistent/toggleable on desktop)
-  3. Sidebar contains: HCP display, Settings link, Logout button (moved from Avatar menu)
-  4. Sidebar properly filters navigation links: public links shown to all users, admin links shown only when `player.isAdmin` is true
-  5. No duplicate link rendering in sidebar (current bug: admin links render twice — once from `links.map()` and once from conditional block)
+   1. Avatar dropdown no longer shows HCP, Settings, or Logout — only the avatar image remains as a visual indicator
+   2. Sidebar drawer is accessible from both mobile and desktop (responsive: temporary on mobile, persistent/toggleable on desktop)
+   3. Sidebar contains: HCP display, Settings link, Logout button (moved from Avatar menu)
+   4. Sidebar properly filters navigation links: public links shown to all users, admin links shown only when `player.isAdmin` is true
+   5. No duplicate link rendering in sidebar (current bug: admin links render twice — once from `links.map()` and once from conditional block)
 
 **Plans**: 2 plans
 **UI hint**: yes
@@ -86,6 +87,33 @@ Plans:
 **Wave 2** *(blocked on Wave 1 completion)*
 
 - [x] 03-02-PLAN.md — Responsive sidebar drawer with filtered links, HCP/Settings/Logout (Wave 2)
+
+### Phase 4: Import Rounds Verification
+
+**Goal**: Enable players to paste Federgolf competition results from a Google Sheet and import them as real rounds in Firestore, with course name matching, for verifying Handicap History and HI calculations
+**Depends on**: Phase 1 (course database), Phase 2 (WHS engine/SD storage)
+**Requirements**: IMPORT-01, IMPORT-02
+**Success Criteria** (what must be TRUE):
+
+   1. User can copy rows from a Google Sheet and paste them into a text area on the Import Rounds page
+   2. The app parses the pasted data, matches course names to the `golf_courses` collection (exact name match first, then LIKE), and finds the matching teebox via CR/SR
+   3. User sees a preview table with all parsed rounds, course match status, and expected Score Differentials before importing
+   4. Imported rounds are saved as real Firestore round documents (not simulated data) — they appear in rounds list, Handicap History, and HI calculations
+   5. Imported rounds have no per-hole shot data (just the round totals + Score Differential)
+   6. After import, the page shows a summary comparing the expected HI (from the sheet's `Index Nuovo`) vs the calculated HI from the app's engine
+
+**Plans**: 2 plans
+**UI hint**: yes
+
+Plans:
+
+**Wave 1**
+
+- [ ] 04-01-PLAN.md — CSV parser, course matcher, round builder, Firestore batch import (Wave 1)
+
+**Wave 2** *(blocked on Wave 1 completion)*
+
+- [ ] 04-02-PLAN.md — Import Rounds page UI: paste form, preview table, import result summary, route, nav link (Wave 2)
 
 ## Progress
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -9,7 +9,7 @@ This roadmap delivers WHS (World Handicap System) handicap calculation, a shared
 - [x] **Phase 1: Course Database & Admin Foundation** - Admin authentication, route protection, golf course CRUD, and the public `golf_courses` collection (completed 2026-05-31)
 - [x] **Phase 2: WHS Engine & Handicap Simulator** - WHS Score Differential and Handicap Index calculation engine plus a dedicated Simulator with course/teebox selection and projected HI display (completed 2026-06-01)
 - [x] **Phase 3: Navigation & Sidebar Reorg** - Move Avatar menu (HCP, settings, logout) to sidebar; fix admin link visibility; make sidebar responsive across all screen sizes (completed 2026-06-01)
-- [ ] **Phase 4: Import Rounds Verification** - Import Federgolf competition results via clipboard paste, match courses, save as real rounds in Firestore for handicap verification (pending)
+- [x] **Phase 4: Import Rounds Verification** - Import Federgolf competition results via clipboard paste, match courses, save as real rounds in Firestore for handicap verification (pending) (completed 2026-06-01)
 
 ## Phase Details
 
@@ -113,7 +113,7 @@ Plans:
 
 **Wave 2** *(blocked on Wave 1 completion)*
 
-- [ ] 04-02-PLAN.md — Import Rounds page UI: paste form, preview table, import result summary, route, nav link (Wave 2)
+- [x] 04-02-PLAN.md — Import Rounds page UI: paste form, preview table, import result summary, route, nav link (Wave 2)
 
 ## Progress
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -109,7 +109,7 @@ Plans:
 
 **Wave 1**
 
-- [ ] 04-01-PLAN.md — CSV parser, course matcher, round builder, Firestore batch import (Wave 1)
+- [x] 04-01-PLAN.md — CSV parser, course matcher, round builder, Firestore batch import (Wave 1)
 
 **Wave 2** *(blocked on Wave 1 completion)*
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,14 +4,14 @@ milestone: v1.0
 milestone_name: milestone
 status: executing
 stopped_at: Completed 03-02-PLAN.md
-last_updated: "2026-06-01T09:35:00.000Z"
-last_activity: 2026-06-01 -- Phase 03 execution completed
+last_updated: "2026-06-01T10:54:46.838Z"
+last_activity: 2026-06-01 -- Phase 04 execution started
 progress:
   total_phases: 4
   completed_phases: 3
   total_plans: 9
   completed_plans: 7
-  percent: 78
+  percent: 75
 ---
 
 # Project State
@@ -21,14 +21,15 @@ progress:
 See: .planning/PROJECT.md (updated 2026-05-31)
 
 **Core value:** Players can accurately calculate their WHS handicap index from their rounds and simulate how future scores would affect it.
-**Current focus:** Phase 04 — import-rounds-verification (planning)
+**Current focus:** Phase 04 — import-rounds-verification
 
 ## Current Position
 
-Phase: 04 (import-rounds-verification) — PLANNING
+Phase: 04 (import-rounds-verification) — EXECUTING
+Plan: 1 of 2
 Plans: 0 of 2 (planned)
-Status: Ready for execution
-Last activity: 2026-06-01 -- Phase 04 planning completed
+Status: Executing Phase 04
+Last activity: 2026-06-01 -- Phase 04 execution started
 
 Progress: [██████████] 100%
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,15 +3,15 @@ gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: milestone
 status: executing
-stopped_at: Completed 03-02-PLAN.md
-last_updated: "2026-06-01T10:54:46.838Z"
-last_activity: 2026-06-01 -- Phase 04 execution started
+stopped_at: Completed 04-02-PLAN.md
+last_updated: "2026-06-01T11:00:00.000Z"
+last_activity: 2026-06-01 -- Phase 04 completed
 progress:
   total_phases: 4
-  completed_phases: 3
-  total_plans: 9
-  completed_plans: 7
-  percent: 75
+  completed_phases: 4
+  total_plans: 11
+  completed_plans: 11
+  percent: 100
 ---
 
 # Project State
@@ -21,15 +21,13 @@ progress:
 See: .planning/PROJECT.md (updated 2026-05-31)
 
 **Core value:** Players can accurately calculate their WHS handicap index from their rounds and simulate how future scores would affect it.
-**Current focus:** Phase 04 — import-rounds-verification
+**Current focus:** Next phase (TBD)
 
 ## Current Position
 
-Phase: 04 (import-rounds-verification) — EXECUTING
-Plan: 1 of 2
-Plans: 0 of 2 (planned)
-Status: Executing Phase 04
-Last activity: 2026-06-01 -- Phase 04 execution started
+Phase: 04 (import-rounds-verification) — COMPLETE
+Plans: 2 of 2 complete
+Status: Phase 04 complete — all milestone phases delivered
 
 Progress: [██████████] 100%
 
@@ -37,7 +35,7 @@ Progress: [██████████] 100%
 
 **Velocity:**
 
-- Total plans completed: 2 (Phase 1)
+- Total plans completed: 11
 - Average duration: —
 - Total execution time: —
 
@@ -48,6 +46,7 @@ Progress: [██████████] 100%
 | 1. Course Database & Admin Foundation | 3/3 | — | — |
 | 2. WHS Engine & Handicap Simulator | 2/2 | — | — |
 | 3. Navigation & Sidebar Reorg | 2/2 | — | — |
+| 4. Import Rounds Verification | 2/2 | — | — |
 
 **Recent Trend:**
 
@@ -55,10 +54,8 @@ Progress: [██████████] 100%
 - Trend: —
 
 *Updated after each plan completion*
-| Phase 02-whs-engine-handicap-simulator P01 | 18min | 3 tasks | 9 files |
-| Phase 02 P02 | 3min | 2 tasks | 5 files |
-| Phase 03-01 P01 | 2min | 2 tasks | 2 files |
-| Phase 03-02 P02 | 2min | 2 tasks | 1 file |
+| Phase 04-01 P01 | — | 4 tasks | 10 files |
+| Phase 04-02 P02 | — | 3 tasks | 11 files |
 
 ## Accumulated Context
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -7,11 +7,11 @@ stopped_at: Completed 03-02-PLAN.md
 last_updated: "2026-06-01T09:35:00.000Z"
 last_activity: 2026-06-01 -- Phase 03 execution completed
 progress:
-  total_phases: 3
+  total_phases: 4
   completed_phases: 3
-  total_plans: 7
+  total_plans: 9
   completed_plans: 7
-  percent: 100
+  percent: 78
 ---
 
 # Project State
@@ -21,14 +21,14 @@ progress:
 See: .planning/PROJECT.md (updated 2026-05-31)
 
 **Core value:** Players can accurately calculate their WHS handicap index from their rounds and simulate how future scores would affect it.
-**Current focus:** Phase 03 — navigation-and-sidebar-reorg (completed 2026-06-01)
+**Current focus:** Phase 04 — import-rounds-verification (planning)
 
 ## Current Position
 
-Phase: 03 (navigation-and-sidebar-reorg) — COMPLETE
-Plans: 2 of 2
-Status: Complete
-Last activity: 2026-06-01 -- Phase 03 execution completed
+Phase: 04 (import-rounds-verification) — PLANNING
+Plans: 0 of 2 (planned)
+Status: Ready for execution
+Last activity: 2026-06-01 -- Phase 04 planning completed
 
 Progress: [██████████] 100%
 

--- a/.planning/phases/04-import-rounds-verification/04-01-PLAN.md
+++ b/.planning/phases/04-import-rounds-verification/04-01-PLAN.md
@@ -1,0 +1,480 @@
+---
+phase: 04-import-rounds-verification
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/components/ImportRounds/ImportRoundParser.utils.ts
+  - src/components/ImportRounds/CourseMatcher.utils.ts
+  - src/components/ImportRounds/RoundBuilder.utils.ts
+  - src/utils/firestore/round.firestore.ts
+  - src/store/zustand/app.store.ts
+autonomous: true
+requirements: [IMPORT-01, IMPORT-02]
+user_setup: []
+
+must_haves:
+  truths:
+    - CSV/TSV text can be parsed into structured round data with auto-detected delimiter and Italian decimal handling
+    - Parsed rounds have course names matched against golf_courses collection (exact, then LIKE, then unmatched)
+    - Matched courses have teebox lookups via CR/SR match
+    - Rounds are built into Firestore-compatible documents with minimal IRoundTotals (score.totals + points.totals only, rest zeroed)
+    - importRoundsBatch writes selected rounds atomically via writeBatch with auto-assigned round numbers
+    - Store holds parsedRounds, importResults, isLoading, error state
+  artifacts:
+    - path: "src/components/ImportRounds/ImportRoundParser.utils.ts"
+      provides: "CSV/TSV parser with delimiter detection, Italian decimal handling, Valida=N filtering"
+      min_lines: 80
+    - path: "src/components/ImportRounds/CourseMatcher.utils.ts"
+      provides: "Course matching (exact → LIKE → unmatched) + teebox CR/SR lookup"
+      min_lines: 60
+    - path: "src/components/ImportRounds/RoundBuilder.utils.ts"
+      provides: "Build Firestore round documents with minimal IRoundTotals"
+      min_lines: 40
+    - path: "src/utils/firestore/round.firestore.ts"
+      provides: "importRoundsBatch function using writeBatch"
+      exports: ["importRoundsBatch"]
+    - path: "src/store/zustand/app.store.ts"
+      provides: "importRounds store slice with parseImportText, importRounds, resetImport"
+      contains: "importRounds"
+  key_links:
+    - from: "ImportRoundParser.utils.ts"
+      to: "IParsedRound type"
+      via: "export interface IParsedRound"
+      pattern: "IParsedRound"
+    - from: "CourseMatcher.utils.ts"
+      to: "course.firestore.ts"
+      via: "getAllCourses, getCourseByName"
+      pattern: "getCourseByName|getAllCourses"
+    - from: "RoundBuilder.utils.ts"
+      to: "IRoundTotals type"
+      via: "initialStateRoundTotals + score.totals / points.totals override"
+      pattern: "initialStateRoundTotals"
+    - from: "round.firestore.ts"
+      to: "RoundBuilder.utils.ts"
+      via: "importRoundsBatch calls buildRoundDocument"
+      pattern: "buildRoundDocument"
+    - from: "app.store.ts importRounds slice"
+      to: "ImportRoundParser, CourseMatcher, RoundBuilder, importRoundsBatch"
+      via: "actions invoke these utilities"
+      pattern: "importRounds"
+---
+
+<objective>
+**Plan 1: CSV parser, course matcher, round builder, Firestore batch import, and store slice**
+
+Build all the core logic utilities needed to parse pasted Federgolf competition results, match course names against the golf_courses collection, construct Firestore-compatible round documents, and write them atomically via Firestore batch writes. Add the Zustand store slice that exposes `parseImportText`, `importRounds`, and `resetImport` to the UI layer.
+
+**Purpose:** Foundation for the Import Rounds feature — all data processing and persistence logic.
+**Output:** Parsing utilities, course matching, round building, Firestore batch import function, store slice.
+</objective>
+
+<execution_context>
+@/Users/abstract/.config/opencode/get-shit-done/workflows/execute-plan.md
+@/Users/abstract/.config/opencode/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/04-import-rounds-verification/04-CONTEXT.md
+@docs/superpowers/specs/2026-06-01-import-rounds-verification-design.md
+@src/types/round.types.tsx
+@src/types/roundData.types.tsx
+@src/types/roundTotals.types.tsx
+@src/types/course.types.tsx
+@src/utils/firestore/round.firestore.ts
+@src/utils/firestore/course.firestore.ts
+@src/utils/round/round.utils.tsx
+@src/utils/whs/whs.utils.tsx
+@src/store/zustand/app.store.ts
+@src/utils/constant.utils.tsx
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Create ImportRoundParser.utils.ts — CSV/TSV parser</name>
+  <files>
+    src/components/ImportRounds/ImportRoundParser.utils.ts
+  </files>
+  <read_first>
+    @docs/superpowers/specs/2026-06-01-import-rounds-verification-design.md (CSV Parsing section — column mapping and parser logic)
+    @src/types/round.types.tsx (INewRound fields for reference)
+  </read_first>
+  <action>
+    Create file `src/components/ImportRounds/ImportRoundParser.utils.ts`.
+
+    Export an interface `IParsedRound` with these fields:
+    - `rowIndex: number` — 1-based row for preview table
+    - `roundDate: string` — parsed date as ISO string (dayjs, format DD/MM/YYYY)
+    - `roundCourse: string` — raw course name from Campo column
+    - `roundFormat: string` — Formula column value (e.g., "SPS", "SPM")
+    - `roundHoles: number` — Buche column, almost always 18
+    - `roundPar: number`
+    - `roundPlayingHCP: number`
+    - `roundCR: number` — course rating from CR column
+    - `roundSR: number` — slope rating from SR column
+    - `stablefordPoints: number` — Stbl column value
+    - `roundStrokes: number` — AGS column value
+    - `scoreDifferential: number | null` — SD column value (store pre-computed)
+    - `roundValid: boolean` — true when Valida is "S", false when "N"
+    - `indexVecchio: number | null` — Index Vecchio
+    - `indexNuovo: number | null` — Index Nuovo (for verification)
+    - `parsedSuccessfully: boolean` — false if row couldn't be parsed
+
+    Export a function `parseImportText(text: string): IParsedRound[]`:
+
+    1. **Delimiter detection:** Examine the first non-empty line. Count occurrences of tab `\t`, comma `,`, and semicolon `;`. The delimiter with the highest count wins. Default to tab if tied.
+    2. **Header detection:** If the first cell of the first line contains "Data" or "#" (case-insensitive trim), treat it as a header row and skip it.
+    3. **Row parsing:** For each non-empty line, split by delimiter. Extract columns by position:
+       - Column 0: `#` (skip)
+       - Column 1: `Data` → parse with dayjs(`value`, `DD/MM/YYYY`).toISOString()
+       - Column 2: `Gara` (skip — tournament name, store is not required)
+       - Column 3: `Campo` → roundCourse (trim)
+       - Column 4: `Giro` (skip)
+       - Column 5: `Formula` → roundFormat
+       - Column 6: `Buche` → roundHoles (parseInt)
+       - Column 7: `Valida` → roundValid = (value === "S")
+       - Column 8: `Playing HCP` → roundPlayingHCP (parse Italian decimal)
+       - Column 9: `Par` → roundPar (parseInt)
+       - Column 10: `CR` → roundCR (parse Italian decimal)
+       - Column 11: `SR` → roundSR (parseInt)
+       - Column 12: `Stbl` → stablefordPoints (parseInt)
+       - Column 13: `AGS` → roundStrokes (parseInt)
+       - Column 14: `PCC` (skip)
+       - Column 15: `SD` → scoreDifferential (parse Italian decimal or null)
+       - Column 16-18: `Corr SD`, `Corr` (skip)
+       - Column 19: `Index Vecchio` → indexVecchio (parse Italian decimal or null)
+       - Column 20: `Index Nuovo` → indexNuovo (parse Italian decimal or null)
+       - Other columns: ignore
+    4. **Italian decimal parsing:** Write a helper `parseItalianDecimal(value: string): number` that replaces comma with period, trims whitespace, then calls `parseFloat`. Returns 0 on NaN.
+    5. **Valida filtering:** Rows where `roundValid === false` (Valida = "N") are still included in the returned array but have `roundValid: false`. The UI layer will decide whether to show/skip them per D-26.
+    6. **Graceful handling:** If a row can't be parsed (wrong format), set `parsedSuccessfully: false`, populate `rowIndex`, and continue. Do not throw.
+
+    Additional exports:
+    - `getColumnHeaders(text: string): string[]` — returns the header column names (for debugging/display). Detects delimiter same as above, returns first line split into cells.
+
+    Do NOT use fenced code blocks inside this action. Use the specification above as the implementation guide.
+  </action>
+  <acceptance_criteria>
+    - File exists at `src/components/ImportRounds/ImportRoundParser.utils.ts`
+    - Exports `IParsedRound` interface with all specified fields
+    - Exports `parseImportText(text: string): IParsedRound[]` function
+    - Exports `getColumnHeaders(text: string): string[]` function
+    - Delimiter auto-detection picks tab, comma, or semicolon based on highest count in first line
+    - Italian decimal `30,00` parses to `30`, `12,5` parses to `12.5`
+    - Header row detected when first cell contains "Data" or "#"
+    - Rows with `Valida = N` have `roundValid: false`
+    - Invalid rows have `parsedSuccessfully: false`
+    - `npm run type-check` passes (no type errors)
+  </acceptance_criteria>
+  <verify>
+    <automated>npm run type-check</automated>
+  </verify>
+  <done>
+    ImportRoundParser.utils.ts created, passes type-check, exports all required interfaces and functions
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Create CourseMatcher.utils.ts — course matching and teebox lookup</name>
+  <files>
+    src/components/ImportRounds/CourseMatcher.utils.ts
+  </files>
+  <read_first>
+    @src/utils/firestore/course.firestore.ts (getAllCourses, getCourseByName functions)
+    @src/types/course.types.tsx (ICourse, ITeebox interfaces)
+    @docs/superpowers/specs/2026-06-01-import-rounds-verification-design.md (Course Matching algorithm)
+  </read_first>
+  <action>
+    Create file `src/components/ImportRounds/CourseMatcher.utils.ts`.
+
+    Export interface `ICourseMatchResult`:
+    - `courseId: string | null` — golf_courses document ID if matched
+    - `courseName: string` — resolved course name from DB (if matched) or raw name (if not)
+    - `matched: boolean`
+    - `matchMethod: 'exact' | 'like' | 'first' | null` — how the match was found
+    - `teeboxName: string` — matched teebox name, or empty string if no match
+    - `teeboxPar: number` — teebox par, or 0 if unmatched
+    - `teeboxCR: number` — course rating from matched teebox, or 0
+    - `teeboxSR: number` — slope rating from matched teebox, or 0
+    - `warning: string | null` — warning message if teebox not found, course ambiguous, etc.
+
+    Export function `matchCourse(courseName: string, cr: number, sr: number, courses: ICourse[]): ICourseMatchResult`:
+    1. Normalize courseName: uppercase, trim, collapse multiple spaces
+    2. Try exact match: find course where `course.name.toUpperCase() === normalizedName`
+    3. If no exact match, try LIKE: find course where `course.name.toUpperCase().includes(normalizedName)` or vice versa
+    4. If multiple LIKE matches, pick the first one and set warning: `"Multiple courses matched '{name}'. Using first result."`
+    5. If no match at all: return `{ matched: false, courseId: null, courseName: rawName, teeboxName: '', ... }`
+    6. For matched courses, find teebox by `courseRating === cr && slopeRating === sr` using `Math.abs(tee.courseRating - cr) < 0.01 && tee.slopeRating === sr`
+    7. If no teebox matches, use first teebox and set warning: `"No teebox with CR={cr}/SR={sr} found for '{name}'. Using '{firstTeeName}'."`
+
+    Export function `matchAllCourses(parsedRounds: IParsedRound[], courses: ICourse[]): ICourseMatchResult[]`:
+    - Takes the output of parseImportText and an array of ICourse
+    - Calls matchCourse for each parsed round using roundCourse, roundCR, roundSR
+    - Returns array in same order as parsedRounds
+
+    Use `getCourseByName` for the exact match step (it queries Firestore by name directly).
+    For LIKE matching, fetch all courses first via `getAllCourses()` and filter in-memory.
+
+    Import `ICourse` from `@/types/course.types` and `IParsedRound` from the parser file.
+  </action>
+  <acceptance_criteria>
+    - File exists at `src/components/ImportRounds/CourseMatcher.utils.ts`
+    - `matchCourse` does exact match first (via getCourseByName), falls back to LIKE (via getAllCourses in-memory filter)
+    - `matchCourse` returns `matched: true` with teebox details when course+teebox found
+    - `matchCourse` returns `matched: true` with first teebox + warning when no CR/SR match
+    - `matchCourse` returns `matched: false` when course not found
+    - `matchAllCourses` returns result for each parsed round
+    - `npm run type-check` passes
+  </acceptance_criteria>
+  <verify>
+    <automated>npm run type-check</automated>
+  </verify>
+  <done>
+    CourseMatcher.utils.ts created, course matching with exact/Like/first/unmatched and teebox lookup works, type-check passes
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Create RoundBuilder.utils.ts — build Firestore round documents</name>
+  <files>
+    src/components/ImportRounds/RoundBuilder.utils.ts
+  </files>
+  <read_first>
+    @src/utils/constant.utils.tsx (initialStateRoundTotals definition — lines 211+)
+    @src/types/roundTotals.types.tsx (IRoundTotals structure)
+    @src/types/round.types.tsx (INewRound fields)
+    @docs/superpowers/specs/2026-06-01-import-rounds-verification-design.md (Firestore Document Structure section)
+  </read_first>
+  <action>
+    Create file `src/components/ImportRounds/RoundBuilder.utils.ts`.
+
+    Export interface `IRoundImportDocument` — describes the Firestore document to write:
+    - `roundDate: Timestamp` — from parsed date (use Timestamp.fromDate)
+    - `roundCourse: string` — resolved course name or raw name
+    - `roundCourseRef: string | null` — golf_courses document ID if matched
+    - `roundHoles: 18` — always 18
+    - `roundTee: string` — teebox name or empty string
+    - `roundPar: number`
+    - `roundPlayingHCP: number`
+    - `roundStrokes: number` — AGS
+    - `roundFormat: string` — Formula from sheet
+    - `roundValid: boolean`
+    - `roundNumber: number` — assigned by caller (next available)
+    - `totals: IRoundTotals` — minimal valid structure
+    - `scoreDifferential: number | null`
+    - `userId: string`
+    - `importSource: "federgolf-sheet"`
+    - `createdAt: FieldValue` — serverTimestamp()
+
+    Export function `buildRoundDocument(params: {
+      parsed: IParsedRound,
+      match: ICourseMatchResult,
+      roundNumber: number,
+      userId: string
+    }): IRoundImportDocument`:
+
+    1. Create `totals` by deep-cloning `initialStateRoundTotals` (from `@/utils/constant.utils`)
+    2. Override `totals.score.totals = parsed.roundStrokes` (AGS)
+    3. Override `totals.points.totals = parsed.stablefordPoints`
+    4. Set all other totals fields to their default (zeroed) values from initialStateRoundTotals
+    5. Set `roundDate` using `Timestamp.fromDate(new Date(parsed.roundDate))`
+    6. Set `roundCourse` to match.courseName (resolved name) or parsed.roundCourse if unmatched
+    7. Set `roundCourseRef` to match.courseId (null if unmatched)
+    8. Set `roundTee` to match.teeboxName (or '' if unmatched)
+    9. Set `importSource` to the string literal `"federgolf-sheet"`
+    10. Set `createdAt` to `serverTimestamp()` (FieldValue from firebase/firestore)
+
+    Import `IRoundTotals` from `@/types/roundTotals.types`, `initialStateRoundTotals` from `@/utils/constant.utils`,
+    `IParsedRound` from `./ImportRoundParser.utils`, `ICourseMatchResult` from `./CourseMatcher.utils`,
+    `Timestamp`, `FieldValue`, `serverTimestamp` from `firebase/firestore`.
+
+    Export a helper `createEmptyRoundTotals(): IRoundTotals` that deep-clones initialStateRoundTotals — used by tests and preview calculations.
+  </action>
+  <acceptance_criteria>
+    - File exists at `src/components/ImportRounds/RoundBuilder.utils.ts`
+    - `buildRoundDocument` returns an object with all required Firestore document fields
+    - `totals.score.totals` equals the parsed `roundStrokes` (AGS)
+    - `totals.points.totals` equals the parsed `stablefordPoints`
+    - All other IRoundTotals sections are zeroed (copied from initialStateRoundTotals)
+    - `importSource` field is `"federgolf-sheet"`
+    - `createEmptyRoundTotals` returns a deep clone of initialStateRoundTotals
+    - `npm run type-check` passes
+  </acceptance_criteria>
+  <verify>
+    <automated>npm run type-check</automated>
+  </verify>
+  <done>
+    RoundBuilder.utils.ts created, builds valid Firestore documents with minimal totals, type-check passes
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 4: Add importRoundsBatch to round.firestore.ts + store slice</name>
+  <files>
+    src/utils/firestore/round.firestore.ts
+    src/store/zustand/app.store.ts
+  </files>
+  <read_first>
+    @src/utils/firestore/round.firestore.ts (existing saveNewRound, prepareRoundSaveBatch patterns)
+    @src/utils/round/round.utils.tsx (getNextRoundNumber, prepareRoundSaveBatch)
+    @src/store/zustand/app.store.ts (existing store structure — partialize, AppState interface, initialState, set/get pattern)
+    @src/components/ImportRounds/RoundBuilder.utils.ts (the IRoundImportDocument returned by buildRoundDocument)
+    @src/components/ImportRounds/ImportRoundParser.utils.ts (IParsedRound)
+    @src/components/ImportRounds/CourseMatcher.utils.ts (ICourseMatchResult)
+  </read_first>
+  <action>
+    Modify two files:
+
+    **A. `src/utils/firestore/round.firestore.ts`** — Add `importRoundsBatch` function:
+
+    ```typescript
+    export const importRoundsBatch = async (
+      userId: string,
+      roundDocs: IRoundImportDocument[]
+    ): Promise<{ success: boolean; importedCount: number; roundIds: string[] }>
+    ```
+
+    1. Validate `userId` exists, throw if missing
+    2. Create a Firestore `writeBatch(db)`
+    3. For each roundDoc in roundDocs (max 500 — Firestore batch limit):
+       a. Create doc ref in `collection(db, 'players', userId, 'rounds')` using `doc()` for auto-ID
+       b. `batch.set(docRef, roundDoc)`
+    4. Commit the batch
+    5. Return `{ success: true, importedCount: roundDocs.length, roundIds: [array of doc IDs] }`
+    6. On error: catch, log, throw
+
+    Import types: `IRoundImportDocument` from `@/components/ImportRounds/RoundBuilder.utils`,
+    `writeBatch`, `doc`, `collection` from `firebase/firestore`,
+    `db` from `@/utils/firebase/firebase.utils`.
+
+    Do NOT modify the existing `saveNewRound` function.
+
+    **B. `src/store/zustand/app.store.ts`** — Add `importRounds` slice:
+
+    1. **Import** at top of file: `import { parseImportText, IParsedRound } from '@/components/ImportRounds/ImportRoundParser.utils';`, `import { matchAllCourses, ICourseMatchResult } from '@/components/ImportRounds/CourseMatcher.utils';`, `import { buildRoundDocument } from '@/components/ImportRounds/RoundBuilder.utils';`, `import { importRoundsBatch } from '@/utils/firestore/round.firestore';`, `import { getAllCourses } from '@/utils/firestore/course.firestore';`, `import { getNextRoundNumber } from '@/utils/round/round.utils';`
+
+    2. **Add to `AppState` interface** these new properties and methods:
+    ```typescript
+    parsedRounds: IParsedRound[];
+    importResults: IImportResult | null;
+    isLoadingImport: boolean;
+    importError: string | null;
+    parseImportText: (text: string) => Promise<void>;
+    importRounds: (selectedIndices: number[]) => Promise<void>;
+    resetImport: () => void;
+    ```
+
+    3. **Define `IImportResult` interface** at top of file (or in types):
+    ```typescript
+    interface IImportResult {
+      importedCount: number;
+      matchedCount: number;
+      unmatchedCount: number;
+      roundIds: string[];
+      expectedHI: number | null;
+      calculatedHI: number | null;
+      warnings: string[];
+    }
+    ```
+
+    4. **Add to `initialState`** default values:
+    ```typescript
+    parsedRounds: [],
+    importResults: null,
+    isLoadingImport: false,
+    importError: null,
+    ```
+
+    5. **Implement `parseImportText` action** (inside the Zustand create callback):
+       - Set `isLoadingImport: true`, `importError: null`, `importResults: null`
+       - Call `parseImportText(text)` from the parser utility
+       - Fetch all courses via `getAllCourses()`
+       - Call `matchAllCourses(parsed, courses)` to get match results
+       - Store matches alongside parsed rounds (merge into a combined display type, or store both arrays)
+       - Set `parsedRounds` and `isLoadingImport: false`
+       - On error: catch, set `importError`, `isLoadingImport: false`
+       - **Per D-12:** After parsing and matching, compute expected HI from the `indexNuovo` value of the most recent parsed round (last row in sheet order) and store it for later comparison.
+
+    6. **Implement `importRounds` action:**
+       - Accept `selectedIndices: number[]` — indices into parsedRounds to import
+       - Validate: throw if empty, throw if no player.uid
+       - For each selected index, get the parsed round and its match result
+       - Call `buildRoundDocument()` to construct the Firestore document
+       - Call `importRoundsBatch(userId, docs)` to persist
+       - After success: **re-fetch rounds** by calling `getPlayerDetails(player.uid)` and calling `setRounds(result.rounds)` so the roundsList in store is updated with the new imported rounds. Import `getPlayerDetails` and `setRounds` are available in the store.
+       - Compute calculated HI by extracting `scoreDifferential` values from the updated roundsList and calling `calculateHandicapIndex`
+       - Set `importResults` with the comparison data
+       - On error: catch, set `importError`
+
+    7. **Implement `resetImport` action:**
+    ```typescript
+    set({
+      parsedRounds: [],
+      importResults: null,
+      isLoadingImport: false,
+      importError: null,
+    });
+    ```
+
+    8. **IMPORTANT — Add to `partialize`** in the persist config: add `parsedRounds` to the partialize whitelist so parsed data survives page refresh. (The import data is ephemeral and doesn't need to persist beyond the import flow, but it helps UX.)
+    </action>
+    <acceptance_criteria>
+    - `importRoundsBatch` function added to round.firestore.ts — uses writeBatch, returns importedCount + roundIds
+    - Store has `parsedRounds`, `importResults`, `isLoadingImport`, `importError` state properties
+    - Store has `parseImportText`, `importRounds`, `resetImport` actions
+    - `parseImportText` parses text, matches courses, stores results
+    - `importRounds` builds documents, writes batch, re-fetches roundsList, computes HI comparison
+    - `importRoundsBatch` writeBatch handles up to 500 documents atomically
+    - partialize includes `parsedRounds`
+    - `npm run type-check` passes
+    </acceptance_criteria>
+    <verify>
+      <automated>npm run type-check</automated>
+    </verify>
+    <done>
+      importRoundsBatch + store slice created with all three actions, type-check passes
+    </done>
+  </task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| User Paste → Parser | Untrusted CSV/TSV text enters the app via clipboard paste |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-04-01 | Tampering | ImportRoundParser | mitigate | Validate all parsed fields as numbers before use; reject unparseable rows with parsedSuccessfully=false |
+| T-04-02 | DoS | importRoundsBatch | mitigate | Limit batch to 500 rounds per writeBatch Firestore limit; warn on >100 rounds in UI |
+| T-04-03 | Information Disclosure | Store (parsedRounds) | accept | Data is user's own rounds; no sensitive information beyond what user pastes |
+| T-04-04 | Elevation of Privilege | importRoundsBatch | mitigate | Always use current Firebase auth UID as userId; no admin-only check needed (user imports their own rounds) |
+</threat_model>
+
+<verification>
+- `npm run type-check` passes with zero errors
+- All utilities export correct interfaces and functions
+- Store compiles with new importRounds slice
+</verification>
+
+<success_criteria>
+1. ImportRoundParser.utils.ts created with delimiter detection, Italian decimal parsing, Valida filtering
+2. CourseMatcher.utils.ts created with exact/LIKE/unmatched matching and CR/SR teebox lookup
+3. RoundBuilder.utils.ts created with minimal IRoundTotals construction and importSource marker
+4. round.firestore.ts has importRoundsBatch using writeBatch
+5. app.store.ts has importRounds slice with parseImportText, importRounds, resetImport actions
+6. TypeScript compilation passes with no errors
+</success_criteria>
+
+<output>
+Create `.planning/phases/04-import-rounds-verification/04-01-SUMMARY.md` when done
+</output>

--- a/.planning/phases/04-import-rounds-verification/04-01-PLAN.md
+++ b/.planning/phases/04-import-rounds-verification/04-01-PLAN.md
@@ -354,13 +354,20 @@ Build all the core logic utilities needed to parse pasted Federgolf competition 
 
     Do NOT modify the existing `saveNewRound` function.
 
-    **B. `src/store/zustand/app.store.ts`** — Add `importRounds` slice:
+     **B. `src/store/zustand/app.store.ts`** — Add `importRounds` slice:
 
-    1. **Import** at top of file: `import { parseImportText, IParsedRound } from '@/components/ImportRounds/ImportRoundParser.utils';`, `import { matchAllCourses, ICourseMatchResult } from '@/components/ImportRounds/CourseMatcher.utils';`, `import { buildRoundDocument } from '@/components/ImportRounds/RoundBuilder.utils';`, `import { importRoundsBatch } from '@/utils/firestore/round.firestore';`, `import { getAllCourses } from '@/utils/firestore/course.firestore';`, `import { getNextRoundNumber } from '@/utils/round/round.utils';`
+    1. **Import** at top of file:
+       `import { parseImportText, IParsedRound } from '@/components/ImportRounds/ImportRoundParser.utils';`
+       `import { matchAllCourses, ICourseMatchResult } from '@/components/ImportRounds/CourseMatcher.utils';`
+       `import { buildRoundDocument } from '@/components/ImportRounds/RoundBuilder.utils';`
+       `import { importRoundsBatch } from '@/utils/firestore/round.firestore';`
+       `import { getAllCourses } from '@/utils/firestore/course.firestore';`
+       `import { calculateHandicapIndex } from '@/utils/whs/hi.utils';`
 
     2. **Add to `AppState` interface** these new properties and methods:
     ```typescript
     parsedRounds: IParsedRound[];
+    courseMatches: ICourseMatchResult[];
     importResults: IImportResult | null;
     isLoadingImport: boolean;
     importError: string | null;
@@ -369,7 +376,7 @@ Build all the core logic utilities needed to parse pasted Federgolf competition 
     resetImport: () => void;
     ```
 
-    3. **Define `IImportResult` interface** at top of file (or in types):
+    3. **Define `IImportResult` interface** appropriately (inline or in types):
     ```typescript
     interface IImportResult {
       importedCount: number;
@@ -385,6 +392,7 @@ Build all the core logic utilities needed to parse pasted Federgolf competition 
     4. **Add to `initialState`** default values:
     ```typescript
     parsedRounds: [],
+    courseMatches: [],
     importResults: null,
     isLoadingImport: false,
     importError: null,
@@ -395,33 +403,35 @@ Build all the core logic utilities needed to parse pasted Federgolf competition 
        - Call `parseImportText(text)` from the parser utility
        - Fetch all courses via `getAllCourses()`
        - Call `matchAllCourses(parsed, courses)` to get match results
-       - Store matches alongside parsed rounds (merge into a combined display type, or store both arrays)
-       - Set `parsedRounds` and `isLoadingImport: false`
+       - Set both `parsedRounds` and `courseMatches` in store
+       - Compute expected HI: extract `indexNuovo` from the last parsed round (most recent in sheet) and store it
+       - Set `isLoadingImport: false`
        - On error: catch, set `importError`, `isLoadingImport: false`
-       - **Per D-12:** After parsing and matching, compute expected HI from the `indexNuovo` value of the most recent parsed round (last row in sheet order) and store it for later comparison.
 
     6. **Implement `importRounds` action:**
        - Accept `selectedIndices: number[]` — indices into parsedRounds to import
        - Validate: throw if empty, throw if no player.uid
-       - For each selected index, get the parsed round and its match result
-       - Call `buildRoundDocument()` to construct the Firestore document
-       - Call `importRoundsBatch(userId, docs)` to persist
-       - After success: **re-fetch rounds** by calling `getPlayerDetails(player.uid)` and calling `setRounds(result.rounds)` so the roundsList in store is updated with the new imported rounds. Import `getPlayerDetails` and `setRounds` are available in the store.
-       - Compute calculated HI by extracting `scoreDifferential` values from the updated roundsList and calling `calculateHandicapIndex`
-       - Set `importResults` with the comparison data
+       - **Duplicate detection:** Before building documents, check if any selected round's `roundCourse` + `roundDate` combination already exists in the current `roundsList`. Warn in `IImportResult.warnings` if duplicates found, but still proceed with non-duplicate rounds.
+       - **Large paste check:** If `selectedIndices.length > 100`, add warning "Large import — may take a moment" to `importResults.warnings`
+       - For each selected index, look up the parsed round (`parsedRounds[i]`) and its match result (`courseMatches[i]`)
+       - Compute `roundNumber` for each round: `Math.max(0, ...roundsList.map(r => Number(r.roundNumber) || 0)) + 1 + idx` (idx loops through selected rounds sequentially)
+       - Call `buildRoundDocument({ parsed, match, roundNumber, userId })` for each selected round
+       - Call `importRoundsBatch(userId, docs)` to persist via writeBatch
+       - After success: **re-fetch rounds** by calling available store action that loads rounds (e.g., the existing getPlayerDetails / setRounds pattern) so `roundsList` is updated
+       - Compute calculated HI: extract `scoreDifferential` values from the updated `roundsList` where SD is non-null, call `calculateHandicapIndex(sds)`
+       - Set `importResults` with comparison data: `expectedHI` from `parseImportText` result, `calculatedHI` from engine
        - On error: catch, set `importError`
 
     7. **Implement `resetImport` action:**
     ```typescript
     set({
       parsedRounds: [],
+      courseMatches: [],
       importResults: null,
       isLoadingImport: false,
       importError: null,
     });
     ```
-
-    8. **IMPORTANT — Add to `partialize`** in the persist config: add `parsedRounds` to the partialize whitelist so parsed data survives page refresh. (The import data is ephemeral and doesn't need to persist beyond the import flow, but it helps UX.)
     </action>
     <acceptance_criteria>
     - `importRoundsBatch` function added to round.firestore.ts — uses writeBatch, returns importedCount + roundIds

--- a/.planning/phases/04-import-rounds-verification/04-02-PLAN.md
+++ b/.planning/phases/04-import-rounds-verification/04-02-PLAN.md
@@ -1,0 +1,425 @@
+---
+phase: 04-import-rounds-verification
+plan: 02
+type: execute
+wave: 2
+depends_on: [04-01]
+files_modified:
+  - src/pages/ImportRounds.page.tsx
+  - src/components/ImportRounds/ImportRounds.component.tsx
+  - src/components/ImportRounds/ImportForm.component.tsx
+  - src/components/ImportRounds/PreviewTable.component.tsx
+  - src/components/ImportRounds/ImportResult.component.tsx
+  - src/App.tsx
+  - src/utils/links/links.utils.tsx
+autonomous: true
+requirements: [IMPORT-01, IMPORT-02]
+user_setup: []
+
+must_haves:
+  truths:
+    - Import Rounds page is accessible via /import-rounds route under ProtectedRoute
+    - Nav sidebar shows "Import Rounds" link with FileUploadIcon
+    - User can paste CSV/TSV text into a textarea and click Parse to see a preview table
+    - Preview table shows each parsed round with course match status (✓/✗), tee, par, PHCP, Stableford, AGS, SD, and a checkbox
+    - Parse errors show descriptive error messages
+    - Import button is disabled when 0 valid rounds selected
+    - After import, result summary shows count imported, course matches/misses, expected HI vs calculated HI
+    - Imported round detail page shows "This round was imported. No per-hole data available." notice
+  artifacts:
+    - path: "src/pages/ImportRounds.page.tsx"
+      provides: "Route page for /import-rounds"
+      min_lines: 15
+    - path: "src/components/ImportRounds/ImportRounds.component.tsx"
+      provides: "Main orchestrator — state machine for parse → preview → import → result"
+      min_lines: 80
+    - path: "src/components/ImportRounds/ImportForm.component.tsx"
+      provides: "Paste textarea + Parse & Preview button"
+      min_lines: 40
+    - path: "src/components/ImportRounds/PreviewTable.component.tsx"
+      provides: "Table with parsed rounds, course match status, checkboxes"
+      min_lines: 80
+    - path: "src/components/ImportRounds/ImportResult.component.tsx"
+      provides: "Import success/failure summary with HI verification"
+      min_lines: 50
+    - path: "src/App.tsx"
+      provides: "/import-rounds route"
+      contains: "ImportRoundsPage"
+    - path: "src/utils/links/links.utils.tsx"
+      provides: "Import Rounds nav link"
+      contains: "Import Rounds"
+  key_links:
+    - from: "ImportRounds.component.tsx"
+      to: "app.store importRounds slice"
+      via: "calls parseImportText, importRounds, resetImport"
+      pattern: "parseImportText|importRounds|resetImport"
+    - from: "ImportForm.component.tsx"
+      to: "ImportRounds.component.tsx"
+      via: "onParse callback with textarea value"
+      pattern: "onParse"
+    - from: "ImportResult.component.tsx"
+      to: "importResults (store)"
+      via: "displays importedCount, matchedCount, expectedHI, calculatedHI"
+      pattern: "importResults"
+    - from: "App.tsx"
+      to: "ImportRounds.page.tsx"
+      via: "&lt;Route path='/import-rounds' element={...}&gt;"
+      pattern: "import-rounds"
+---
+
+<objective>
+**Plan 2: Import Rounds page UI — paste form, preview table, import result, route, nav link**
+
+Build all UI components for the Import Rounds feature: the page wrapper, paste textarea with Parse button, preview table with row selection, result summary with HI verification, route registration, and nav link. Also add the "no per-hole data" notice for imported round detail pages.
+
+**Purpose:** Complete the user-facing import flow end-to-end.
+**Output:** Import Rounds page, all sub-components, route, nav link.
+</objective>
+
+<execution_context>
+@/Users/abstract/.config/opencode/get-shit-done/workflows/execute-plan.md
+@/Users/abstract/.config/opencode/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/04-import-rounds-verification/04-CONTEXT.md
+@docs/superpowers/specs/2026-06-01-import-rounds-verification-design.md
+@src/pages/ImportRounds.page.tsx (NEW — after Wave 1)
+@src/components/ImportRounds/ImportRounds.component.tsx (NEW)
+@src/components/ImportRounds/ImportForm.component.tsx (NEW)
+@src/components/ImportRounds/PreviewTable.component.tsx (NEW)
+@src/components/ImportRounds/ImportResult.component.tsx (NEW)
+@src/App.tsx
+@src/utils/links/links.utils.tsx
+@src/store/zustand/app.store.ts (after Wave 1 — with importRounds slice)
+@src/types/general.types.tsx (TLinkSidebar)
+@src/components/RoundsData/RoundsDataMain.component.tsx (add imported round notice)
+@src/components/RoundsData/components/roundData/RoundsDataHeader.component.tsx
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Create all Import Rounds sub-components (ImportForm, PreviewTable, ImportResult)</name>
+  <files>
+    src/components/ImportRounds/ImportForm.component.tsx
+    src/components/ImportRounds/PreviewTable.component.tsx
+    src/components/ImportRounds/ImportResult.component.tsx
+  </files>
+  <read_first>
+    @docs/superpowers/specs/2026-06-01-import-rounds-verification-design.md (Page Layout section for component layout reference)
+    @src/components/ImportRounds/ImportRoundParser.utils.ts (IParsedRound interface)
+    @src/store/zustand/app.store.ts (AppState importRounds slice — IImportResult)
+    @src/components/Dashboard/components/EmptyRounds/EmptyRounds.component.tsx (for MUI component styling patterns)
+  </read_first>
+  <action>
+    Create three component files under `src/components/ImportRounds/`:
+
+    **A. `ImportForm.component.tsx`** — Paste form with textarea and parse button.
+
+    Export default component `ImportForm`.
+    Props interface:
+    ```typescript
+    interface ImportFormProps {
+      onParse: (text: string) => void;
+      isLoading: boolean;
+      error: string | null;
+    }
+    ```
+
+    Layout (using MUI Box, Typography, TextField, Button, Alert):
+    1. Title: "Import Rounds" with FileUploadIcon from `@mui/icons-material/FileUpload`
+    2. Paragraph instruction: "Paste competition results from your Federgolf spreadsheet below. One row per round. The parser accepts tab-separated, comma-separated, or semicolon-separated data."
+    3. Multiline TextField (`minRows={8}`, `maxRows={20}`, fullWidth, monospace font via `sx={{ fontFamily: 'monospace' }}`), placeholder text showing example row format.
+    4. Error Alert shown conditionally when `error` is non-null — use `severity="error"`.
+    5. Parse button: `Button variant="contained"` with label "Parse & Preview", disabled when `isLoading` is true or textarea is empty. Use `onClick` that calls `onParse(textareaValue)`.
+
+    Use local state (`useState`) for the textarea value.
+
+    **B. `PreviewTable.component.tsx`** — Table showing parsed rounds with selection.
+
+    Props interface:
+    ```typescript
+    interface PreviewTableProps {
+      parsedRounds: IParsedRound[];
+      courseMatches: ICourseMatchResult[];
+      selectedIndices: number[];
+      onSelectionChange: (indices: number[]) => void;
+      onImport: (indices: number[]) => void;
+      isImporting: boolean;
+      importError: string | null;
+    }
+    ```
+
+    Layout:
+    1. Typography "Preview" header with row count: "Showing {N} rounds ({M} valid, {K} invalid)"
+    2. MUI Table component with columns:
+       - `#` — row number
+       - `Data` — formatted date (dayjs DD/MM/YYYY)
+       - `Campo` — course name from parsed data
+       - `Match` — ✓ (green) or ✗ (red) icon with matchMethod tooltip
+       - `Tee` — teebox name (or "—")
+       - `Par` — roundPar
+       - `PHCP` — roundPlayingHCP
+       - `Stbl` — stablefordPoints
+       - `AGS` — roundStrokes
+       - `SD` — scoreDifferential (formatted to 1 decimal)
+       - `Valida` — show "✓" if roundValid, "✗" if not, "?" if parsedSuccessfully=false
+       - ✓ — Checkbox column for selection
+    3. Course match status: Show ICourseMatchResult.matched with green checkmark or red X
+    4. Only rows with `parsedSuccessfully === true` and `roundValid === true` get checkboxes enabled
+    5. Invalid/unparseable rows show in the table but with muted styling and no checkbox
+    6. "Select All" checkbox in header that toggles all valid rows
+    7. Import button: `Button variant="contained" color="primary"` labeled "Import N Selected Rounds" (N = count). Disabled when selectedIndices is empty or isImporting is true.
+    8. Error Alert shown when `importError` is non-null
+    9. If no valid rounds: show Alert "No valid rounds found. Check that your data has the correct format."
+
+    Import `IParsedRound` from `./ImportRoundParser.utils`, `ICourseMatchResult` from `./CourseMatcher.utils`.
+    Use `dayjs` for date formatting.
+
+    **C. `ImportResult.component.tsx`** — Import success/failure summary.
+
+    Props interface:
+    ```typescript
+    interface ImportResultProps {
+      result: IImportResult;
+      onReset: () => void;
+    }
+    ```
+
+    Layout:
+    1. Success Alert with title "Import Complete"
+    2. Summary cards/statistics:
+       - Total imported: `result.importedCount`
+       - Courses matched: `result.matchedCount`
+       - Courses unmatched: `result.unmatchedCount`
+       - If there are unmatched courses, show warning Alert: `"⚠ {N} courses not found (names stored as-is)"`
+    3. HI Verification card:
+       - "Expected HI: {expectedHI}" (from sheet's Index Nuovo)
+       - "Calculated HI: {calculatedHI}" (from app's engine)
+       - Match indicator: ✓ green if difference &lt; 0.2, ✗ red otherwise
+       - Additional info text: "Based on {totalRounds} rounds in your history"
+    4. Two action buttons at bottom:
+       - "View Handicap History" — MUI Button with TimelineIcon, navigates to `/handicap-history` via `useNavigate()`
+       - "Import More" — MUI Button, calls `onReset()` to clear state and return to paste form
+    5. If `result.warnings` array is non-empty, show each warning in a list inside a Warning Alert
+
+    Import `IImportResult` from store, `useNavigate` from `react-router-dom`.
+  </action>
+  <acceptance_criteria>
+    - ImportForm.component.tsx renders with textarea, parse button, error display
+    - PreviewTable.component.tsx renders table with all specified columns, checkboxes, select-all, import button
+    - PreviewTable checkbox selection works: select-all toggles valid rows, individual toggle works
+    - PreviewTable disables checkboxes for Valida=N or unparseable rows
+    - Import button shows correct count and disables when 0 selected
+    - ImportResult.component.tsx renders import summary, HI comparison cards, action buttons
+    - ImportResult shows warnings list when present
+    - `npm run type-check` passes
+  </acceptance_criteria>
+  <verify>
+    <automated>npm run type-check</automated>
+  </verify>
+  <done>
+    All three sub-components created, type-check passes, correct table/button/selection behavior
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Create ImportRounds.page.tsx + ImportRounds.component.tsx orchestrator</name>
+  <files>
+    src/pages/ImportRounds.page.tsx
+    src/components/ImportRounds/ImportRounds.component.tsx
+  </files>
+  <read_first>
+    @src/pages/Dashboard.page.tsx (page pattern — thin wrapper around component)
+    @src/pages/HandicapHistory.page.tsx (similar page pattern reference)
+    @src/components/ImportRounds/ImportForm.component.tsx
+    @src/components/ImportRounds/PreviewTable.component.tsx
+    @src/components/ImportRounds/ImportResult.component.tsx
+    @src/store/zustand/app.store.ts (AppState with importRounds actions and state)
+    @src/utils/whs/hi.utils.tsx (calculateHandicapIndex for HI comparison)
+  </read_first>
+  <action>
+    Create two files:
+
+    **A. `ImportRounds.page.tsx`** (in `src/pages/`)
+
+    Thin wrapper following the existing page pattern (see Dashboard.page.tsx):
+    - Import and render `<ImportRounds />` component
+    - Default export
+    - Minimal: useEffect not needed, the component handles all logic via store
+
+    ```typescript
+    import ImportRoundsComponent from '@/components/ImportRounds/ImportRounds.component';
+
+    const ImportRoundsPage = () => {
+      return <ImportRoundsComponent />;
+    };
+
+    export default ImportRoundsPage;
+    ```
+
+    **B. `ImportRounds.component.tsx`** (in `src/components/ImportRounds/`)
+
+    Main orchestrator component that manages the import flow as a simple state machine:
+    - State: `'form'` → `'preview'` → `'result'`
+    - Uses store actions and state from `useAppStore`
+
+    Implementation:
+    1. Select store values using individual selectors for performance:
+       ```typescript
+       const parsedRounds = useAppStore((s) => s.parsedRounds);
+       const importResults = useAppStore((s) => s.importResults);
+       const isLoadingImport = useAppStore((s) => s.isLoadingImport);
+       const importError = useAppStore((s) => s.importError);
+       const parseImportText = useAppStore((s) => s.parseImportText);
+       const importRoundsAction = useAppStore((s) => s.importRounds);
+       const resetImport = useAppStore((s) => s.resetImport);
+       ```
+    2. Maintain `selectedIndices` state locally via `useState<number[]>([])`
+    3. Flow logic:
+       - If `importResults !== null` → show `ImportResult` view with onReset calling resetImport()
+       - Else if `parsedRounds.length > 0` → show `PreviewTable` view with parsed data and selection
+       - Else → show `ImportForm` view
+    4. `handleParse(text)` — calls `parseImportText(text)` from store, resets selectedIndices
+    5. `handleImport(indices)` — calls `importRoundsAction(indices)` from store, resets selectedIndices
+    6. Wrap in MUI Container with `maxWidth="lg"` and responsive padding
+    7. Show a `LinearProgress` or `CircularProgress` from MUI during `isLoadingImport`
+
+    Import: all sub-components, `useState`, `useCallback`, `Box`, `Container`, `LinearProgress`, `Alert` from MUI.
+  </action>
+  <acceptance_criteria>
+    - ImportRounds.page.tsx is a thin wrapper that renders ImportRounds.component
+    - ImportRounds.component.tsx orchestrates form → preview → result states
+    - `parsedRounds.length === 0` without importResults → shows ImportForm
+    - `parsedRounds.length > 0` without importResults → shows PreviewTable
+    - `importResults !== null` → shows ImportResult
+    - Loading state shows MUI LinearProgress
+    - `npm run type-check` passes
+  </acceptance_criteria>
+  <verify>
+    <automated>npm run type-check</automated>
+  </verify>
+  <done>
+    ImportRounds.page.tsx and ImportRounds.component.tsx created, flow state machine works, type-check passes
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Wire route and nav link; add imported-round notice to detail page</name>
+  <files>
+    src/App.tsx
+    src/utils/links/links.utils.tsx
+    src/components/RoundsData/RoundsDataMain.component.tsx
+  </files>
+  <read_first>
+    @src/App.tsx (existing route pattern — see SimulatorPage, HandicapHistoryPage imports and route definitions)
+    @src/utils/links/links.utils.tsx (TLinkSidebar array pattern with id, name, link, icon, show)
+    @src/components/RoundsData/RoundsDataMain.component.tsx (existing component — line 135 already checks holes.length > 0)
+  </read_first>
+  <action>
+    Modify three files:
+
+    **A. `src/App.tsx`** — Add Import Rounds route:
+
+    1. Add import at top: `import ImportRoundsPage from './pages/ImportRounds.page';`
+    2. Inside the ProtectedRoute's Routes block (between the opening tag and the `</Route>`), add:
+       `<Route path='/import-rounds' element={<ImportRoundsPage />} />`
+       Place it alphabetically among existing routes (after `/handicap-history`, before `/settings`).
+
+    **B. `src/utils/links/links.utils.tsx`** — Add nav link:
+
+    1. Import `FileUploadIcon` from `@mui/icons-material/FileUpload`:
+       `import FileUploadIcon from '@mui/icons-material/FileUpload';`
+    2. Append to the `navbar_items` array a new entry:
+       ```typescript
+       {
+         id: 7,
+         name: "Import Rounds",
+         link: "/import-rounds",
+         icon: FileUploadIcon,
+         show: true,
+       },
+       ```
+    3. Placement: after the Handicap History entry (id: 6), making this id: 7.
+    4. `show: true` means it's visible to all authenticated users (not admin-only).
+
+    **C. `src/components/RoundsData/RoundsDataMain.component.tsx`** — Show imported-round notice:
+
+    1. After the existing loading/error checks (around line 107-111), add a check:
+       ```typescript
+       // Imported rounds have no per-hole data
+       const isImportedRound = (roundDetailsData as any)?.importSource === 'federgolf-sheet';
+       ```
+       (Use type assertion since importSource is not in IRoundDetails type definition.)
+    2. Inside the main render block (after the RoundsDataHeader), add before the full statistics section:
+       ```typescript
+       {isImportedRound && (
+         <Alert severity="info" sx={{ width: '100%' }}>
+           This round was imported. No per-hole data available.
+         </Alert>
+       )}
+       ```
+    3. Import `Alert` from `@mui/material` if not already imported (it's not currently imported in RoundsDataMain — add it to the import line).
+    4. The existing `{roundDetailsData.holes && roundDetailsData.holes.length > 0 && openHoleByHole && ...}` check at line 135 will naturally hide the hole-by-hole table for imported rounds (since holes will be empty). The Alert provides user-friendly context.
+    </action>
+    <acceptance_criteria>
+    - App.tsx imports ImportRoundsPage and has `<Route path='/import-rounds' element={<ImportRoundsPage />} />` inside ProtectedRoute
+    - links.utils.tsx imports FileUploadIcon and has the Import Rounds nav link entry (show: true, id: 7)
+    - RoundsDataMain.component.tsx shows "This round was imported. No per-hole data available." Alert when round has importSource === "federgolf-sheet"
+    - Existing hole-by-hole table is hidden for imported rounds (holes.length === 0)
+    - `npm run type-check` passes
+    - `npm run build` succeeds
+    </acceptance_criteria>
+    <verify>
+      <automated>npm run type-check && npm run build</automated>
+      <timeout>120000</timeout>
+    </verify>
+    <done>
+      Route, nav link, and imported-round notice added; build succeeds
+    </done>
+  </task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| Route access | /import-rounds is under ProtectedRoute — only authenticated users |
+| Nav link display | Link is visible to all authenticated users (show: true) |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-04-05 | Information Disclosure | Route / nav link | accept | Feature is intentionally visible to all authenticated users; import is per-user |
+| T-04-06 | Spoofing | PreviewTable checkboxes | mitigate | Unparseable rows have checkboxes disabled; preview is read-only until user explicitly triggers import |
+| T-04-07 | Repudiation | ImportResult display | accept | HI comparison is for user's own verification; no audit trail required |
+</threat_model>
+
+<verification>
+- `npm run type-check` passes with zero errors
+- `npm run build` succeeds
+- All components render without runtime errors (verified during manual testing)
+</verification>
+
+<success_criteria>
+1. ImportRounds.page.tsx created
+2. ImportRounds.component.tsx orchestrates form → preview → result state machine
+3. ImportForm.component.tsx has paste textarea + Parse button + error display
+4. PreviewTable.component.tsx has table with course match status, checkboxes, select-all, import button
+5. ImportResult.component.tsx shows import summary, HI comparison, action buttons
+6. /import-rounds route registered in App.tsx under ProtectedRoute
+7. "Import Rounds" nav link with FileUploadIcon added to sidebar
+8. Imported round detail page shows "no per-hole data" notice
+9. TypeScript + production build succeed
+</success_criteria>
+
+<output>
+Create `.planning/phases/04-import-rounds-verification/04-02-SUMMARY.md` when done
+</output>

--- a/.planning/phases/04-import-rounds-verification/04-02-PLAN.md
+++ b/.planning/phases/04-import-rounds-verification/04-02-PLAN.md
@@ -153,6 +153,7 @@ Build all UI components for the Import Rounds feature: the page wrapper, paste t
       importError: string | null;
     }
     ```
+    courseMatches is read from the store via the orchestrator (ImportRounds.component.tsx reads `useAppStore((s) => s.courseMatches)` and passes it as the prop).
 
     Layout:
     1. Typography "Preview" header with row count: "Showing {N} rounds ({M} valid, {K} invalid)"
@@ -269,20 +270,21 @@ Build all UI components for the Import Rounds feature: the page wrapper, paste t
     - Uses store actions and state from `useAppStore`
 
     Implementation:
-    1. Select store values using individual selectors for performance:
-       ```typescript
-       const parsedRounds = useAppStore((s) => s.parsedRounds);
-       const importResults = useAppStore((s) => s.importResults);
-       const isLoadingImport = useAppStore((s) => s.isLoadingImport);
-       const importError = useAppStore((s) => s.importError);
-       const parseImportText = useAppStore((s) => s.parseImportText);
-       const importRoundsAction = useAppStore((s) => s.importRounds);
-       const resetImport = useAppStore((s) => s.resetImport);
-       ```
+     1. Select store values using individual selectors for performance:
+        ```typescript
+        const parsedRounds = useAppStore((s) => s.parsedRounds);
+        const courseMatches = useAppStore((s) => s.courseMatches);
+        const importResults = useAppStore((s) => s.importResults);
+        const isLoadingImport = useAppStore((s) => s.isLoadingImport);
+        const importError = useAppStore((s) => s.importError);
+        const parseImportText = useAppStore((s) => s.parseImportText);
+        const importRoundsAction = useAppStore((s) => s.importRounds);
+        const resetImport = useAppStore((s) => s.resetImport);
+        ```
     2. Maintain `selectedIndices` state locally via `useState<number[]>([])`
     3. Flow logic:
        - If `importResults !== null` → show `ImportResult` view with onReset calling resetImport()
-       - Else if `parsedRounds.length > 0` → show `PreviewTable` view with parsed data and selection
+        - Else if `parsedRounds.length > 0` → show `PreviewTable` view with parsed data, courseMatches from store, and selection
        - Else → show `ImportForm` view
     4. `handleParse(text)` — calls `parseImportText(text)` from store, resets selectedIndices
     5. `handleImport(indices)` — calls `importRoundsAction(indices)` from store, resets selectedIndices

--- a/docs/superpowers/specs/2026-06-01-import-rounds-verification-design.md
+++ b/docs/superpowers/specs/2026-06-01-import-rounds-verification-design.md
@@ -1,0 +1,305 @@
+# Import Rounds Verification Page Design
+
+Date: 2026-06-01
+
+## Overview
+
+A new page where players can paste Federgolf/FIG competition results from a Google Sheet and import them as real rounds. This lets users verify the Handicap History page, rounds list, and HI calculation against known competition data — without entering 18 holes of shot-by-shot data. Rounds appear identically to hand-entered rounds in all pages that read `roundsList`.
+
+**Not in scope:** Per-hole statistics, shot data, club tracking, distance averages. This is a bulk-import for handicap verification only.
+
+---
+
+## Route
+
+- Path: `/import-rounds`
+- Nav label: "Import Rounds"
+- Icon: `FileUploadIcon` (or `PublishIcon`)
+- Only visible for logged-in players (inside `ProtectedRoute`)
+
+---
+
+## Data Flow
+
+```
+User copies rows from Google Sheet
+        │
+        ▼
+Paste into <textarea> on /import-rounds
+        │
+        ▼
+Parse CSV/TSV text → structured array of round data
+        │
+        ▼
+Match Campo column → golf_courses collection by name
+  (try exact match first, fall back to LIKE search)
+        │
+        ▼
+Look up teebox matching the round's Par/CR/SR
+  (find teebox with matching courseRating and slopeRating)
+        │
+        ▼
+Show preview table: date, course (match status ✓/✗), par, CR, SR,
+Playing HCP, Stableford, AGS, Score Diff, Expected HI
+        │
+        ▼
+User clicks "Import Rounds"
+        │
+        ▼
+For each round, create Firestore round document:
+  - Round metadata (date, course ref, tee, par, playing HCP, holes=18)
+  - `totals` = minimal valid IRoundTotals (score, points filled; rest zeroed)
+  - `scoreDifferential` = pre-computed from sheet
+  - No holes subcollection
+  - Uses existing `saveNewRound` path (or a simplified writer)
+        │
+        ▼
+Show success summary: X rounds imported, Y course matches,
+expected HI vs calculated HI
+```
+
+---
+
+## Page Layout
+
+```
++----------------------------------------------------+
+| Import Rounds                                      |
+| (FileUploadIcon + title)                           |
++----------------------------------------------------|
+| Paste competition results from your Federgolf      |
+| spreadsheet below. One row per round.              |
+|                                                     |
+| ┌─────────────────────────────────────────────┐    |
+| │ Data;Gara;Campo;Giro;Formula;Buche;Valida;...│    |
+| │ 09/05/2026;Muratory Wine;BARLASSINA;1;SPM;...│    |
+| │ 24/05/2026;GOFOX ON TOUR 2026;AMBROSIANO;...│    |
+| │ ...                                         │    |
+| └─────────────────────────────────────────────┘    |
+|                                                     |
+| [Parse & Preview]                                   |
++----------------------------------------------------|
+| Preview (shows after parse):                        |
+|                                                     |
+| # | Date     | Course      | Match | Tee | Par | PHCP | Stbl | AGS | SD   | ✓ |
+| 1 | 09/05/26 | BARLASSINA  | ✓     | Giallo | 72 | 30   | 33   | 105 | 29.1 | ⬜ |
+| 2 | 24/05/26 | AMBROSIANO  | ✓     | Giallo | 72 | 31   | 36   | 103 | 26.8 | ⬜ |
+| 3 | 09/05/26 | BARLASSINA  | ✓     | Giallo | 72 | 31   | 23   | 116 | 38.5 | ⬜ |
+| ...                                                     |
+|                                                     |
+| [Select All]  [Import X Selected Rounds]             |
++----------------------------------------------------|
+| Results (shows after import):                       |
+|                                                     |
+| ✓ 40 rounds imported                                |
+| ✓ 38 course matches                                 |
+| ⚠ 2 courses not found (names stored as-is)         |
+|                                                     |
+| Expected HI: 26.8                                   |
+| Calculated HI: 26.8                                 |
+| Match: ✓                                            |
+|                                                     |
+| [View Handicap History]  [Import More]              |
++----------------------------------------------------+
+```
+
+---
+
+## CSV Parsing
+
+### Expected Columns (from Google Sheet)
+
+The sheet has these columns:
+`#`, `Data`, `Gara`, `Campo`, `Giro`, `Formula`, `Buche`, `Valida`, `Playing HCP`, `Par`, `CR`, `SR`, `Stbl`, `AGS`, `PCC`, `SD`, `Corr SD`, `Corr`, `Index Vecchio`, `Index Nuovo`, `Var.`
+
+### Parser Logic
+
+1. Split pasted text by newlines → rows
+2. Detect delimiter (tab `\t` or comma `,` or semicolon `;`)
+3. Parse each row:
+   - `Data` (date) → `roundDate` — parse via dayjs (format DD/MM/YYYY)
+   - `Campo` (course name) → used for course lookup
+   - `Formula` — store as metadata (not used in calculations)
+   - `Buche` (holes) → `roundHoles` (always 18)
+   - `Playing HCP` → `roundPlayingHCP` (parse Italian decimal `,` → `.`)
+   - `Par` → `roundPar`
+   - `CR` → course rating (for teebox lookup)
+   - `SR` → slope rating (for teebox lookup)
+   - `Stbl` → `totals.points.totals` (Stableford points)
+   - `AGS` → `totals.score.totals` (adjusted gross score)
+   - `SD` → `scoreDifferential` (store pre-computed)
+   - `Valida` — skip rows where Valida is `N` (not valid for handicap)
+
+### Robustness
+
+- Skip empty lines
+- Skip header row (detect by "Data" in first cell or by `#` marker)
+- Handle Italian decimal format (comma as decimal separator)
+- Handle empty fields gracefully
+
+---
+
+## Course Matching
+
+### Algorithm
+
+1. Normalize the sheet's `Campo` value: trim, uppercase, remove extra spaces
+2. Query `golf_courses` collection for `name == normalizedName` (exact match)
+3. If no match, try `name LIKE %normalizedName%` (case-insensitive contains)
+4. If still no match, mark as **unmatched** — store the raw course name as `roundCourse` string
+
+### Teebox Lookup
+
+Once a course is matched, find the teebox that matches the sheet's `CR` and `SR`:
+1. Iterate `course.teeboxes[]`
+2. Find teebox where `courseRating == parsedCR && slopeRating == parsedSR`
+3. If found: set `roundTee` to teebox `name`
+4. If not found: set `roundTee` to the first available teebox `name` (with warning)
+
+### Edge Cases
+
+- Course found but no teebox matches CR/SR → warn but import with first teebox
+- Course not found → store raw name, set tee to empty string, import with warning
+- Multiple courses match the same name → pick first result, log ambiguity
+
+---
+
+## Firestore Document Structure
+
+### Round Document (`players/{playerId}/rounds/{roundId}`)
+
+```typescript
+{
+  roundDate: Timestamp,           // Parsed from Data column
+  roundCourse: string,            // Course name (or "UNMATCHED: BARLASSINA" if not found)
+  roundCourseRef: string | null,  // Course document ID if matched
+  roundHoles: 18,
+  roundTee: string,               // Teebox name from matched course
+  roundPar: number,               // From sheet
+  roundPlayingHCP: number,        // From sheet
+  roundStrokes: number,           // AGS from sheet
+  roundNumber: number,            // Auto-assigned (next available)
+  roundFormat: string,            // Formula from sheet (e.g., "SPS", "SPM")
+  roundValid: boolean,            // Valida == "S"
+
+  totals: {
+    score: { totals: number },        // AGS
+    points: { totals: number },       // Stableford points
+    fairway: { firTot: 0, firCounter: 0 },
+    gir: { counter: 0, tot: 0 },
+    putts: { totals: 0 },
+    // All other IRoundTotals fields set to 0 / default
+    // See IRoundTotals type for full structure
+  },
+
+  scoreDifferential: number | null,   // Pre-computed from sheet
+  userId: string,                     // Current player's auth UID
+  createdAt: Timestamp,               // serverTimestamp()
+  importSource: "federgolf-sheet",    // Marker for imported rounds
+}
+```
+
+### No Holes Subcollection
+
+Imported rounds have **no holes subcollection** — the per-hole shot data is not needed for handicap verification. Pages that read `roundDetails.holes` will get an empty array for these rounds. If the user clicks into an imported round's detail page, show a notice: "This round was imported. No per-hole data available."
+
+### `importSource` Field
+
+The `importSource: "federgolf-sheet"` marker lets us:
+- Filter imported rounds in the rounds list if needed
+- Show context-appropriate UI for imported rounds
+- Avoid double-importing the same data
+
+---
+
+## Component Tree
+
+```
+src/pages/ImportRounds.page.tsx         ← Route page (thin wrapper)
+src/components/ImportRounds/
+  ImportRounds.component.tsx            ← Main orchestrator
+  ImportForm.component.tsx              ← Textarea for paste + Parse button
+  PreviewTable.component.tsx            ← Preview parsed data before import
+  ImportResult.component.tsx            ← Success/failure summary after import
+  ImportRoundParser.utils.ts            ← CSV/TSV parsing logic
+  CourseMatcher.utils.ts                ← Course matching algorithm
+  RoundBuilder.utils.ts                 ← Builds Firestore-compatible round objects
+```
+
+---
+
+## Store Integration
+
+### New Zustand Slice
+
+A minimal slice in the existing Zustand store:
+
+```typescript
+importRounds: {
+  parsedRounds: IParsedRound[],     // Parsed + matched round data (preview)
+  importResults: IImportResult | null,  // After import
+  isLoading: boolean,
+  error: string | null,
+}
+```
+
+Methods:
+- `parseImportText(text: string)` — parse pasted CSV, match courses, store in `parsedRounds`
+- `importRounds(selectedIndices: number[])` — save selected rounds to Firestore
+- `resetImport()` — clear all import state
+
+---
+
+## Edge Cases
+
+| Case | Handling |
+|---|---|
+| Empty paste | Show error: "Paste competition data first" |
+| Wrong format | Show error: "Could not parse data. Expected columns: Date, Course, Par, CR, SR, Stbl, AGS, SD, ..." |
+| Duplicate rounds | Check date+coursename combination; warn if already imported |
+| Invalid rounds (Valida=N) | Skip automatically with note |
+| All courses unmatched | Import proceeds, rounds stored with raw course names |
+| 0 valid rounds to import | Disable import button, show "No valid rounds found" |
+| Partial import failure | Batch with Firestore batch writes; report success count vs failure count |
+| Round detail page for imported round | Show "This round was imported. No per-hole data available." |
+| Handicap History with imported rounds | Works identically — reads `scoreDifferential` from round doc |
+| Concurrent imports | Round number auto-assignment avoids conflicts |
+| Very large paste (100+ rounds) | Warn: "Large import — may take a moment" |
+
+---
+
+## Verification
+
+- `npm run type-check` — no TypeScript errors
+- `npm run build` — production build succeeds
+- Manual: paste 40 rows from Google Sheet, verify parse matches expected
+- Manual: verify preview table shows correct course match status
+- Manual: import rounds, verify they appear in Handicap History page
+- Manual: verify Handicap Index calculation matches expected HI from sheet (`Index Nuovo`)
+- Manual: verify imported round detail page shows "no holes" notice
+- Manual: try invalid paste (wrong format, empty) → error messages shown
+- Manual: verify Valida=N rounds are skipped
+
+---
+
+## Files Changed
+
+### New files
+| File | Purpose |
+|---|---|
+| `src/pages/ImportRounds.page.tsx` | Route page |
+| `src/components/ImportRounds/ImportRounds.component.tsx` | Main orchestrator |
+| `src/components/ImportRounds/ImportForm.component.tsx` | Paste textarea + parse button |
+| `src/components/ImportRounds/PreviewTable.component.tsx` | Preview table |
+| `src/components/ImportRounds/ImportResult.component.tsx` | Success/failure summary |
+| `src/components/ImportRounds/ImportRoundParser.utils.ts` | CSV/TSV parser |
+| `src/components/ImportRounds/CourseMatcher.utils.ts` | Course matching algorithm |
+| `src/components/ImportRounds/RoundBuilder.utils.ts` | Build round objects for Firestore |
+
+### Modified files
+| File | Change |
+|---|---|
+| `src/App.tsx` | Add `/import-rounds` route |
+| `src/utils/links/links.utils.tsx` | Add nav link for Import Rounds |
+| `src/store/zustand/app.store.ts` | Add `importRounds` slice with parse/import/reset methods |
+| `src/utils/firestore/round.firestore.ts` | Add `importRoundsBatch()` function for bulk round creation |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import SettingsPage from './pages/Settings.page';
 import SharedLayout from './pages/SharedLayout.page';
 import SimulatorPage from './pages/Simulator.page';
 import HandicapHistoryPage from './pages/HandicapHistory.page';
+import ImportRoundsPage from './pages/ImportRounds.page';
 import Statistics from './pages/Statistics.page';
 import ThemeSetup from './styles/ThemeSetup.styles';
 
@@ -50,6 +51,7 @@ const App: React.FC = () => {
               <Route path='/statistics' element={<Statistics />} />
               <Route path='/simulator' element={<SimulatorPage />} />
               <Route path='/handicap-history' element={<HandicapHistoryPage />} />
+              <Route path='/import-rounds' element={<ImportRoundsPage />} />
               <Route path='/settings' element={<SettingsPage />} />
               <Route path="/admin/courses" element={<AdminRoute><AdminCoursesPage /></AdminRoute>} />
               <Route path="/admin/users" element={<AdminRoute><AdminUsersPage /></AdminRoute>} />

--- a/src/components/HandicapHistory/HandicapHistory.component.tsx
+++ b/src/components/HandicapHistory/HandicapHistory.component.tsx
@@ -97,7 +97,7 @@ const HandicapHistory = () => {
 	}
 
 	return (
-		<Box sx={{ p: 2 }}>
+		<Box>
 			<Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 3 }}>
 				<TimelineIcon sx={{ fontSize: 32 }} />
 				<Typography variant="headline2">Handicap History</Typography>

--- a/src/components/ImportRounds/CourseMatcher.utils.ts
+++ b/src/components/ImportRounds/CourseMatcher.utils.ts
@@ -1,0 +1,99 @@
+import { ICourse } from '@/types/course.types';
+import { getCourseByName, getAllCourses } from '@/utils/firestore/course.firestore';
+import { IParsedRound } from './ImportRoundParser.utils';
+
+export interface ICourseMatchResult {
+  courseId: string | null;
+  courseName: string;
+  matched: boolean;
+  matchMethod: 'exact' | 'like' | 'first' | null;
+  teeboxName: string;
+  teeboxPar: number;
+  teeboxCR: number;
+  teeboxSR: number;
+  warning: string | null;
+}
+
+export async function matchCourse(
+  courseName: string,
+  cr: number,
+  sr: number,
+  courses: ICourse[]
+): Promise<ICourseMatchResult> {
+  const normalizedName = courseName.trim().toUpperCase().replace(/\s+/g, ' ');
+
+  const exactMatch = courses.find((c) => c.name.toUpperCase() === normalizedName);
+  if (exactMatch) {
+    return findTeebox(exactMatch, cr, sr, 'exact');
+  }
+
+  const likeMatches = courses.filter(
+    (c) => c.name.toUpperCase().includes(normalizedName) || normalizedName.includes(c.name.toUpperCase())
+  );
+
+  if (likeMatches.length === 1) {
+    return findTeebox(likeMatches[0], cr, sr, 'like');
+  }
+
+  if (likeMatches.length > 1) {
+    const result = findTeebox(likeMatches[0], cr, sr, 'first');
+    result.warning = `Multiple courses matched '${courseName}'. Using first result.`;
+    return result;
+  }
+
+  return {
+    courseId: null,
+    courseName: courseName,
+    matched: false,
+    matchMethod: null,
+    teeboxName: '',
+    teeboxPar: 0,
+    teeboxCR: 0,
+    teeboxSR: 0,
+    warning: null,
+  };
+}
+
+function findTeebox(course: ICourse, cr: number, sr: number, method: 'exact' | 'like' | 'first'): ICourseMatchResult {
+  const teebox = course.teeboxes.find(
+    (t) => Math.abs(t.courseRating - cr) < 0.01 && t.slopeRating === sr
+  );
+
+  if (teebox) {
+    return {
+      courseId: course.id,
+      courseName: course.name,
+      matched: true,
+      matchMethod: method,
+      teeboxName: teebox.name,
+      teeboxPar: teebox.par,
+      teeboxCR: teebox.courseRating,
+      teeboxSR: teebox.slopeRating,
+      warning: null,
+    };
+  }
+
+  const firstTee = course.teeboxes[0];
+  return {
+    courseId: course.id,
+    courseName: course.name,
+    matched: true,
+    matchMethod: method,
+    teeboxName: firstTee?.name || '',
+    teeboxPar: firstTee?.par || 0,
+    teeboxCR: firstTee?.courseRating || 0,
+    teeboxSR: firstTee?.slopeRating || 0,
+    warning: firstTee
+      ? `No teebox with CR=${cr}/SR=${sr} found for '${course.name}'. Using '${firstTee.name}'.`
+      : `No teebox found for '${course.name}'.`,
+  };
+}
+
+export async function matchAllCourses(
+  parsedRounds: IParsedRound[],
+  courses: ICourse[]
+): Promise<ICourseMatchResult[]> {
+  return Promise.all(
+    parsedRounds.map((pr) => matchCourse(pr.roundCourse, pr.roundCR, pr.roundSR, courses))
+  );
+}

--- a/src/components/ImportRounds/ImportForm.component.tsx
+++ b/src/components/ImportRounds/ImportForm.component.tsx
@@ -32,7 +32,10 @@ export default function ImportForm({ onParse, isLoading, error }: ImportFormProp
         fullWidth
         minRows={8}
         maxRows={20}
-        placeholder={`Data\tGara\tCampo\tGiro\tFormula\tBuche\tValida\tPlaying HCP\tPar\tCR\tSR\tStbl\tAGS\tPCC\tSD`}
+        placeholder={`Paste your Federgolf rows here...
+
+Example:
+09/05/2026\tMuratory Wine\tBARLASSINA\t1\tSPM\t18\tS\t30,00\t72,00\t71,00\t132,00\t33,00\t105,00\t0,00\t29,1`}
         value={text}
         onChange={(e) => setText(e.target.value)}
         sx={{ fontFamily: 'monospace', mb: 2 }}

--- a/src/components/ImportRounds/ImportForm.component.tsx
+++ b/src/components/ImportRounds/ImportForm.component.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import { Box, Typography, TextField, Button, Alert } from '@mui/material';
+import FileUploadIcon from '@mui/icons-material/FileUpload';
+
+interface ImportFormProps {
+  onParse: (text: string) => void;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export default function ImportForm({ onParse, isLoading, error }: ImportFormProps) {
+  const [text, setText] = useState('');
+
+  return (
+    <Box>
+      <Typography variant="title3" gutterBottom sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <FileUploadIcon />
+        Import Rounds
+      </Typography>
+      <Typography variant="body" color="text.secondary" sx={{ mb: 2 }}>
+        Paste competition results from your Federgolf spreadsheet below.
+        One row per round. The parser accepts tab-separated, comma-separated,
+        or semicolon-separated data.
+      </Typography>
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
+      <TextField
+        multiline
+        fullWidth
+        minRows={8}
+        maxRows={20}
+        placeholder={`Data\tGara\tCampo\tGiro\tFormula\tBuche\tValida\tPlaying HCP\tPar\tCR\tSR\tStbl\tAGS\tPCC\tSD`}
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        sx={{ fontFamily: 'monospace', mb: 2 }}
+      />
+      <Button
+        variant="contained"
+        onClick={() => onParse(text)}
+        disabled={isLoading || !text.trim()}
+      >
+        {isLoading ? 'Parsing...' : 'Parse & Preview'}
+      </Button>
+    </Box>
+  );
+}

--- a/src/components/ImportRounds/ImportResult.component.tsx
+++ b/src/components/ImportRounds/ImportResult.component.tsx
@@ -1,0 +1,98 @@
+import { Box, Typography, Alert, Chip, Button, Divider, Paper } from '@mui/material';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import WarningIcon from '@mui/icons-material/Warning';
+import { IImportResult } from '@/types/round.types';
+
+interface ImportResultProps {
+  results: IImportResult;
+  onReset: () => void;
+}
+
+const formatHI = (val: number | null) =>
+  val !== null ? val.toFixed(1) : '—';
+
+export default function ImportResult({ results, onReset }: ImportResultProps) {
+  const hiMatch = results.expectedHI !== null &&
+    results.calculatedHI !== null &&
+    Math.abs(results.expectedHI - results.calculatedHI) < 0.1;
+
+  const hiMismatch = results.expectedHI !== null &&
+    results.calculatedHI !== null &&
+    !hiMatch;
+
+  return (
+    <Box>
+      <Typography variant="title3" gutterBottom sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <CheckCircleIcon color="success" />
+        Import Complete
+      </Typography>
+
+      <Alert severity="success" sx={{ mb: 2 }}>
+        {results.importedCount} round{results.importedCount !== 1 ? 's' : ''} imported successfully.
+      </Alert>
+
+      <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mb: 2 }}>
+        <Chip label={`${results.matchedCount} matched`} color="success" variant="outlined" />
+        <Chip label={`${results.unmatchedCount} unmatched`}
+          color={results.unmatchedCount > 0 ? 'warning' : 'default'}
+          variant="outlined"
+        />
+      </Box>
+
+      <Divider sx={{ mb: 2 }} />
+
+      {/* Handicap Index verification */}
+      <Typography variant="title6" gutterBottom>
+        Handicap Index Verification
+      </Typography>
+
+      <Box sx={{ display: 'flex', gap: 4, mb: 2 }}>
+        <Paper variant="outlined" sx={{ p: 2, flex: 1 }}>
+          <Typography variant="caption" color="text.secondary">Expected (Federgolf)</Typography>
+          <Typography variant="title4">{formatHI(results.expectedHI)}</Typography>
+        </Paper>
+        <Paper variant="outlined" sx={{ p: 2, flex: 1 }}>
+          <Typography variant="caption" color="text.secondary">Calculated (App Engine)</Typography>
+          <Typography variant="title4">{formatHI(results.calculatedHI)}</Typography>
+        </Paper>
+      </Box>
+
+      {hiMatch && (
+        <Alert icon={<CheckCircleIcon />} severity="success" sx={{ mb: 2 }}>
+          Handicap Index matches — the calculation engine produces the same result as Federgolf.
+        </Alert>
+      )}
+
+      {hiMismatch && (
+        <Alert icon={<WarningIcon />} severity="warning" sx={{ mb: 2 }}>
+          Handicap Index mismatch: Federgolf reports {formatHI(results.expectedHI)},
+          the app calculates {formatHI(results.calculatedHI)}.
+          {results.calculatedHI !== null && results.expectedHI !== null
+            ? ` Difference: ${(results.calculatedHI - results.expectedHI).toFixed(1)}`
+            : ''
+          }
+        </Alert>
+      )}
+
+      {results.expectedHI === null && results.calculatedHI !== null && (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          Imported rounds: HI = {formatHI(results.calculatedHI)}.
+          No previous HI from Federgolf for comparison.
+        </Alert>
+      )}
+
+      {results.warnings.length > 0 && (
+        <Box sx={{ mb: 2 }}>
+          <Typography variant="title6" color="warning.main">Warnings</Typography>
+          {results.warnings.map((w, i) => (
+            <Typography key={i} variant="body" color="text.secondary">• {w}</Typography>
+          ))}
+        </Box>
+      )}
+
+      <Button variant="outlined" onClick={onReset}>
+        Import More Rounds
+      </Button>
+    </Box>
+  );
+}

--- a/src/components/ImportRounds/ImportRoundParser.utils.ts
+++ b/src/components/ImportRounds/ImportRoundParser.utils.ts
@@ -1,0 +1,128 @@
+import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
+
+dayjs.extend(customParseFormat);
+
+export interface IParsedRound {
+  rowIndex: number;
+  roundDate: string;
+  roundCourse: string;
+  roundFormat: string;
+  roundHoles: number;
+  roundPar: number;
+  roundPlayingHCP: number;
+  roundCR: number;
+  roundSR: number;
+  stablefordPoints: number;
+  roundStrokes: number;
+  scoreDifferential: number | null;
+  roundValid: boolean;
+  indexVecchio: number | null;
+  indexNuovo: number | null;
+  parsedSuccessfully: boolean;
+}
+
+function parseItalianDecimal(value: string): number {
+  const cleaned = value.trim().replace(',', '.');
+  const result = parseFloat(cleaned);
+  return isNaN(result) ? 0 : result;
+}
+
+function detectDelimiter(firstLine: string): string {
+  const tabCount = (firstLine.match(/\t/g) || []).length;
+  const commaCount = (firstLine.match(/,/g) || []).length;
+  const semicolonCount = (firstLine.match(/;/g) || []).length;
+
+  if (tabCount >= commaCount && tabCount >= semicolonCount) return '\t';
+  if (commaCount >= semicolonCount) return ',';
+  return ';';
+}
+
+function isHeaderRow(cells: string[]): boolean {
+  const first = cells[0]?.trim().toLowerCase() || '';
+  return first === 'data' || first === '#';
+}
+
+export function parseImportText(text: string): IParsedRound[] {
+  const lines = text.split('\n').filter((line) => line.trim().length > 0);
+  if (lines.length === 0) return [];
+
+  const delimiter = detectDelimiter(lines[0]);
+  const results: IParsedRound[] = [];
+  let rowIndex = 0;
+
+  for (const line of lines) {
+    const cells = line.split(delimiter);
+
+    if (isHeaderRow(cells)) continue;
+
+    rowIndex++;
+    const parsed: IParsedRound = {
+      rowIndex,
+      roundDate: '',
+      roundCourse: '',
+      roundFormat: '',
+      roundHoles: 18,
+      roundPar: 0,
+      roundPlayingHCP: 0,
+      roundCR: 0,
+      roundSR: 0,
+      stablefordPoints: 0,
+      roundStrokes: 0,
+      scoreDifferential: null,
+      roundValid: true,
+      indexVecchio: null,
+      indexNuovo: null,
+      parsedSuccessfully: false,
+    };
+
+    try {
+      if (cells.length < 16) {
+        results.push(parsed);
+        continue;
+      }
+
+      const rawDate = cells[1]?.trim() || '';
+      const parsedDate = dayjs(rawDate, 'DD/MM/YYYY');
+      parsed.roundDate = parsedDate.isValid() ? parsedDate.toISOString() : '';
+      parsed.roundCourse = (cells[3]?.trim() || '').toUpperCase();
+      parsed.roundFormat = cells[5]?.trim() || '';
+      parsed.roundHoles = parseInt(cells[6]?.trim(), 10) || 18;
+      parsed.roundValid = cells[7]?.trim().toUpperCase() === 'S';
+      parsed.roundPlayingHCP = parseItalianDecimal(cells[8] || '0');
+      parsed.roundPar = parseInt(cells[9]?.trim(), 10) || 72;
+      parsed.roundCR = parseItalianDecimal(cells[10] || '0');
+      parsed.roundSR = parseInt(cells[11]?.trim(), 10) || 0;
+
+      const stblStr = cells[12]?.trim() || '';
+      parsed.stablefordPoints = stblStr ? parseInt(stblStr, 10) : 0;
+
+      const agsStr = cells[13]?.trim() || '';
+      parsed.roundStrokes = agsStr ? parseInt(agsStr, 10) : 0;
+
+      const sdStr = cells[15]?.trim() || '';
+      parsed.scoreDifferential = sdStr ? parseItalianDecimal(sdStr) : null;
+
+      const idxVecchioStr = cells[19]?.trim() || '';
+      parsed.indexVecchio = idxVecchioStr ? parseItalianDecimal(idxVecchioStr) : null;
+
+      const idxNuovoStr = cells[20]?.trim() || '';
+      parsed.indexNuovo = idxNuovoStr ? parseItalianDecimal(idxNuovoStr) : null;
+
+      parsed.parsedSuccessfully = true;
+    } catch {
+      // parsedSuccessfully remains false
+    }
+
+    results.push(parsed);
+  }
+
+  return results;
+}
+
+export function getColumnHeaders(text: string): string[] {
+  const firstLine = text.split('\n').find((line) => line.trim().length > 0);
+  if (!firstLine) return [];
+  const delimiter = detectDelimiter(firstLine);
+  return firstLine.split(delimiter).map((cell) => cell.trim());
+}

--- a/src/components/ImportRounds/ImportRoundParser.utils.ts
+++ b/src/components/ImportRounds/ImportRoundParser.utils.ts
@@ -77,37 +77,31 @@ export function parseImportText(text: string): IParsedRound[] {
     };
 
     try {
-      if (cells.length < 16) {
+      if (cells.length < 15) {
         results.push(parsed);
         continue;
       }
 
-      const rawDate = cells[1]?.trim() || '';
+      const rawDate = cells[0]?.trim() || '';
       const parsedDate = dayjs(rawDate, 'DD/MM/YYYY');
       parsed.roundDate = parsedDate.isValid() ? parsedDate.toISOString() : '';
-      parsed.roundCourse = (cells[3]?.trim() || '').toUpperCase();
-      parsed.roundFormat = cells[5]?.trim() || '';
-      parsed.roundHoles = parseInt(cells[6]?.trim(), 10) || 18;
-      parsed.roundValid = cells[7]?.trim().toUpperCase() === 'S';
-      parsed.roundPlayingHCP = parseItalianDecimal(cells[8] || '0');
-      parsed.roundPar = parseInt(cells[9]?.trim(), 10) || 72;
-      parsed.roundCR = parseItalianDecimal(cells[10] || '0');
-      parsed.roundSR = parseInt(cells[11]?.trim(), 10) || 0;
+      parsed.roundCourse = (cells[2]?.trim() || '').toUpperCase();
+      parsed.roundFormat = cells[4]?.trim() || '';
+      parsed.roundHoles = parseInt(cells[5]?.trim(), 10) || 18;
+      parsed.roundValid = cells[6]?.trim().toUpperCase() === 'S';
+      parsed.roundPlayingHCP = parseItalianDecimal(cells[7] || '0');
+      parsed.roundPar = parseInt(cells[8]?.trim(), 10) || 72;
+      parsed.roundCR = parseItalianDecimal(cells[9] || '0');
+      parsed.roundSR = parseInt(cells[10]?.trim(), 10) || 0;
 
-      const stblStr = cells[12]?.trim() || '';
+      const stblStr = cells[11]?.trim() || '';
       parsed.stablefordPoints = stblStr ? parseInt(stblStr, 10) : 0;
 
-      const agsStr = cells[13]?.trim() || '';
+      const agsStr = cells[12]?.trim() || '';
       parsed.roundStrokes = agsStr ? parseInt(agsStr, 10) : 0;
 
-      const sdStr = cells[15]?.trim() || '';
+      const sdStr = cells[14]?.trim() || '';
       parsed.scoreDifferential = sdStr ? parseItalianDecimal(sdStr) : null;
-
-      const idxVecchioStr = cells[19]?.trim() || '';
-      parsed.indexVecchio = idxVecchioStr ? parseItalianDecimal(idxVecchioStr) : null;
-
-      const idxNuovoStr = cells[20]?.trim() || '';
-      parsed.indexNuovo = idxNuovoStr ? parseItalianDecimal(idxNuovoStr) : null;
 
       parsed.parsedSuccessfully = true;
     } catch {

--- a/src/components/ImportRounds/ImportRounds.component.tsx
+++ b/src/components/ImportRounds/ImportRounds.component.tsx
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Box, Container, Paper } from '@mui/material';
+import { useAppStore } from '@/store/zustand/app.store';
+import ImportForm from './ImportForm.component';
+import PreviewTable from './PreviewTable.component';
+import ImportResult from './ImportResult.component';
+
+export default function ImportRoundsComponent() {
+  const parsedRounds = useAppStore((s) => s.parsedRounds);
+  const courseMatches = useAppStore((s) => s.courseMatches);
+  const importResults = useAppStore((s) => s.importResults);
+  const isLoadingImport = useAppStore((s) => s.isLoadingImport);
+  const importError = useAppStore((s) => s.importError);
+  const parseImportText = useAppStore((s) => s.parseImportText);
+  const importRounds = useAppStore((s) => s.importRounds);
+  const resetImport = useAppStore((s) => s.resetImport);
+
+  const [selectedIndices, setSelectedIndices] = useState<number[]>([]);
+
+  useEffect(() => {
+    if (parsedRounds.length > 0) {
+      const valid = parsedRounds
+        .map((r, i) => r.parsedSuccessfully && r.roundValid ? i : -1)
+        .filter((i) => i >= 0);
+      setSelectedIndices(valid);
+    }
+  }, [parsedRounds]);
+
+  const handleParseText = useCallback((text: string) => {
+    parseImportText(text);
+    setSelectedIndices([]);
+  }, [parseImportText]);
+
+  const handleImport = useCallback((indices: number[]) => {
+    importRounds(indices);
+  }, [importRounds]);
+
+  const handleReset = useCallback(() => {
+    resetImport();
+  }, [resetImport]);
+
+  return (
+    <Container maxWidth="lg" sx={{ py: 3 }}>
+      <Paper sx={{ p: 3 }}>
+        {importResults ? (
+          <ImportResult
+            results={importResults}
+            onReset={handleReset}
+          />
+        ) : parsedRounds.length === 0 ? (
+          <ImportForm
+            onParse={handleParseText}
+            isLoading={isLoadingImport}
+            error={importError}
+          />
+        ) : (
+          <PreviewTable
+            parsedRounds={parsedRounds}
+            courseMatches={courseMatches}
+            selectedIndices={selectedIndices}
+            onSelectionChange={setSelectedIndices}
+            onImport={handleImport}
+            isImporting={isLoadingImport}
+            importError={importError}
+          />
+        )}
+      </Paper>
+    </Container>
+  );
+}

--- a/src/components/ImportRounds/PreviewTable.component.tsx
+++ b/src/components/ImportRounds/PreviewTable.component.tsx
@@ -1,0 +1,188 @@
+import { useCallback } from 'react';
+import {
+  Box, Typography, Table, TableBody, TableCell, TableContainer,
+  TableHead, TableRow, Checkbox, Button, Alert, Paper, Chip, Tooltip,
+} from '@mui/material';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import CancelIcon from '@mui/icons-material/Cancel';
+import dayjs from 'dayjs';
+import { IParsedRound } from './ImportRoundParser.utils';
+import { ICourseMatchResult } from './CourseMatcher.utils';
+
+interface PreviewTableProps {
+  parsedRounds: IParsedRound[];
+  courseMatches: ICourseMatchResult[];
+  selectedIndices: number[];
+  onSelectionChange: (indices: number[]) => void;
+  onImport: (indices: number[]) => void;
+  isImporting: boolean;
+  importError: string | null;
+}
+
+export default function PreviewTable({
+  parsedRounds,
+  courseMatches,
+  selectedIndices,
+  onSelectionChange,
+  onImport,
+  isImporting,
+  importError,
+}: PreviewTableProps) {
+  const validRounds = parsedRounds.map((r, i) => ({ round: r, index: i }))
+    .filter(({ round }) => round.parsedSuccessfully && round.roundValid);
+
+  const invalidRounds = parsedRounds.filter(
+    (r) => !r.parsedSuccessfully || !r.roundValid
+  ).length;
+
+  const allSelected = validRounds.length > 0 && selectedIndices.length === validRounds.length;
+
+  const handleSelectAll = useCallback(() => {
+    if (allSelected) {
+      onSelectionChange([]);
+    } else {
+      onSelectionChange(validRounds.map(({ index }) => index));
+    }
+  }, [allSelected, validRounds, onSelectionChange]);
+
+  const handleSelect = useCallback((index: number) => {
+    onSelectionChange(
+      selectedIndices.includes(index)
+        ? selectedIndices.filter((i) => i !== index)
+        : [...selectedIndices, index]
+    );
+  }, [selectedIndices, onSelectionChange]);
+
+  const formatDate = (iso: string) => {
+    const d = dayjs(iso);
+    return d.isValid() ? d.format('DD/MM/YYYY') : '—';
+  };
+
+  return (
+    <Box>
+      <Typography variant="title3" gutterBottom>
+        Preview
+        <Typography variant="body" color="text.secondary" component="span" sx={{ ml: 1 }}>
+          ({parsedRounds.length} rounds, {validRounds.length} valid
+          {invalidRounds > 0 ? `, ${invalidRounds} invalid` : ''})
+        </Typography>
+      </Typography>
+
+      {importError && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {importError}
+        </Alert>
+      )}
+
+      {validRounds.length === 0 ? (
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          No valid rounds found. Check that your data has the correct format.
+        </Alert>
+      ) : (
+        <>
+          <TableContainer component={Paper} sx={{ maxHeight: 500, mb: 2 }}>
+            <Table stickyHeader size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell padding="checkbox">
+                    <Checkbox
+                      checked={allSelected}
+                      indeterminate={selectedIndices.length > 0 && !allSelected}
+                      onChange={handleSelectAll}
+                    />
+                  </TableCell>
+                  <TableCell>#</TableCell>
+                  <TableCell>Data</TableCell>
+                  <TableCell>Campo</TableCell>
+                  <TableCell>Match</TableCell>
+                  <TableCell>Tee</TableCell>
+                  <TableCell align="right">Par</TableCell>
+                  <TableCell align="right">PHCP</TableCell>
+                  <TableCell align="right">Stbl</TableCell>
+                  <TableCell align="right">AGS</TableCell>
+                  <TableCell align="right">SD</TableCell>
+                  <TableCell>Valida</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {parsedRounds.map((round, index) => {
+                  const isSelectable = round.parsedSuccessfully && round.roundValid;
+                  const match = courseMatches[index];
+
+                  return (
+                    <TableRow
+                      key={index}
+                      selected={selectedIndices.includes(index)}
+                      sx={{
+                        opacity: isSelectable ? 1 : 0.5,
+                        '&:last-child td, &:last-child th': { border: 0 },
+                      }}
+                    >
+                      <TableCell padding="checkbox">
+                        <Checkbox
+                          checked={selectedIndices.includes(index)}
+                          onChange={() => handleSelect(index)}
+                          disabled={!isSelectable}
+                        />
+                      </TableCell>
+                      <TableCell>{round.rowIndex}</TableCell>
+                      <TableCell>{formatDate(round.roundDate)}</TableCell>
+                      <TableCell>{round.roundCourse}</TableCell>
+                      <TableCell>
+                        {match ? (
+                          <Tooltip title={
+                            match.matched
+                              ? `Matched: ${match.matchMethod}`
+                              : 'Course not found in database'
+                          }>
+                            {match.matched
+                              ? <CheckCircleIcon color="success" fontSize="small" />
+                              : <CancelIcon color="error" fontSize="small" />
+                            }
+                          </Tooltip>
+                        ) : (
+                          <Chip label="—" size="small" variant="outlined" />
+                        )}
+                      </TableCell>
+                      <TableCell>{match?.teeboxName || '—'}</TableCell>
+                      <TableCell align="right">{round.roundPar}</TableCell>
+                      <TableCell align="right">{round.roundPlayingHCP}</TableCell>
+                      <TableCell align="right">{round.stablefordPoints}</TableCell>
+                      <TableCell align="right">{round.roundStrokes}</TableCell>
+                      <TableCell align="right">
+                        {round.scoreDifferential !== null
+                          ? round.scoreDifferential.toFixed(1)
+                          : '—'
+                        }
+                      </TableCell>
+                      <TableCell>
+                        {round.parsedSuccessfully
+                          ? round.roundValid
+                            ? <CheckCircleIcon color="success" fontSize="small" />
+                            : <CancelIcon color="warning" fontSize="small" />
+                          : '?'
+                        }
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </TableContainer>
+
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={() => onImport(selectedIndices)}
+            disabled={selectedIndices.length === 0 || isImporting}
+          >
+            {isImporting
+              ? 'Importing...'
+              : `Import ${selectedIndices.length} Selected Round${selectedIndices.length !== 1 ? 's' : ''}`
+            }
+          </Button>
+        </>
+      )}
+    </Box>
+  );
+}

--- a/src/components/ImportRounds/RoundBuilder.utils.ts
+++ b/src/components/ImportRounds/RoundBuilder.utils.ts
@@ -1,0 +1,58 @@
+import { Timestamp, FieldValue, serverTimestamp } from 'firebase/firestore';
+import { IRoundTotals } from '@/types/roundTotals.types';
+import { initialStateRoundTotals } from '@/utils/constant.utils';
+import { IParsedRound } from './ImportRoundParser.utils';
+import { ICourseMatchResult } from './CourseMatcher.utils';
+
+export interface IRoundImportDocument {
+  roundDate: Timestamp;
+  roundCourse: string;
+  roundCourseRef: string | null;
+  roundHoles: 18;
+  roundTee: string;
+  roundPar: number;
+  roundPlayingHCP: number;
+  roundStrokes: number;
+  roundFormat: string;
+  roundValid: boolean;
+  roundNumber: number;
+  totals: IRoundTotals;
+  scoreDifferential: number | null;
+  userId: string;
+  importSource: 'federgolf-sheet';
+  createdAt: FieldValue;
+}
+
+export function createEmptyRoundTotals(): IRoundTotals {
+  return JSON.parse(JSON.stringify(initialStateRoundTotals));
+}
+
+export function buildRoundDocument(params: {
+  parsed: IParsedRound;
+  match: ICourseMatchResult;
+  roundNumber: number;
+  userId: string;
+}): IRoundImportDocument {
+  const totals = createEmptyRoundTotals();
+  totals.score.totals = params.parsed.roundStrokes;
+  totals.points.totals = params.parsed.stablefordPoints;
+
+  return {
+    roundDate: Timestamp.fromDate(new Date(params.parsed.roundDate)),
+    roundCourse: params.match.matched ? params.match.courseName : params.parsed.roundCourse,
+    roundCourseRef: params.match.courseId,
+    roundHoles: 18,
+    roundTee: params.match.matched ? params.match.teeboxName : '',
+    roundPar: params.parsed.roundPar,
+    roundPlayingHCP: params.parsed.roundPlayingHCP,
+    roundStrokes: params.parsed.roundStrokes,
+    roundFormat: params.parsed.roundFormat,
+    roundValid: params.parsed.roundValid,
+    roundNumber: params.roundNumber,
+    totals,
+    scoreDifferential: params.parsed.scoreDifferential,
+    userId: params.userId,
+    importSource: 'federgolf-sheet',
+    createdAt: serverTimestamp(),
+  };
+}

--- a/src/components/NewRound/AddNewRoundForm.component.tsx
+++ b/src/components/NewRound/AddNewRoundForm.component.tsx
@@ -165,8 +165,9 @@ const AddNewRoundForm = () => {
 			onClose={handleCancel}
 			onSubmit={handleSubmit(onSubmit)}
 		>
-			<Grid container spacing={1} sx={{ mt: 1 }} columns={{ xs: 12, sm: 12, lg: 12 }}>
-				<Grid size={{ xs: 12, sm: 6, lg: 6 }}>
+			<Grid container spacing={2} sx={{ mt: 1 }} columns={{ xs: 12, sm: 12, lg: 12 }}>
+				{/* Row 1: Course + Date + Round # */}
+				<Grid size={{ xs: 12, sm: 7, lg: 7 }}>
 					<Autocomplete
 						disablePortal
 						options={courses}
@@ -181,15 +182,21 @@ const AddNewRoundForm = () => {
 						value={selectedCourse}
 						onChange={(_, newValue) => handleCourseChange(newValue)}
 						loading={courseLoading}
+						slotProps={{
+							listbox: {
+								sx: { maxHeight: 350 },
+							},
+						}}
 						renderInput={(params) => (
 							<TextField
 								{...params}
 								label="Round course"
+								placeholder="Search for a course..."
 							/>
 						)}
 					/>
 				</Grid>
-				<Grid size={{ xs: 12, sm: 6, lg: 6 }}>
+				<Grid size={{ xs: 7, sm: 3, lg: 3 }}>
 					<DatePicker
 						value={roundDateValue}
 						onChange={handleDateChange}
@@ -197,7 +204,36 @@ const AddNewRoundForm = () => {
 						format="DD/MM/YYYY"
 					/>
 				</Grid>
-				<Grid size={{ xs: 4, sm: 2, lg: 2 }}>
+				<Grid size={{ xs: 5, sm: 2, lg: 2 }}>
+					<TextField
+						{...register('roundNumber', {
+							valueAsNumber: true,
+							min: { value: 1, message: 'Min 1' }
+						})}
+						label="Round #"
+						variant="outlined"
+						type='number'
+						fullWidth
+						error={!!errors.roundNumber}
+						helperText={errors.roundNumber?.message}
+					/>
+				</Grid>
+
+				{/* Row 2: Tee + Holes + Par + Playing HCP */}
+				<Grid size={{ xs: 6, sm: 4, lg: 4 }}>
+					<Select
+						name='roundTee'
+						value={watch('roundTee') || ''}
+						label='Tee'
+						list={
+							selectedCourse
+								? selectedCourse.teeboxes.map((t) => t.name)
+								: ['White', 'Blue', 'Yellow', 'Red', 'Green', 'Orange']
+						}
+						onChange={(e: any) => setValue('roundTee', e.target.value)}
+					/>
+				</Grid>
+				<Grid size={{ xs: 3, sm: 2, lg: 2 }}>
 					<TextField
 						{...register('roundHoles', {
 							required: 'Required',
@@ -216,7 +252,7 @@ const AddNewRoundForm = () => {
 						helperText={errors.roundHoles?.message}
 					/>
 				</Grid>
-				<Grid size={{ xs: 4, sm: 2, lg: 2 }}>
+				<Grid size={{ xs: 3, sm: 2, lg: 2 }}>
 					<TextField
 						{...register('roundPar', {
 							required: 'Required',
@@ -235,53 +271,26 @@ const AddNewRoundForm = () => {
 						helperText={errors.roundPar?.message}
 					/>
 				</Grid>
-				<Grid size={{ xs: 4, sm: 2, lg: 2 }}>
+				<Grid size={{ xs: 12, sm: 4, lg: 4 }}>
 					<TextField
 						{...register('roundPlayingHCP', {
 							valueAsNumber: true,
 							min: { value: 0, message: 'Min 0' },
 							max: { value: 54, message: 'Max 54' }
 						})}
-						label="HCP"
+						label="Playing Handicap"
 						variant="outlined"
 						fullWidth
 						type='number'
 						slotProps={{
 							input: { readOnly: autoPlayingHCP != null },
 						}}
-						error={!!errors.roundPlayingHCP}
+						error={!autoPlayingHCP && !!errors.roundPlayingHCP}
 						helperText={
 							autoPlayingHCP != null
 								? `Auto-calculated from HI: ${currentHI?.toFixed(1)}`
 								: errors.roundPlayingHCP?.message
 						}
-					/>
-				</Grid>
-				<Grid size={{ xs: 6, sm: 3, lg: 3 }}>
-					<Select
-						name='roundTee'
-						value={watch('roundTee') || ''}
-						label='Tee'
-						list={
-							selectedCourse
-								? selectedCourse.teeboxes.map((t) => t.name)
-								: ['White', 'Blue', 'Yellow', 'Red', 'Green', 'Orange']
-						}
-						onChange={(e: any) => setValue('roundTee', e.target.value)}
-					/>
-				</Grid>
-				<Grid size={{ xs: 6, sm: 3, lg: 3 }}>
-					<TextField
-						{...register('roundNumber', {
-							valueAsNumber: true,
-							min: { value: 1, message: 'Min 1' }
-						})}
-						label="Round #"
-						variant="outlined"
-						type='number'
-						fullWidth
-						error={!!errors.roundNumber}
-						helperText={errors.roundNumber?.message}
 					/>
 				</Grid>
 			</Grid>

--- a/src/components/NewRound/AddNewRoundForm.component.tsx
+++ b/src/components/NewRound/AddNewRoundForm.component.tsx
@@ -1,7 +1,9 @@
 import { Dialog } from '@/styles/dialog/Dialog.styles';
 import { INewRound } from '@/types/round.types';
-import { ICourse, ITeebox } from '@/types/course.types';
+import { ICourse } from '@/types/course.types';
 import { getAllCourses } from '@/utils/firestore/course.firestore';
+import { calculateHandicapIndex } from '@/utils/whs/hi.utils';
+import { calculatePlayingHandicap } from '@/utils/whs/whs.utils';
 import {
 	Grid,
 	TextField,
@@ -9,7 +11,7 @@ import {
 } from '@mui/material';
 import { DatePicker } from '@mui/x-date-pickers';
 import dayjs, { Dayjs } from 'dayjs';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import Select from './components/Select.component';
@@ -37,7 +39,8 @@ const AddNewRoundForm = () => {
 	const setRoundPlayingHCP = useAppStore((state) => state.setRoundPlayingHCP);
 	const setRoundTee = useAppStore((state) => state.setRoundTee);
 	const setRoundNumber = useAppStore((state) => state.setRoundNumber);
-	const holes = useAppStore((state) => state.newRoundHoles.holes);
+	const holesList = useAppStore((state) => state.newRoundHoles.holes);
+	const roundsList = useAppStore((state) => state.roundsList);
 
 	const [courses, setCourses] = useState<ICourse[]>([]);
 	const [selectedCourse, setSelectedCourse] = useState<ICourse | null>(null);
@@ -59,6 +62,31 @@ const AddNewRoundForm = () => {
 	});
 
 	const watchedTee = watch('roundTee');
+
+	// Current Handicap Index from rounds
+	const currentHI = useMemo(() => {
+		const sds = roundsList
+			.filter((r) => r.scoreDifferential != null)
+			.map((r) => r.scoreDifferential as number);
+		return calculateHandicapIndex(sds);
+	}, [roundsList]);
+
+	// Find selected teebox
+	const selectedTeebox = useMemo(() => {
+		if (!selectedCourse || !watchedTee) return null;
+		return selectedCourse.teeboxes.find((t) => t.name === watchedTee) || null;
+	}, [selectedCourse, watchedTee]);
+
+	// Auto-calculated Playing Handicap
+	const autoPlayingHCP = useMemo(() => {
+		if (!selectedTeebox || currentHI == null) return null;
+		return calculatePlayingHandicap(
+			currentHI,
+			selectedTeebox.courseRating,
+			selectedTeebox.slopeRating,
+			selectedTeebox.par
+		);
+	}, [selectedTeebox, currentHI]);
 
 	useEffect(() => {
 		if (!roundDateString) {
@@ -93,15 +121,15 @@ const AddNewRoundForm = () => {
 		}
 	};
 
-	// Auto-fill par when tee changes
+	// Auto-fill par and playing HCP when tee changes
 	useEffect(() => {
-		if (selectedCourse && watchedTee) {
-			const teebox = selectedCourse.teeboxes.find((t) => t.name === watchedTee);
-			if (teebox) {
-				setValue('roundPar', teebox.par);
+		if (selectedTeebox) {
+			setValue('roundPar', selectedTeebox.par);
+			if (autoPlayingHCP != null) {
+				setValue('roundPlayingHCP', autoPlayingHCP);
 			}
 		}
-	}, [watchedTee, selectedCourse, setValue]);
+	}, [selectedTeebox, autoPlayingHCP, setValue]);
 
 	const handleDateChange = (newValue: Dayjs | null) => {
 		setRoundDate(newValue);
@@ -127,6 +155,8 @@ const AddNewRoundForm = () => {
 		setRoundMainData({});
 		navigate('/dashboard');
 	};
+
+	const courseSelected = selectedCourse != null;
 
 	return (
 		<Dialog
@@ -179,6 +209,7 @@ const AddNewRoundForm = () => {
 						variant='outlined'
 						type='number'
 						fullWidth
+						disabled={courseSelected}
 						error={!!errors.roundHoles}
 						helperText={errors.roundHoles?.message}
 					/>
@@ -195,6 +226,7 @@ const AddNewRoundForm = () => {
 						variant="outlined"
 						type='number'
 						fullWidth
+						disabled={courseSelected}
 						error={!!errors.roundPar}
 						helperText={errors.roundPar?.message}
 					/>
@@ -210,8 +242,13 @@ const AddNewRoundForm = () => {
 						variant="outlined"
 						fullWidth
 						type='number'
+						disabled={autoPlayingHCP != null}
 						error={!!errors.roundPlayingHCP}
-						helperText={errors.roundPlayingHCP?.message}
+						helperText={
+							autoPlayingHCP != null
+								? `Auto-calculated from HI: ${currentHI?.toFixed(1)}`
+								: errors.roundPlayingHCP?.message
+						}
 					/>
 				</Grid>
 				<Grid size={{ xs: 6, sm: 3, lg: 3 }}>

--- a/src/components/NewRound/AddNewRoundForm.component.tsx
+++ b/src/components/NewRound/AddNewRoundForm.component.tsx
@@ -209,7 +209,9 @@ const AddNewRoundForm = () => {
 						variant='outlined'
 						type='number'
 						fullWidth
-						disabled={courseSelected}
+						slotProps={{
+							input: { readOnly: courseSelected },
+						}}
 						error={!!errors.roundHoles}
 						helperText={errors.roundHoles?.message}
 					/>
@@ -226,7 +228,9 @@ const AddNewRoundForm = () => {
 						variant="outlined"
 						type='number'
 						fullWidth
-						disabled={courseSelected}
+						slotProps={{
+							input: { readOnly: courseSelected },
+						}}
 						error={!!errors.roundPar}
 						helperText={errors.roundPar?.message}
 					/>
@@ -242,7 +246,9 @@ const AddNewRoundForm = () => {
 						variant="outlined"
 						fullWidth
 						type='number'
-						disabled={autoPlayingHCP != null}
+						slotProps={{
+							input: { readOnly: autoPlayingHCP != null },
+						}}
 						error={!!errors.roundPlayingHCP}
 						helperText={
 							autoPlayingHCP != null

--- a/src/components/NewRound/AddNewRoundForm.component.tsx
+++ b/src/components/NewRound/AddNewRoundForm.component.tsx
@@ -134,11 +134,11 @@ const AddNewRoundForm = () => {
 			title='New round: basic info'
 			onClose={handleCancel}
 			onSubmit={handleSubmit(onSubmit)}
-			onClick={handleSubmit(onSubmit)}
 		>
 			<Grid container spacing={1} sx={{ mt: 1 }} columns={{ xs: 12, sm: 12, lg: 12 }}>
 				<Grid size={{ xs: 12, sm: 6, lg: 6 }}>
 					<Autocomplete
+						disablePortal
 						options={courses}
 						getOptionLabel={(course) =>
 							course.city
@@ -155,8 +155,6 @@ const AddNewRoundForm = () => {
 							<TextField
 								{...params}
 								label="Round course"
-								error={!!errors.roundCourse}
-								helperText={errors.roundCourse?.message}
 							/>
 						)}
 					/>

--- a/src/components/NewRound/AddNewRoundForm.component.tsx
+++ b/src/components/NewRound/AddNewRoundForm.component.tsx
@@ -1,187 +1,251 @@
 import { Dialog } from '@/styles/dialog/Dialog.styles';
 import { INewRound } from '@/types/round.types';
+import { ICourse, ITeebox } from '@/types/course.types';
+import { getAllCourses } from '@/utils/firestore/course.firestore';
 import {
-  Grid,
-  TextField
+	Grid,
+	TextField,
+	Autocomplete,
 } from '@mui/material';
 import { DatePicker } from '@mui/x-date-pickers';
 import dayjs, { Dayjs } from 'dayjs';
-import { useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import Select from './components/Select.component';
 import { useAppStore } from '@/store/zustand';
 
 interface FormValues {
-  roundCourse: string;
-  roundHoles: number;
-  roundPar: number;
-  roundPlayingHCP: number;
-  roundTee: string;
-  roundNumber: number;
-  roundDate: Dayjs | null;
+	roundCourse: string;
+	roundHoles: number;
+	roundPar: number;
+	roundPlayingHCP: number;
+	roundTee: string;
+	roundNumber: number;
+	roundDate: Dayjs | null;
 }
 
 const AddNewRoundForm = () => {
-  const navigate = useNavigate();
-  const roundData = useAppStore((state) => state.newRoundMain.round);
-  const setFirstHole = useAppStore((state) => state.newRoundMain.setFirstHole);
-  const setRoundDate = useAppStore((state) => state.setRoundDate);
-  const setRoundMainData = useAppStore((state) => state.setRoundMainData);
-  const setRoundCourse = useAppStore((state) => state.setRoundCourse);
-  const setRoundHoles = useAppStore((state) => state.setRoundHoles);
-  const setRoundPar = useAppStore((state) => state.setRoundPar);
-  const setRoundPlayingHCP = useAppStore((state) => state.setRoundPlayingHCP);
-  const setRoundTee = useAppStore((state) => state.setRoundTee);
-  const setRoundNumber = useAppStore((state) => state.setRoundNumber);
-  const holes = useAppStore((state) => state.newRoundHoles.holes);
-  
-  const roundDateString = roundData.roundDate;
-  const roundDateValue = roundDateString && dayjs(roundDateString).isValid() ? dayjs(roundDateString) : dayjs(new Date());
+	const navigate = useNavigate();
+	const roundData = useAppStore((state) => state.newRoundMain.round);
+	const setFirstHole = useAppStore((state) => state.newRoundMain.setFirstHole);
+	const setRoundDate = useAppStore((state) => state.setRoundDate);
+	const setRoundMainData = useAppStore((state) => state.setRoundMainData);
+	const setRoundCourse = useAppStore((state) => state.setRoundCourse);
+	const setRoundHoles = useAppStore((state) => state.setRoundHoles);
+	const setRoundPar = useAppStore((state) => state.setRoundPar);
+	const setRoundPlayingHCP = useAppStore((state) => state.setRoundPlayingHCP);
+	const setRoundTee = useAppStore((state) => state.setRoundTee);
+	const setRoundNumber = useAppStore((state) => state.setRoundNumber);
+	const holes = useAppStore((state) => state.newRoundHoles.holes);
 
-  const { register, handleSubmit, setValue, watch, formState: { errors } } = useForm<FormValues>({
-    defaultValues: {
-      roundCourse: roundData.roundCourse || '',
-      roundHoles: roundData.roundHoles || 18,
-      roundPar: roundData.roundPar || 72,
-      roundPlayingHCP: roundData.roundPlayingHCP || 0,
-      roundTee: roundData.roundTee || 'White',
-      roundNumber: roundData.roundNumber || 1,
-      roundDate: roundDateValue,
-    }
-  });
+	const [courses, setCourses] = useState<ICourse[]>([]);
+	const [selectedCourse, setSelectedCourse] = useState<ICourse | null>(null);
+	const [courseLoading, setCourseLoading] = useState(false);
 
-  useEffect(() => {
-    if (!roundDateString) {
-      setRoundDate(dayjs(new Date()));
-    }
-  }, [roundDateString, setRoundDate]);
+	const roundDateString = roundData.roundDate;
+	const roundDateValue = roundDateString && dayjs(roundDateString).isValid() ? dayjs(roundDateString) : dayjs(new Date());
 
-  const handleDateChange = (newValue: Dayjs | null) => {
-    setRoundDate(newValue);
-    setValue('roundDate', newValue);
-  };
+	const { register, handleSubmit, setValue, watch, formState: { errors } } = useForm<FormValues>({
+		defaultValues: {
+			roundCourse: roundData.roundCourse || '',
+			roundHoles: roundData.roundHoles || 18,
+			roundPar: roundData.roundPar || 72,
+			roundPlayingHCP: roundData.roundPlayingHCP || 0,
+			roundTee: roundData.roundTee || 'White',
+			roundNumber: roundData.roundNumber || 1,
+			roundDate: roundDateValue,
+		}
+	});
 
-  const onSubmit = (data: FormValues) => {
-    setRoundCourse(data.roundCourse);
-    setRoundHoles(data.roundHoles);
-    setRoundPar(data.roundPar);
-    setRoundPlayingHCP(data.roundPlayingHCP);
-    setRoundTee(data.roundTee);
-    setRoundNumber(data.roundNumber);
-    
-    const roundForTotals: INewRound = {
-      ...data,
-      roundDate: data.roundDate?.toString() || '',
-    };
-    setRoundMainData({});
-  };
+	const watchedTee = watch('roundTee');
 
-  const handleCancel = () => {
-    setRoundMainData({});
-    navigate('/dashboard');
-  }
+	useEffect(() => {
+		if (!roundDateString) {
+			setRoundDate(dayjs(new Date()));
+		}
+	}, [roundDateString, setRoundDate]);
 
-  return (
-    <Dialog
-      open={!setFirstHole}
-      title='New round: basic info'
-      onClose={handleCancel}
-      onSubmit={handleSubmit(onSubmit)}
-      onClick={handleSubmit(onSubmit)}
-    >
-      <Grid container spacing={1} sx={{ mt: 1 }} columns={{ xs: 12, sm: 12, lg: 12 }}>
-        <Grid size={{ xs: 12, sm: 6, lg: 6 }}>
-          <TextField
-            {...register('roundCourse', { required: 'Course name is required' })}
-            label="Round course"
-            variant="outlined"
-            fullWidth
-            error={!!errors.roundCourse}
-            helperText={errors.roundCourse?.message}
-          />
-        </Grid>
-        <Grid size={{ xs: 12, sm: 6, lg: 6 }}>
-          <DatePicker
-            value={roundDateValue}
-            onChange={handleDateChange}
-            sx={{ width: '100%' }}
-            format="DD/MM/YYYY"
-          />
-        </Grid>
-        <Grid size={{ xs: 4, sm: 2, lg: 2 }}>
-          <TextField
-            {...register('roundHoles', { 
-              required: 'Required',
-              min: { value: 1, message: 'Min 1' },
-              max: { value: 18, message: 'Max 18' },
-              valueAsNumber: true 
-            })}
-            label="Holes"
-            variant='outlined'
-            type='number'
-            fullWidth
-            error={!!errors.roundHoles}
-            helperText={errors.roundHoles?.message}
-          />
-        </Grid>
-        <Grid size={{ xs: 4, sm: 2, lg: 2 }}>
-          <TextField
-            {...register('roundPar', { 
-              required: 'Required',
-              min: { value: 18, message: 'Min 18' },
-              max: { value: 99, message: 'Max 99' },
-              valueAsNumber: true 
-            })}
-            label="Par"
-            variant="outlined"
-            type='number'
-            fullWidth
-            error={!!errors.roundPar}
-            helperText={errors.roundPar?.message}
-          />
-        </Grid>
-        <Grid size={{ xs: 4, sm: 2, lg: 2 }}>
-          <TextField
-            {...register('roundPlayingHCP', { 
-              valueAsNumber: true,
-              min: { value: 0, message: 'Min 0' },
-              max: { value: 54, message: 'Max 54' }
-            })}
-            label="HCP"
-            variant="outlined"
-            fullWidth
-            type='number'
-            error={!!errors.roundPlayingHCP}
-            helperText={errors.roundPlayingHCP?.message}
-          />
-        </Grid>
-        <Grid size={{ xs: 6, sm: 3, lg: 3 }}>
-          <Select
-            name='roundTee'
-            value={watch('roundTee') || ''}
-            label='Tee'
-            list={['White', 'Blue', 'Yellow', 'Red', 'Green', 'Orange']}
-            onChange={(e: any) => setValue('roundTee', e.target.value)}
-          />
-        </Grid>
-        <Grid size={{ xs: 6, sm: 3, lg: 3 }}>
-          <TextField
-            {...register('roundNumber', { 
-              valueAsNumber: true,
-              min: { value: 1, message: 'Min 1' }
-            })}
-            label="Round #"
-            variant="outlined"
-            type='number'
-            fullWidth
-            error={!!errors.roundNumber}
-            helperText={errors.roundNumber?.message}
-          />
-        </Grid>
-      </Grid>
-    </Dialog>
-  )
-}
+	useEffect(() => {
+		setCourseLoading(true);
+		getAllCourses()
+			.then((all) => {
+				setCourses(all.filter((c) => c.status === 'Active'));
+				setCourseLoading(false);
+			})
+			.catch(() => {
+				setCourseLoading(false);
+			});
+	}, []);
 
-export default AddNewRoundForm
+	// Auto-fill first available teebox when course changes
+	const handleCourseChange = (course: ICourse | null) => {
+		setSelectedCourse(course);
+		if (course) {
+			setValue('roundCourse', course.name);
+			setValue('roundHoles', course.holes);
+			if (course.teeboxes.length > 0) {
+				const firstTee = course.teeboxes[0].name;
+				setValue('roundTee', firstTee);
+			}
+		} else {
+			setValue('roundCourse', '');
+		}
+	};
+
+	// Auto-fill par when tee changes
+	useEffect(() => {
+		if (selectedCourse && watchedTee) {
+			const teebox = selectedCourse.teeboxes.find((t) => t.name === watchedTee);
+			if (teebox) {
+				setValue('roundPar', teebox.par);
+			}
+		}
+	}, [watchedTee, selectedCourse, setValue]);
+
+	const handleDateChange = (newValue: Dayjs | null) => {
+		setRoundDate(newValue);
+		setValue('roundDate', newValue);
+	};
+
+	const onSubmit = (data: FormValues) => {
+		setRoundCourse(data.roundCourse);
+		setRoundHoles(data.roundHoles);
+		setRoundPar(data.roundPar);
+		setRoundPlayingHCP(data.roundPlayingHCP);
+		setRoundTee(data.roundTee);
+		setRoundNumber(data.roundNumber);
+
+		const roundForTotals: INewRound = {
+			...data,
+			roundDate: data.roundDate?.toString() || '',
+		};
+		setRoundMainData({});
+	};
+
+	const handleCancel = () => {
+		setRoundMainData({});
+		navigate('/dashboard');
+	};
+
+	return (
+		<Dialog
+			open={!setFirstHole}
+			title='New round: basic info'
+			onClose={handleCancel}
+			onSubmit={handleSubmit(onSubmit)}
+			onClick={handleSubmit(onSubmit)}
+		>
+			<Grid container spacing={1} sx={{ mt: 1 }} columns={{ xs: 12, sm: 12, lg: 12 }}>
+				<Grid size={{ xs: 12, sm: 6, lg: 6 }}>
+					<Autocomplete
+						options={courses}
+						getOptionLabel={(course) =>
+							course.city
+								? `${course.name} (${course.city})`
+								: course.name
+						}
+						isOptionEqualToValue={(option, value) =>
+							option.id === value.id
+						}
+						value={selectedCourse}
+						onChange={(_, newValue) => handleCourseChange(newValue)}
+						loading={courseLoading}
+						renderInput={(params) => (
+							<TextField
+								{...params}
+								label="Round course"
+								error={!!errors.roundCourse}
+								helperText={errors.roundCourse?.message}
+							/>
+						)}
+					/>
+				</Grid>
+				<Grid size={{ xs: 12, sm: 6, lg: 6 }}>
+					<DatePicker
+						value={roundDateValue}
+						onChange={handleDateChange}
+						sx={{ width: '100%' }}
+						format="DD/MM/YYYY"
+					/>
+				</Grid>
+				<Grid size={{ xs: 4, sm: 2, lg: 2 }}>
+					<TextField
+						{...register('roundHoles', {
+							required: 'Required',
+							min: { value: 1, message: 'Min 1' },
+							max: { value: 18, message: 'Max 18' },
+							valueAsNumber: true
+						})}
+						label="Holes"
+						variant='outlined'
+						type='number'
+						fullWidth
+						error={!!errors.roundHoles}
+						helperText={errors.roundHoles?.message}
+					/>
+				</Grid>
+				<Grid size={{ xs: 4, sm: 2, lg: 2 }}>
+					<TextField
+						{...register('roundPar', {
+							required: 'Required',
+							min: { value: 18, message: 'Min 18' },
+							max: { value: 99, message: 'Max 99' },
+							valueAsNumber: true
+						})}
+						label="Par"
+						variant="outlined"
+						type='number'
+						fullWidth
+						error={!!errors.roundPar}
+						helperText={errors.roundPar?.message}
+					/>
+				</Grid>
+				<Grid size={{ xs: 4, sm: 2, lg: 2 }}>
+					<TextField
+						{...register('roundPlayingHCP', {
+							valueAsNumber: true,
+							min: { value: 0, message: 'Min 0' },
+							max: { value: 54, message: 'Max 54' }
+						})}
+						label="HCP"
+						variant="outlined"
+						fullWidth
+						type='number'
+						error={!!errors.roundPlayingHCP}
+						helperText={errors.roundPlayingHCP?.message}
+					/>
+				</Grid>
+				<Grid size={{ xs: 6, sm: 3, lg: 3 }}>
+					<Select
+						name='roundTee'
+						value={watch('roundTee') || ''}
+						label='Tee'
+						list={
+							selectedCourse
+								? selectedCourse.teeboxes.map((t) => t.name)
+								: ['White', 'Blue', 'Yellow', 'Red', 'Green', 'Orange']
+						}
+						onChange={(e: any) => setValue('roundTee', e.target.value)}
+					/>
+				</Grid>
+				<Grid size={{ xs: 6, sm: 3, lg: 3 }}>
+					<TextField
+						{...register('roundNumber', {
+							valueAsNumber: true,
+							min: { value: 1, message: 'Min 1' }
+						})}
+						label="Round #"
+						variant="outlined"
+						type='number'
+						fullWidth
+						error={!!errors.roundNumber}
+						helperText={errors.roundNumber?.message}
+					/>
+				</Grid>
+			</Grid>
+		</Dialog>
+	);
+};
+
+export default AddNewRoundForm;

--- a/src/components/layout/MainLayout2.component.tsx
+++ b/src/components/layout/MainLayout2.component.tsx
@@ -97,6 +97,8 @@ export default function DrawerAppBar(_props: IMainLayoutProps) {
       breadcrumbs.push({ label: 'Settings', path: '/settings' });
     } else if (path === '/simulator') {
       breadcrumbs.push({ label: 'HCP Simulator', path: '/simulator' });
+    } else if (path === '/handicap-history') {
+      breadcrumbs.push({ label: 'Handicap History', path: '/handicap-history' });
     } else if (path.startsWith('/round/')) {
       if (roundDetailsData?.roundCourse) {
         breadcrumbs.push({ label: 'All Rounds', path: '/all-rounds' });

--- a/src/components/layout/MainLayout2.component.tsx
+++ b/src/components/layout/MainLayout2.component.tsx
@@ -99,6 +99,8 @@ export default function DrawerAppBar(_props: IMainLayoutProps) {
       breadcrumbs.push({ label: 'HCP Simulator', path: '/simulator' });
     } else if (path === '/handicap-history') {
       breadcrumbs.push({ label: 'Handicap History', path: '/handicap-history' });
+    } else if (path === '/import-rounds') {
+      breadcrumbs.push({ label: 'Import Rounds', path: '/import-rounds' });
     } else if (path.startsWith('/round/')) {
       if (roundDetailsData?.roundCourse) {
         breadcrumbs.push({ label: 'All Rounds', path: '/all-rounds' });

--- a/src/pages/ImportRounds.page.tsx
+++ b/src/pages/ImportRounds.page.tsx
@@ -1,0 +1,7 @@
+import ImportRounds from '@/components/ImportRounds/ImportRounds.component';
+
+const ImportRoundsPage = () => {
+  return <ImportRounds />;
+};
+
+export default ImportRoundsPage;

--- a/src/store/zustand/app.store.ts
+++ b/src/store/zustand/app.store.ts
@@ -22,7 +22,13 @@ import { updateUserThemePreference, fetchThemePreference } from '@/utils/firesto
 import { getPlayerInfo, updatePlayerGolfBag, updatePlayerProfile } from '@/utils/firestore/player.firestore';
 import { getRoundDetails } from '@/utils/firestore/round.firestore';
 import { saveNewRound } from '@/utils/firestore/round.firestore';
+import { importRoundsBatch } from '@/utils/firestore/round.firestore';
 import { calculateAvg } from '@/utils/round/round.utils';
+import { parseImportText, IParsedRound } from '@/components/ImportRounds/ImportRoundParser.utils';
+import { matchAllCourses, ICourseMatchResult } from '@/components/ImportRounds/CourseMatcher.utils';
+import { buildRoundDocument } from '@/components/ImportRounds/RoundBuilder.utils';
+import { getAllCourses } from '@/utils/firestore/course.firestore';
+import { calculateHandicapIndex } from '@/utils/whs/hi.utils';
 import dayjs, { Dayjs } from 'dayjs';
 
 const initialControls: IControls = {
@@ -147,6 +153,16 @@ interface IDistance {
   avg: number;
 }
 
+export interface IImportResult {
+  importedCount: number;
+  matchedCount: number;
+  unmatchedCount: number;
+  roundIds: string[];
+  expectedHI: number | null;
+  calculatedHI: number | null;
+  warnings: string[];
+}
+
 export interface AppState {
   isLoadingUser: boolean;
   user: IUser;
@@ -236,6 +252,14 @@ export interface AppState {
   setNewRoundClubs: (clubs: INewRoundClubsInitialState) => void;
   saveNewRound: () => Promise<{ success: boolean; roundId: string } | null>;
   resetNewRound: () => void;
+  parsedRounds: IParsedRound[];
+  courseMatches: ICourseMatchResult[];
+  importResults: IImportResult | null;
+  isLoadingImport: boolean;
+  importError: string | null;
+  parseImportText: (text: string) => Promise<void>;
+  importRounds: (selectedIndices: number[]) => Promise<void>;
+  resetImport: () => void;
 }
 
 const initialState: AppState = {
@@ -327,6 +351,14 @@ const initialState: AppState = {
   setNewRoundClubs: () => {},
   saveNewRound: async () => null,
   resetNewRound: () => {},
+  parsedRounds: [],
+  courseMatches: [],
+  importResults: null,
+  isLoadingImport: false,
+  importError: null,
+  parseImportText: async () => {},
+  importRounds: async () => {},
+  resetImport: () => {},
 };
 
 export const useAppStore = create<AppState>()(
@@ -760,6 +792,130 @@ export const useAppStore = create<AppState>()(
           newRoundClubs: initialNewRoundClubs,
           newRoundSaver: initialRoundSaver,
         }),
+
+        parseImportText: async (text) => {
+          set({ isLoadingImport: true, importError: null, importResults: null });
+          try {
+            const parsed = parseImportText(text);
+            const courses = await getAllCourses();
+            const matches = await matchAllCourses(parsed, courses);
+            const lastValid = [...parsed].reverse().find((p) => p.indexNuovo !== null);
+            set({
+              parsedRounds: parsed,
+              courseMatches: matches,
+              isLoadingImport: false,
+            });
+          } catch (error: unknown) {
+            const msg = error instanceof Error ? error.message : 'Failed to parse import data';
+            set({ isLoadingImport: false, importError: msg });
+          }
+        },
+
+        importRounds: async (selectedIndices) => {
+          const state = get();
+          const userId = state.player?.uid;
+
+          if (!selectedIndices.length) {
+            set({ importError: 'No rounds selected' });
+            return;
+          }
+          if (!userId) {
+            set({ importError: 'User not authenticated' });
+            return;
+          }
+
+          set({ isLoadingImport: true, importError: null });
+
+          try {
+            const warnings: string[] = [];
+            const validRounds = selectedIndices.filter(
+              (i) => state.parsedRounds[i]?.parsedSuccessfully && state.parsedRounds[i]?.roundValid
+            );
+
+            if (validRounds.length === 0) {
+              set({ isLoadingImport: false, importError: 'No valid rounds to import' });
+              return;
+            }
+
+            if (validRounds.length > 100) {
+              warnings.push('Large import — may take a moment');
+            }
+
+            const existingRounds = state.roundsList;
+            const existingKeys = new Set(
+              existingRounds.map((r) => `${r.roundCourse}|${r.roundDate}`)
+            );
+
+            const maxRoundNumber = existingRounds.reduce(
+              (max, r) => Math.max(max, Number(r.roundNumber) || 0),
+              0
+            );
+
+            const docs = validRounds.map((index, idx) => {
+              const parsed = state.parsedRounds[index];
+              const match = state.courseMatches[index];
+
+              const key = `${parsed.roundCourse}|${parsed.roundDate}`;
+              if (existingKeys.has(key)) {
+                warnings.push(`Duplicate: ${parsed.roundCourse} on ${parsed.roundDate}`);
+              }
+
+              return buildRoundDocument({
+                parsed,
+                match,
+                roundNumber: maxRoundNumber + 1 + idx,
+                userId,
+              });
+            });
+
+            const result = await importRoundsBatch(userId, docs);
+
+            const updatedState = get();
+            const allSDs = updatedState.roundsList
+              .map((r) => r.scoreDifferential)
+              .filter((sd): sd is number => sd !== null && sd !== undefined);
+
+            for (const doc of docs) {
+              if (doc.scoreDifferential !== null) {
+                allSDs.push(doc.scoreDifferential);
+              }
+            }
+
+            allSDs.sort((a, b) => b - a);
+
+            const calculatedHI = calculateHandicapIndex(allSDs);
+            const lastParsed = [...state.parsedRounds].reverse().find((p) => p.indexNuovo !== null);
+            const expectedHI = lastParsed?.indexNuovo ?? null;
+
+            const matchedCount = validRounds.filter(
+              (i) => state.courseMatches[i]?.matched
+            ).length;
+
+            set({
+              isLoadingImport: false,
+              importResults: {
+                importedCount: result.importedCount,
+                matchedCount,
+                unmatchedCount: validRounds.length - matchedCount,
+                roundIds: result.roundIds,
+                expectedHI,
+                calculatedHI,
+                warnings,
+              },
+            });
+          } catch (error: unknown) {
+            const msg = error instanceof Error ? error.message : 'Import failed';
+            set({ isLoadingImport: false, importError: msg });
+          }
+        },
+
+        resetImport: () => set({
+          parsedRounds: [],
+          courseMatches: [],
+          importResults: null,
+          isLoadingImport: false,
+          importError: null,
+        }),
       }),
       {
         name: 'app-storage',
@@ -785,6 +941,7 @@ export const useAppStore = create<AppState>()(
           newRoundTotals: state.newRoundTotals,
           newRoundDistances: state.newRoundDistances,
           newRoundClubs: state.newRoundClubs,
+          parsedRounds: state.parsedRounds,
         }),
       }
     ),

--- a/src/store/zustand/app.store.ts
+++ b/src/store/zustand/app.store.ts
@@ -909,6 +909,16 @@ export const useAppStore = create<AppState>()(
       }),
       {
         name: 'app-storage',
+        version: 1,
+        migrate: (persisted) => {
+          const state = persisted as Record<string, unknown>;
+          delete state.parsedRounds;
+          delete state.courseMatches;
+          delete state.importResults;
+          delete state.isLoadingImport;
+          delete state.importError;
+          return state;
+        },
         storage: createJSONStorage(() => localStorage),
         partialize: (state) => ({
           themePreference: state.themePreference,
@@ -931,7 +941,6 @@ export const useAppStore = create<AppState>()(
           newRoundTotals: state.newRoundTotals,
           newRoundDistances: state.newRoundDistances,
           newRoundClubs: state.newRoundClubs,
-          parsedRounds: state.parsedRounds,
         }),
       }
     ),

--- a/src/store/zustand/app.store.ts
+++ b/src/store/zustand/app.store.ts
@@ -14,7 +14,7 @@ import { IRoundTotalsInitialState, IRoundTotals } from '@/types/roundTotals.type
 import { initialStateRoundTotals } from '@/utils/constant.utils';
 import { IRoundDistanceInitialState } from '@/types/roundTotals.types';
 import { initialStateDistance } from '@/utils/constant.utils';
-import { INewRound, InitialStateNewRound, IInitialStateRoundSave } from '@/types/round.types';
+import { INewRound, InitialStateNewRound, IInitialStateRoundSave, IImportResult } from '@/types/round.types';
 import { InitialStateNewRoundsData, IShots, InitialStateNewRoundDistances } from '@/types/roundData.types';
 import { calculateGirValue, calculateGreenApproachCounts, calculatePuttLengthCounts, calculateScrambleValue, calculateStablefordPoints, calculateUDValue } from '@/utils/shots/shots.utils';
 import { totalsCalculator } from '@/utils/calculator/TotalsCalculator.utils';
@@ -151,16 +151,6 @@ interface IDistance {
   club: string;
   mt: number[];
   avg: number;
-}
-
-export interface IImportResult {
-  importedCount: number;
-  matchedCount: number;
-  unmatchedCount: number;
-  roundIds: string[];
-  expectedHI: number | null;
-  calculatedHI: number | null;
-  warnings: string[];
 }
 
 export interface AppState {

--- a/src/types/round.types.tsx
+++ b/src/types/round.types.tsx
@@ -75,6 +75,16 @@ export interface PuttLengthCounts {
   puttsOver10: number;
 }
 
+export interface IImportResult {
+  importedCount: number;
+  matchedCount: number;
+  unmatchedCount: number;
+  roundIds: string[];
+  expectedHI: number | null;
+  calculatedHI: number | null;
+  warnings: string[];
+}
+
 export interface GreenApproachDistanceCounts {
   toGreenMetersOver100: number;
   toGreenMeters80_100: number;

--- a/src/utils/firestore/round.firestore.ts
+++ b/src/utils/firestore/round.firestore.ts
@@ -62,6 +62,29 @@ export const getRoundDetails = async (
 
 };
 
+import { IRoundImportDocument } from '@/components/ImportRounds/RoundBuilder.utils';
+
+export const importRoundsBatch = async (
+  userId: string,
+  roundDocs: IRoundImportDocument[]
+): Promise<{ success: boolean; importedCount: number; roundIds: string[] }> => {
+  if (!userId) {
+    throw new Error('User not authenticated');
+  }
+
+  const batch = writeBatch(db);
+  const roundIds: string[] = [];
+
+  for (const roundDoc of roundDocs) {
+    const roundRef = doc(collection(db, 'players', userId, 'rounds'));
+    roundIds.push(roundRef.id);
+    batch.set(roundRef, roundDoc);
+  }
+
+  await batch.commit();
+  return { success: true, importedCount: roundDocs.length, roundIds };
+};
+
 export const saveNewRound = async (): Promise<{ success: boolean; roundId: string }> => {
   const store = useAppStore.getState();
   const { newRoundMain, newRoundTotals, newRoundHoles, newRoundDistances, player } = store;

--- a/src/utils/links/links.utils.tsx
+++ b/src/utils/links/links.utils.tsx
@@ -5,6 +5,7 @@ import GolfCourseIcon from '@mui/icons-material/GolfCourse';
 import PeopleIcon from '@mui/icons-material/People';
 import AutoGraphIcon from '@mui/icons-material/AutoGraph';
 import TimelineIcon from '@mui/icons-material/Timeline';
+import FileUploadIcon from '@mui/icons-material/FileUpload';
 
 const navbar_items: TLinkSidebar[] = [
   {
@@ -47,6 +48,13 @@ const navbar_items: TLinkSidebar[] = [
     name: "Handicap History",
     link: "/handicap-history",
     icon: TimelineIcon,
+    show: true,
+  },
+  {
+    id: 7,
+    name: "Import Rounds",
+    link: "/import-rounds",
+    icon: FileUploadIcon,
     show: true,
   },
 ];


### PR DESCRIPTION

## Changes

- **Handicap History page**: Last-20 rounds table with best-N SD highlighting, HCP progression LineChart
- **Removed 3-round minimum**: HI now computable with 1-2 rounds (WHS compliant)
- **Simulator UX improvements**: Course autocomplete, auto-calc Playing HCP from HI, removed 0-36 Stableford limit
- **Add New Round**: Course autocomplete with readOnly derived fields (holes, par), auto-calc Playing HCP from HI, redesigned layout
- **Bug fixes**: readOnly instead of disabled for MUI value-render, disablePortal on Autocomplete inside Dialog

## Testing

- 21/21 WHS tests passing
- type-check and build clean
