### PR TITLE
feat: HCP history persistence + backfill

### DIFF
--- a/docs/superpowers/plans/2026-06-03-hcp-history-persistence.md
+++ b/docs/superpowers/plans/2026-06-03-hcp-history-persistence.md
@@ -1,0 +1,1048 @@
+# HCP History Persistence + Backfill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist `previousHCP` on every round alongside `handicapIndex` and `hcpDelta`, backfill these three fields on existing rounds via a one-time manual trigger in Settings, and update `/handicap-history` to show Old HCP / New HCP / Δ columns and a per-round HI line chart (with the existing dashed reference line preserved).
+
+**Architecture:** Add a `previousHCP` field to the round schema; wire it through the two save paths (`saveNewRound`, `importRoundsBatch`) so every new write carries it. Add a one-shot `backfillHcpHistory(userId)` utility that walks existing rounds chronologically, computes the three fields using the same formula as imports, and writes a single Firestore batch. Expose a manual trigger in Settings, gated to render only when at least one round is missing the new fields. Strip the chart's hidden-data branches (D-11 anchor, D-14 single-point) and replace with a simple per-round HI filter; keep the dashed reference line at `initialHCP`.
+
+**Tech Stack:** React 19, TypeScript 6, MUI v7, Firebase Firestore v12, Vitest. Existing patterns: `IBasicRoundData` round schema, `writeBatch` for atomic writes, `useAppStore` Zustand selector for rounds.
+
+**Working directory:** branch `feat/hcp-history-persistence` (off `development`)
+
+---
+
+## File map
+
+| File | Responsibility | Touch type |
+|---|---|---|
+| `src/types/roundData.types.tsx` | `IBasicRoundData` shape | Modify — add `previousHCP` field |
+| `src/components/ImportRounds/RoundBuilder.utils.ts` | `IRoundImportDocument` + `buildRoundDocument` | Modify — thread `previousHCP` |
+| `src/utils/round/round.utils.tsx` | `prepareRoundSaveBatch` | Modify — accept and write `previousHCP` |
+| `src/utils/firestore/round.firestore.ts` | `saveNewRound`, `importRoundsBatch` | Modify — compute and pass `previousHCP` |
+| `src/utils/firestore/backfillHcpHistory.utils.ts` | One-time backfill function | New |
+| `src/utils/firestore/backfillHcpHistory.utils.test.ts` | Vitest unit tests for backfill calc | New |
+| `src/components/Settings/Settings.component.tsx` | Backfill trigger UI | Modify — add gated section, dialog, snackbar |
+| `src/components/HandicapHistory/HandicapHistory.component.tsx` | Table + chart | Modify — add columns, strip chart branches |
+
+---
+
+## Task 1: Add `previousHCP` to `IBasicRoundData`
+
+**Files:**
+- Modify: `src/types/roundData.types.tsx:159-176`
+
+- [ ] **Step 1: Edit `src/types/roundData.types.tsx`**
+
+Add `previousHCP?: number | null;` to `IBasicRoundData`. Place it directly above `handicapIndex` to keep the per-round HI trio grouped:
+
+```ts
+export interface IBasicRoundData {
+  id: string,
+  // roundData: DocumentData,
+  roundCourse?: string,
+  roundDate: number,
+  roundHoles?: string,
+  roundTee?: string,
+  roundPar?: string,
+  roundNumber?: string,
+  roundPlayingHCP?: string,
+  roundStrokes?: number,
+  userId?: string
+  createdAt: number,
+  scoreDifferential?: number | null,
+  previousHCP?: number | null,
+  handicapIndex?: number | null,
+  hcpDelta?: number | null,
+  totals: IRoundTotals
+}
+```
+
+- [ ] **Step 2: Verify type-check passes**
+
+Run: `npm run type-check`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/types/roundData.types.tsx
+git commit -m "feat: add previousHCP to IBasicRoundData"
+```
+
+---
+
+## Task 2: Update `IRoundImportDocument` and `buildRoundDocument` to carry `previousHCP`
+
+**Files:**
+- Modify: `src/components/ImportRounds/RoundBuilder.utils.ts:7-26, 32-64`
+
+- [ ] **Step 1: Add `previousHCP` to `IRoundImportDocument`**
+
+Replace the interface in `src/components/ImportRounds/RoundBuilder.utils.ts`:
+
+```ts
+export interface IRoundImportDocument {
+  roundDate: Timestamp;
+  roundCourse: string;
+  roundCourseRef: string | null;
+  roundHoles: 18;
+  roundTee: string;
+  roundPar: number;
+  roundPlayingHCP: number;
+  roundStrokes: number;
+  roundFormat: string;
+  roundValid: boolean;
+  roundNumber: number;
+  totals: IRoundTotals;
+  scoreDifferential: number | null;
+  previousHCP: number | null;
+  handicapIndex: number | null;
+  hcpDelta: number | null;
+  userId: string;
+  importSource: 'federgolf-sheet';
+  createdAt: FieldValue;
+}
+```
+
+- [ ] **Step 2: Add `previousHCP` to `buildRoundDocument` params and return**
+
+Replace the function signature and body in `src/components/ImportRounds/RoundBuilder.utils.ts`:
+
+```ts
+export function buildRoundDocument(params: {
+  parsed: IParsedRound;
+  match: ICourseMatchResult;
+  roundNumber: number;
+  userId: string;
+  previousHCP?: number | null;
+  handicapIndex?: number | null;
+  hcpDelta?: number | null;
+}): IRoundImportDocument {
+  const totals = createEmptyRoundTotals();
+  totals.score.totals = params.parsed.roundStrokes;
+  totals.points.totals = params.parsed.stablefordPoints;
+
+  return {
+    roundDate: Timestamp.fromDate(new Date(params.parsed.roundDate)),
+    roundCourse: params.match.matched ? params.match.courseName : params.parsed.roundCourse,
+    roundCourseRef: params.match.courseId,
+    roundHoles: 18,
+    roundTee: params.match.matched ? params.match.teeboxName : '',
+    roundPar: params.parsed.roundPar,
+    roundPlayingHCP: params.parsed.roundPlayingHCP,
+    roundStrokes: params.parsed.roundStrokes,
+    roundFormat: params.parsed.roundFormat,
+    roundValid: params.parsed.roundValid,
+    roundNumber: params.roundNumber,
+    totals,
+    scoreDifferential: params.parsed.scoreDifferential,
+    previousHCP: params.previousHCP ?? null,
+    handicapIndex: params.handicapIndex ?? null,
+    hcpDelta: params.hcpDelta ?? null,
+    userId: params.userId,
+    importSource: 'federgolf-sheet',
+    createdAt: serverTimestamp(),
+  };
+}
+```
+
+- [ ] **Step 3: Verify type-check passes**
+
+Run: `npm run type-check`
+Expected: error in `importRoundsBatch` (it doesn't pass `previousHCP` yet) — **this is expected** and will be fixed in Task 5.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/ImportRounds/RoundBuilder.utils.ts
+git commit -m "feat: thread previousHCP through RoundBuilder"
+```
+
+---
+
+## Task 3: Update `prepareRoundSaveBatch` to accept and write `previousHCP`
+
+**Files:**
+- Modify: `src/utils/round/round.utils.tsx:84-120`
+
+- [ ] **Step 1: Add `previousHCP` parameter to `prepareRoundSaveBatch`**
+
+Replace the function in `src/utils/round/round.utils.tsx`:
+
+```ts
+export const prepareRoundSaveBatch = (
+  batch: WriteBatch,
+  userId: string,
+  general: INewRound,
+  totals: IRoundTotals,
+  currentRoundDistances: IDistance[],
+  holes: IShots[],
+  scoreDifferential?: number | null,
+  previousHCP?: number | null,
+  handicapIndex?: number | null,
+  hcpDelta?: number | null
+): string => {
+  const playerRoundsCollectionRef = collection(db, 'players', userId, 'rounds');
+  const roundRef = doc(playerRoundsCollectionRef);
+  const roundId = roundRef.id;
+
+  batch.set(roundRef, {
+    ...general,
+    totals: totals,
+    distances: currentRoundDistances,
+    userId: userId,
+    scoreDifferential: scoreDifferential ?? null,
+    previousHCP: previousHCP ?? null,
+    handicapIndex: handicapIndex ?? null,
+    hcpDelta: hcpDelta ?? null,
+    roundDate: general.roundDate ? Timestamp.fromDate(new Date(general.roundDate)) : serverTimestamp(),
+    createdAt: serverTimestamp(),
+  });
+  holes.forEach((holeData: IShots) => {
+    const holeDocId = holeData.holeNumber?.toString();
+    if (holeDocId && holeData.holeNumber > 0) {
+      const holeRef = doc(db, 'players', userId, 'rounds', roundId, 'holes', holeDocId);
+      batch.set(holeRef, holeData);
+    } else {
+      console.warn("Skipping hole due to missing/invalid holeNumber: ", holeData);
+    }
+  });
+  return roundId;
+};
+```
+
+- [ ] **Step 2: Verify type-check passes**
+
+Run: `npm run type-check`
+Expected: error in `saveNewRound` (it doesn't pass `previousHCP` yet) — **this is expected** and will be fixed in Task 4.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/utils/round/round.utils.tsx
+git commit -m "feat: thread previousHCP through prepareRoundSaveBatch"
+```
+
+---
+
+## Task 4: Update `saveNewRound` to compute and pass `previousHCP`
+
+**Files:**
+- Modify: `src/utils/firestore/round.firestore.ts:185-234`
+
+- [ ] **Step 1: Lift `previousHCP` out of the `try` and pass it to `prepareRoundSaveBatch`**
+
+In `src/utils/firestore/round.firestore.ts`, replace the section that declares `let handicapIndex` / `let hcpDelta` through the call to `prepareRoundSaveBatch`:
+
+```ts
+    // Compute Handicap Index, previousHCP, and delta (per D-04, D-08, HCP-PERSIST)
+    let handicapIndex: number | null = null;
+    let hcpDelta: number | null = null;
+    let previousHCP: number | null = null;
+    try {
+      // CR-02 fix: legacy users (pre-Phase-5 rounds, no stored handicapIndex) need
+      // the live WHS recalc, not the player's initialHCP, as the previousHCP for
+      // the new hcpDelta computation.
+      const mostRecent = store.roundsList[0];
+      let prevHCP: number | null;
+      if (mostRecent?.handicapIndex != null) {
+        prevHCP = mostRecent.handicapIndex;
+      } else if (store.roundsList.length > 0) {
+        // Legacy fallback: live WHS recalc from existing SDs (mirrors D-15 chart branch)
+        const legacySDs = store.roundsList
+          .map((r) => r.scoreDifferential)
+          .filter((sd): sd is number => sd !== null && sd !== undefined);
+        prevHCP = calculateHandicapIndex(legacySDs);
+      } else {
+        prevHCP = player?.initialHCP ?? null;
+      }
+      if (prevHCP != null && scoreDifferential != null) {
+        const previousSDs = store.roundsList
+          .map((r) => r.scoreDifferential)
+          .filter((sd): sd is number => sd !== null && sd !== undefined)
+          .slice(0, 19);
+        const virtualSDs = [scoreDifferential, ...previousSDs].slice(0, 20);
+        const newHI = calculateHandicapIndex(virtualSDs);
+        if (newHI != null) {
+          handicapIndex = newHI;
+          previousHCP = prevHCP;
+          hcpDelta = +((newHI - prevHCP)).toFixed(1);
+        }
+      }
+    } catch (hiError: any) {
+      console.error('saveNewRound: Error computing Handicap Index:', hiError);
+      // Round save continues without HI/delta — non-blocking
+    }
+
+    const batchSaveRound = writeBatch(db);
+    savedRoundId = prepareRoundSaveBatch(
+      batchSaveRound,
+      userId,
+      general,
+      currentTotals,
+      currentRoundDistances,
+      holes,
+      scoreDifferential,
+      previousHCP,
+      handicapIndex,
+      hcpDelta
+    );
+    await batchSaveRound.commit();
+```
+
+- [ ] **Step 2: Verify type-check passes**
+
+Run: `npm run type-check`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/utils/firestore/round.firestore.ts
+git commit -m "feat: persist previousHCP on new round save"
+```
+
+---
+
+## Task 5: Update `importRoundsBatch` to capture `previousHCP` per round
+
+**Files:**
+- Modify: `src/utils/firestore/round.firestore.ts:69-135`
+
+- [ ] **Step 1: Capture `previousHCP` in the loop and pass it to `buildRoundDocument`**
+
+In `src/utils/firestore/round.firestore.ts`, the `importRoundsBatch` function uses `writeBatch` + `batch.set` directly (not `buildRoundDocument` for the final write). Update the loop to also compute `previousHCP` and include it in the document:
+
+```ts
+  for (const roundDoc of sortedDocs) {
+    const newSD = roundDoc.scoreDifferential;
+    let handicapIndex: number | null = null;
+    let hcpDelta: number | null = null;
+    let previousHCP: number | null = runningHCP;
+
+    if (runningHCP != null && newSD != null) {
+      const virtualSDs = [newSD, ...runningSDs].slice(0, 20);
+      const newHI = calculateHandicapIndex(virtualSDs);
+      if (newHI != null) {
+        handicapIndex = newHI;
+        hcpDelta = +((newHI - runningHCP)).toFixed(1);
+      }
+    } else if (runningHCP == null) {
+      previousHCP = null;
+    }
+
+    const enrichedDoc: IRoundImportDocument = {
+      ...roundDoc,
+      previousHCP,
+      handicapIndex,
+      hcpDelta,
+    };
+
+    const batch = writeBatch(db);
+    const roundRef = doc(collection(db, 'players', userId, 'rounds'));
+    roundIds.push(roundRef.id);
+    batch.set(roundRef, enrichedDoc);
+    await batch.commit();
+    console.log(`importRoundsBatch: imported round ${roundRef.id} (handicapIndex=${handicapIndex}, hcpDelta=${hcpDelta})`);
+
+    if (newSD != null) {
+      runningSDs = [newSD, ...runningSDs].slice(0, 19);
+    }
+    if (handicapIndex != null) {
+      runningHCP = handicapIndex;
+    } else {
+      runningHCP = null;
+    }
+  }
+```
+
+- [ ] **Step 2: Verify type-check passes**
+
+Run: `npm run type-check`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/utils/firestore/round.firestore.ts
+git commit -m "feat: persist previousHCP on import rounds"
+```
+
+---
+
+## Task 6: Create `backfillHcpHistory` utility (TDD)
+
+**Files:**
+- Create: `src/utils/firestore/backfillHcpHistory.utils.ts`
+- Create: `src/utils/firestore/backfillHcpHistory.utils.test.ts`
+
+The function is a small orchestrator around `calculateHandicapIndex`. The **calculation** is the unit-testable part. The Firestore I/O is best tested via manual UAT or with a Firestore emulator (not configured here). To keep TDD viable, we extract the calculation into a pure helper and unit-test that, then keep the I/O wrapper thin.
+
+### Step A: write the failing test
+
+- [ ] **Step 1: Create the test file `src/utils/firestore/backfillHcpHistory.utils.test.ts`**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { computeRoundHcpHistory } from './backfillHcpHistory.utils';
+
+describe('computeRoundHcpHistory', () => {
+  it('returns empty for empty input', () => {
+    const out = computeRoundHcpHistory([], 18.0);
+    expect(out).toEqual([]);
+  });
+
+  it('anchors first round to initialHCP', () => {
+    const out = computeRoundHcpHistory(
+      [{ id: 'r1', roundDate: 1, scoreDifferential: 12.0 }],
+      18.0
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      id: 'r1',
+      previousHCP: 18.0,
+      hcpDelta: +(12.0 - 18.0).toFixed(1), // -6.0
+    });
+    expect(out[0].handicapIndex).toBe(12.0);
+  });
+
+  it('chains subsequent rounds off previous handicapIndex', () => {
+    const out = computeRoundHcpHistory(
+      [
+        { id: 'r1', roundDate: 1, scoreDifferential: 12.0 },
+        { id: 'r2', roundDate: 2, scoreDifferential: 14.0 },
+      ],
+      18.0
+    );
+    expect(out).toHaveLength(2);
+    expect(out[1]).toMatchObject({
+      id: 'r2',
+      previousHCP: 12.0, // anchored to r1's handicapIndex
+    });
+    expect(out[1].hcpDelta).toBe(+(out[1].handicapIndex! - 12.0).toFixed(1));
+  });
+
+  it('skips rounds with null scoreDifferential', () => {
+    const out = computeRoundHcpHistory(
+      [
+        { id: 'r1', roundDate: 1, scoreDifferential: null },
+        { id: 'r2', roundDate: 2, scoreDifferential: 14.0 },
+      ],
+      18.0
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].id).toBe('r2');
+    expect(out[0].previousHCP).toBe(18.0); // initialHCP because r1 was skipped
+  });
+
+  it('returns null previousHCP/hcpDelta for first round when no initialHCP', () => {
+    const out = computeRoundHcpHistory(
+      [{ id: 'r1', roundDate: 1, scoreDifferential: 12.0 }],
+      null
+    );
+    expect(out[0].previousHCP).toBeNull();
+    expect(out[0].hcpDelta).toBeNull();
+    expect(out[0].handicapIndex).toBe(12.0);
+  });
+
+  it('produces null hcpDelta when first round has no anchor and we cannot compute delta', () => {
+    const out = computeRoundHcpHistory(
+      [
+        { id: 'r1', roundDate: 1, scoreDifferential: 12.0 },
+        { id: 'r2', roundDate: 2, scoreDifferential: 14.0 },
+      ],
+      null
+    );
+    // r1: no anchor → previousHCP null, hcpDelta null
+    expect(out[0].previousHCP).toBeNull();
+    expect(out[0].hcpDelta).toBeNull();
+    // r2: anchored to r1.handicapIndex
+    expect(out[1].previousHCP).toBe(12.0);
+    expect(out[1].hcpDelta).toBe(+(out[1].handicapIndex! - 12.0).toFixed(1));
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- --run backfillHcpHistory`
+Expected: all tests fail with "Cannot find module './backfillHcpHistory.utils'" or "computeRoundHcpHistory is not a function".
+
+### Step B: implement
+
+- [ ] **Step 3: Create `src/utils/firestore/backfillHcpHistory.utils.ts`**
+
+```ts
+/**
+ * One-time backfill of per-round HCP history fields.
+ *
+ * Walks a player's rounds chronologically, computing `previousHCP`,
+ * `handicapIndex`, and `hcpDelta` using the same formula as
+ * `importRoundsBatch`. The first round's `previousHCP` is anchored to
+ * the player's `initialHCP` (or null if absent). Subsequent rounds
+ * anchor to the previous round's `handicapIndex`.
+ *
+ * Pure helper `computeRoundHcpHistory` is unit-tested; the Firestore
+ * wrapper `backfillHcpHistory` is integration-tested manually.
+ */
+
+import {
+  collection,
+  getDocs,
+  orderBy,
+  query,
+  writeBatch,
+  doc,
+  Timestamp,
+  getDoc,
+} from 'firebase/firestore';
+import { db } from '@/utils/firebase/firebase.utils';
+import { calculateHandicapIndex } from '@/utils/whs/hi.utils';
+import { IBasicRoundData } from '@/types/roundData.types';
+
+export interface IRoundHcpInput {
+  id: string;
+  roundDate: number;
+  scoreDifferential: number | null;
+}
+
+export interface IRoundHcpComputed {
+  id: string;
+  previousHCP: number | null;
+  handicapIndex: number | null;
+  hcpDelta: number | null;
+}
+
+/**
+ * Pure calculation: given a chronologically-sorted list of rounds and
+ * the player's initialHCP, return the per-round HCP fields to write.
+ */
+export const computeRoundHcpHistory = (
+  rounds: IRoundHcpInput[],
+  initialHCP: number | null
+): IRoundHcpComputed[] => {
+  const result: IRoundHcpComputed[] = [];
+  let runningSDs: number[] = [];
+  let runningHCP: number | null = initialHCP;
+
+  for (const round of rounds) {
+    let previousHCP: number | null = runningHCP;
+    let handicapIndex: number | null = null;
+    let hcpDelta: number | null = null;
+
+    if (round.scoreDifferential != null) {
+      const virtualSDs = [round.scoreDifferential, ...runningSDs].slice(0, 20);
+      const newHI = calculateHandicapIndex(virtualSDs);
+      if (newHI != null) {
+        handicapIndex = newHI;
+        if (previousHCP != null) {
+          hcpDelta = +(newHI - previousHCP).toFixed(1);
+        }
+        runningSDs = [round.scoreDifferential, ...runningSDs].slice(0, 19);
+        runningHCP = newHI;
+      } else {
+        // HI could not be computed (shouldn't happen with a non-null SD)
+        previousHCP = null;
+        runningHCP = null;
+      }
+    } else {
+      // Round lacks a scoreDifferential — cannot compute anything; break the chain
+      previousHCP = null;
+      runningHCP = null;
+    }
+
+    result.push({ id: round.id, previousHCP, handicapIndex, hcpDelta });
+  }
+
+  return result;
+};
+
+export interface IBackfillResult {
+  success: boolean;
+  processed: number;
+  updated: number;
+  skipped: number;
+  error?: string;
+}
+
+/**
+ * Fetch all rounds, compute the HCP history, and write a single batch.
+ * Idempotent: re-runs produce the same values.
+ */
+export const backfillHcpHistory = async (
+  userId: string
+): Promise<IBackfillResult> => {
+  if (!userId) {
+    return { success: false, processed: 0, updated: 0, skipped: 0, error: 'User ID required' };
+  }
+
+  try {
+    // 1. Fetch player.initialHCP
+    const playerDocRef = doc(db, 'players', userId);
+    const playerSnap = await getDoc(playerDocRef);
+    const initialHCP: number | null = playerSnap.exists()
+      ? (playerSnap.data().initialHCP ?? null)
+      : null;
+
+    // 2. Fetch all rounds, sorted by date ascending
+    const roundsColRef = collection(db, 'players', userId, 'rounds');
+    const roundsQuery = query(roundsColRef, orderBy('roundDate', 'asc'));
+    const roundsSnap = await getDocs(roundsQuery);
+
+    if (roundsSnap.empty) {
+      return { success: true, processed: 0, updated: 0, skipped: 0 };
+    }
+
+    const inputs: IRoundHcpInput[] = roundsSnap.docs.map((d) => {
+      const data = d.data();
+      const roundDate =
+        data.roundDate instanceof Timestamp
+          ? data.roundDate.toMillis()
+          : Number(data.roundDate);
+      const sd = data.scoreDifferential ?? null;
+      return { id: d.id, roundDate, scoreDifferential: sd };
+    });
+
+    // 3. Compute the values (pure)
+    const computed = computeRoundHcpHistory(inputs, initialHCP);
+
+    // 4. Build batch
+    const batch = writeBatch(db);
+    let updated = 0;
+    let skipped = 0;
+    const processed = computed.length;
+
+    for (let i = 0; i < computed.length; i++) {
+      const next = computed[i];
+      const origDoc = roundsSnap.docs[i];
+      const origData = origDoc.data();
+      const samePrev = origData.previousHCP === next.previousHCP;
+      const sameHI = origData.handicapIndex === next.handicapIndex;
+      const sameDelta = origData.hcpDelta === next.hcpDelta;
+      if (samePrev && sameHI && sameDelta) {
+        skipped += 1;
+        continue;
+      }
+      const roundRef = doc(db, 'players', userId, 'rounds', next.id);
+      batch.update(roundRef, {
+        previousHCP: next.previousHCP,
+        handicapIndex: next.handicapIndex,
+        hcpDelta: next.hcpDelta,
+      });
+      updated += 1;
+    }
+
+    if (updated > 0) {
+      await batch.commit();
+    }
+
+    return { success: true, processed, updated, skipped };
+  } catch (err: any) {
+    console.error('backfillHcpHistory failed:', err);
+    return {
+      success: false,
+      processed: 0,
+      updated: 0,
+      skipped: 0,
+      error: err?.message ?? 'Unknown error',
+    };
+  }
+};
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- --run backfillHcpHistory`
+Expected: all 6 tests pass.
+
+- [ ] **Step 5: Run type-check**
+
+Run: `npm run type-check`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/utils/firestore/backfillHcpHistory.utils.ts src/utils/firestore/backfillHcpHistory.utils.test.ts
+git commit -m "feat: add backfillHcpHistory utility with pure calc helper"
+```
+
+---
+
+## Task 7: Add Settings UI for backfill trigger
+
+**Files:**
+- Modify: `src/components/Settings/Settings.component.tsx:24-140`
+
+The Settings page is rendered inside the `SnackbarProvider` (root layout), so `useSnackbar` is available. The `roundsList` from `useAppStore` is already used by other pages.
+
+- [ ] **Step 1: Import the backfill function and snackbar hook**
+
+At the top of `src/components/Settings/Settings.component.tsx`, add the import:
+
+```ts
+import { backfillHcpHistory } from '@/utils/firestore/backfillHcpHistory.utils';
+import { useSnackbar } from '@/components/Admin/SnackbarProvider.component';
+import { Button, CircularProgress } from '@mui/material';
+import { Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions } from '@mui/material';
+import { IBasicRoundData } from '@/types/roundData.types';
+```
+
+- [ ] **Step 2: Add backfill state, condition, and handlers inside the `Settings` component**
+
+Inside the `Settings` function (after the existing `useState` declarations), add:
+
+```ts
+  const { showSnackbar } = useSnackbar();
+  const roundsList = useAppStore((state) => state.roundsList) as IBasicRoundData[];
+
+  const roundsNeedingBackfill = roundsList.filter(
+    (r) =>
+      r.previousHCP == null ||
+      r.handicapIndex == null ||
+      r.hcpDelta == null
+  ).length;
+
+  const [backfillConfirmOpen, setBackfillConfirmOpen] = useState(false);
+  const [isBackfilling, setIsBackfilling] = useState(false);
+
+  const handleBackfill = async () => {
+    if (!playerId) return;
+    setIsBackfilling(true);
+    try {
+      const result = await backfillHcpHistory(playerId);
+      if (result.success) {
+        showSnackbar(
+          `Updated ${result.updated} round${result.updated !== 1 ? 's' : ''}, ${result.skipped} already up to date.`,
+          'success'
+        );
+        // Refresh player details so roundsList reflects the new fields
+        await useAppStore.getState().getPlayerDetails(playerId);
+      } else {
+        showSnackbar(`Backfill failed: ${result.error ?? 'unknown error'}`, 'error');
+      }
+    } catch (err: any) {
+      showSnackbar(`Backfill failed: ${err?.message ?? 'unknown error'}`, 'error');
+    } finally {
+      setIsBackfilling(false);
+      setBackfillConfirmOpen(false);
+    }
+  };
+```
+
+- [ ] **Step 3: Add the backfill Card section and confirmation dialog**
+
+After the existing "Initial Handicap" `Card` (just before the closing `</Box>` on line 134 of the original file), add:
+
+```tsx
+      {roundsNeedingBackfill > 0 && (
+        <Box sx={{ mt: 3, maxWidth: 480 }}>
+          <Card>
+            <CardContent>
+              <Typography variant="title3" gutterBottom>
+                HCP History Backfill
+              </Typography>
+              <Typography variant="body" color="text.secondary" sx={{ mb: 2 }}>
+                {roundsNeedingBackfill} of your existing rounds don't have
+                Old HCP, New HCP, and Δ values yet. Run this one-time
+                recalculation to compute them using the same formula as
+                new rounds. New rounds will be calculated automatically
+                going forward.
+              </Typography>
+              {isBackfilling ? (
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+                  <CircularProgress size={20} />
+                  <Typography variant="body" color="text.secondary">
+                    Recalculating {roundsNeedingBackfill} rounds...
+                  </Typography>
+                </Box>
+              ) : (
+                <Button
+                  variant="contained"
+                  color="primary"
+                  onClick={() => setBackfillConfirmOpen(true)}
+                  disabled={!playerId}
+                >
+                  Recalculate HCP history
+                </Button>
+              )}
+            </CardContent>
+          </Card>
+        </Box>
+      )}
+
+      <Dialog
+        open={backfillConfirmOpen}
+        onClose={() => !isBackfilling && setBackfillConfirmOpen(false)}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle>Recalculate Handicap History?</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            This will update the Old HCP, New HCP, and Δ fields on every
+            round using the same formula as new rounds. The operation
+            cannot be undone.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={() => setBackfillConfirmOpen(false)}
+            disabled={isBackfilling}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={handleBackfill}
+            disabled={isBackfilling}
+          >
+            Recalculate
+          </Button>
+        </DialogActions>
+      </Dialog>
+```
+
+- [ ] **Step 4: Verify type-check passes**
+
+Run: `npm run type-check`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/Settings/Settings.component.tsx
+git commit -m "feat: add manual HCP history backfill trigger to Settings"
+```
+
+---
+
+## Task 8: Add Old HCP and New HCP columns to the Handicap History table
+
+**Files:**
+- Modify: `src/components/HandicapHistory/HandicapHistory.component.tsx:199-272`
+
+- [ ] **Step 1: Add two new `<TableCell>` headers between "Score Diff." and "Δ"**
+
+In `src/components/HandicapHistory/HandicapHistory.component.tsx`, replace the `<TableHead>` block:
+
+```tsx
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>Date</TableCell>
+                      <TableCell>Course</TableCell>
+                      <TableCell>Tee</TableCell>
+                      <TableCell align="right">
+                        Strokes
+                      </TableCell>
+                      <TableCell align="right">
+                        Score Diff.
+                      </TableCell>
+                      <TableCell align="right">
+                        Old HCP
+                      </TableCell>
+                      <TableCell align="right">
+                        New HCP
+                      </TableCell>
+                      <TableCell align="right">
+                        Δ
+                      </TableCell>
+                      <TableCell align="center">
+                        Used
+                      </TableCell>
+                    </TableRow>
+                  </TableHead>
+```
+
+- [ ] **Step 2: Add two new `<TableCell>` rows between Score Diff. and Δ in the body**
+
+In the same file, replace the `TableBody` row block (the part that renders Strokes / Score Diff. / Δ / Used). Replace the four cells in question with the six-cell version:
+
+```tsx
+                                  <TableCell align="right">
+                                    {round.totals?.score
+                                      ?.totals ?? '\u2014'}
+                                  </TableCell>
+                                  <TableCell align="right">
+                                    {round.scoreDifferential !=
+                                    null
+                                      ? round.scoreDifferential.toFixed(
+                                              1
+                                          )
+                                      : '\u2014'}
+                                  </TableCell>
+                                  <TableCell align="right">
+                                    {round.previousHCP != null
+                                      ? round.previousHCP.toFixed(1)
+                                      : '\u2014'}
+                                  </TableCell>
+                                  <TableCell align="right">
+                                    {round.handicapIndex != null
+                                      ? round.handicapIndex.toFixed(1)
+                                      : '\u2014'}
+                                  </TableCell>
+                                  <TableCell align="right">
+                                    {round.hcpDelta != null
+                                      ? `${
+                                              round.hcpDelta > 0
+                                                  ? '+'
+                                                  : ''
+                                          }${round.hcpDelta.toFixed(1)}`
+                                      : '\u2014'}
+                                  </TableCell>
+                                  <TableCell align="center">
+                                    {isHighlighted
+                                      ? '\u2606'
+                                      : ''}
+                                  </TableCell>
+```
+
+- [ ] **Step 3: Verify type-check passes**
+
+Run: `npm run type-check`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/HandicapHistory/HandicapHistory.component.tsx
+git commit -m "feat: add Old HCP and New HCP columns to handicap history table"
+```
+
+---
+
+## Task 9: Strip chart branches and update `progressionData` logic
+
+**Files:**
+- Modify: `src/components/HandicapHistory/HandicapHistory.component.tsx:71-137`
+
+- [ ] **Step 1: Replace `currentHI` with a simple sort-and-pick from `roundsWithSD`**
+
+Replace the `currentHI` `useMemo` block (lines 71-84) with:
+
+```ts
+  // Current Handicap Index — prefer the most recent round's stored handicapIndex.
+  // After the backfill runs, this is always set when rounds exist.
+  const currentHI = useMemo(() => {
+    if (!roundsList.length) return null;
+    const mostRecentWithHI = roundsList
+      .slice()
+      .sort((a, b) => b.roundDate - a.roundDate)
+      .find((r) => r.handicapIndex != null);
+    return mostRecentWithHI?.handicapIndex ?? null;
+  }, [roundsList]);
+```
+
+- [ ] **Step 2: Replace `progressionData` with a simple chronological filter**
+
+Replace the entire `progressionData` `useMemo` block (lines 92-137) with:
+
+```ts
+  // HCP progression — chronological, one point per round with stored HI.
+  // The dashed reference line at initialHCP (rendered separately) provides
+  // the "started here" context.
+  const progressionData = useMemo(() => {
+    return [...roundsWithSD]
+      .filter((r) => r.handicapIndex != null)
+      .sort((a, b) => a.roundDate - b.roundDate)
+      .map((r) => ({ date: r.roundDate, hi: r.handicapIndex as number }));
+  }, [roundsWithSD]);
+```
+
+- [ ] **Step 3: Verify the `ChartsReferenceLine` block is still present**
+
+The existing JSX at the bottom of the file (around lines 319-328) should remain untouched:
+
+```tsx
+                          {hasInitialHCP && (
+                            <ChartsReferenceLine
+                              y={initialHCP as number}
+                              label="Initial HCP"
+                              lineStyle={{
+                                strokeDasharray: '5 5',
+                                stroke: '#888',
+                              }}
+                            />
+                          )}
+```
+
+Confirm it is still there; no changes needed.
+
+- [ ] **Step 4: Verify type-check passes**
+
+Run: `npm run type-check`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/HandicapHistory/HandicapHistory.component.tsx
+git commit -m "feat: simplify handicap history chart to per-round HI line"
+```
+
+---
+
+## Task 10: Final verification
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `npm test -- --run`
+Expected: all tests pass, including the new `backfillHcpHistory` tests.
+
+- [ ] **Step 2: Run type-check**
+
+Run: `npm run type-check`
+Expected: no errors.
+
+- [ ] **Step 3: Run a production build**
+
+Run: `npm run build`
+Expected: build succeeds.
+
+- [ ] **Step 4: Run the WHS calculation tests**
+
+Run: `npm run test:calc:whs`
+Expected: all WHS tests pass (no formula changes — this confirms the backfill uses the same calculations as the existing tests).
+
+- [ ] **Step 5: Manual UAT — backfill on a mixed-state account**
+
+On a test account with at least 5 rounds, where some have `handicapIndex` / `hcpDelta` and some don't:
+
+1. Open Settings. Confirm the "HCP History Backfill" card is visible with the correct count.
+2. Click "Recalculate HCP history" → confirm dialog → confirm.
+3. Confirm the snackbar reports the correct `updated` + `skipped` count.
+4. Re-open Settings. Confirm the card is gone.
+5. Open `/handicap-history`. Confirm:
+   - All rows have Old HCP / New HCP / Δ values.
+   - The chart shows a line through all rounds.
+   - The dashed reference line at `initialHCP` is still visible.
+
+- [ ] **Step 6: Manual UAT — backfill idempotency**
+
+1. Edit any round in the Firestore console and clear its `previousHCP` field.
+2. Refresh the app, open Settings. Confirm the backfill card reappears with `count === 1`.
+3. Run the backfill. Confirm `updated === 1, skipped === (rounds.length - 1)`.
+
+- [ ] **Step 7: Manual UAT — new round save**
+
+1. Save a new round via the New Round form.
+2. In the Firestore console, confirm the new round document has `previousHCP`, `handicapIndex`, and `hcpDelta` populated.
+
+- [ ] **Step 8: Commit any straggler changes (e.g. lint fixes)**
+
+```bash
+git status
+# if anything changed:
+git add -A
+git commit -m "chore: lint and type-check fixes"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** §1 data model = Task 1. §2 save paths = Tasks 4, 5 (with 2, 3 as wiring). §3 backfill = Task 6. §4 Settings UI = Task 7. §5 table = Task 8. §6 chart = Task 9. §8 verification = Task 10.
+- **Type consistency:** `previousHCP` is the field name throughout. The `IBackfillResult` shape in Task 6 matches the snackbar message format in Task 7. `computeRoundHcpHistory` is exported and used only inside the same file (no external call sites, so no signature drift risk).
+- **No placeholders:** every step has either a code block or an exact command.

--- a/docs/superpowers/specs/2026-06-03-hcp-history-persistence-design.md
+++ b/docs/superpowers/specs/2026-06-03-hcp-history-persistence-design.md
@@ -1,0 +1,234 @@
+# HCP History Persistence + Backfill Design
+
+Date: 2026-06-03
+
+## Overview
+
+Persist `previousHCP` (old HCP) on every round alongside the already-stored `handicapIndex` (new HCP) and `hcpDelta`, backfill these three fields on existing rounds via a one-time manual trigger in Settings, and update the `/handicap-history` table and chart to surface them.
+
+**Why now:** Phase 5 (HCP-INIT, branches 05-01 / 05-02 / 05-03) added the computation and storage of `handicapIndex` and `hcpDelta` for new rounds, but the `previousHCP` value used in the calculation was kept as a local variable only. Rounds saved before Phase 5 also have none of the three fields. The chart in D-14 (initialHCP set, no rounds with stored HI) currently renders a single point at `Date.now()` that sits on top of the dashed reference line, making the per-round progression invisible.
+
+---
+
+## 1. Data model additions
+
+Add `previousHCP` to `IBasicRoundData` in `src/types/roundData.types.tsx`:
+
+```ts
+previousHCP?: number | null;
+```
+
+Final per-round shape (all optional / nullable to remain backward compatible):
+
+| Field | Meaning | Source |
+|---|---|---|
+| `scoreDifferential` | Round's SD | WHS 5.1 |
+| `previousHCP` | HI carried into this round | Previous round's `handicapIndex`, or `initialHCP` for the first round; `null` if no `initialHCP` and no prior round |
+| `handicapIndex` | HI after this round | `calculateHandicapIndex([newSD, ...prior20SDs])` |
+| `hcpDelta` | `handicapIndex - previousHCP`, rounded to 1 decimal | Derived |
+
+---
+
+## 2. Save paths — persist `previousHCP` going forward
+
+The `previousHCP` value is already computed in two places; we just need to write it to Firestore.
+
+### `src/utils/firestore/round.firestore.ts` — `saveNewRound`
+
+The `previousHCP` local var (lines 192-204) is already computed (CR-02 fix). Pass it through to `prepareRoundSaveBatch` so it's written to the new round document.
+
+### `src/utils/firestore/round.firestore.ts` — `importRoundsBatch`
+
+The running `runningHCP` is already tracked. Capture it as `previousHCP` for the next round's `enrichedDoc` (mirror what `saveNewRound` does).
+
+### `src/utils/round/round.utils.tsx` — `prepareRoundSaveBatch`
+
+Add `previousHCP?: number | null` parameter; write it into the round document alongside `scoreDifferential`, `handicapIndex`, `hcpDelta`.
+
+### `src/components/ImportRounds/RoundBuilder.utils.ts` — `IRoundImportDocument`
+
+Add `previousHCP?: number | null` to both the construction params interface and the document interface.
+
+---
+
+## 3. Backfill utility (one-time)
+
+**New file:** `src/utils/firestore/backfillHcpHistory.utils.ts`
+
+```ts
+export interface IBackfillResult {
+  success: boolean;
+  processed: number;
+  updated: number;
+  skipped: number;
+  error?: string;
+}
+
+export const backfillHcpHistory = async (
+  userId: string
+): Promise<IBackfillResult>;
+```
+
+**Algorithm:**
+
+1. Fetch `player.initialHCP` (from `player.firestore` or `useAppStore`).
+2. Query all rounds for `userId`, ordered by `roundDate` ascending.
+3. Walk rounds chronologically, mirroring `importRoundsBatch`:
+   - `previousHCP` = previous round's `handicapIndex`, or `initialHCP` if this is the first round, or `null` if neither is available.
+   - `handicapIndex` = `calculateHandicapIndex([newSD, ...runningSDs].slice(0, 20))`; `null` if SD missing.
+   - `hcpDelta` = `+(handicapIndex - previousHCP).toFixed(1)`; `null` if either is `null`.
+4. Skip rounds where `scoreDifferential == null` (cannot compute HI) — log a warning, don't write.
+5. Build a single Firestore `writeBatch` with one `update` per processable round, writing only `{ previousHCP, handicapIndex, hcpDelta }` — never touching other fields.
+6. Commit the batch. Firestore `writeBatch` is atomic.
+7. Return `{ processed, updated, skipped, success }`. `updated` counts rounds whose values actually changed; `skipped` counts rounds whose existing values already match.
+
+**Idempotency:** Re-runnable. A round whose three fields are already correct produces a no-op `update` and is counted in `skipped`.
+
+**Edge cases:**
+
+| Scenario | Behavior |
+|---|---|
+| 0 rounds | Return `{ processed: 0, updated: 0, skipped: 0, success: true }`. No Firestore call. |
+| Rounds without `initialHCP` (legacy user) | First round gets `previousHCP = null` and `hcpDelta = null`; subsequent rounds work normally. |
+| Round with `scoreDifferential == null` | Skip with `console.warn`; don't write. |
+| Network / batch failure | Catch and return `{ success: false, error: message }`; no partial writes. |
+
+---
+
+## 4. Settings UI — manual one-time trigger
+
+Add a new section to `src/components/Settings/Settings.component.tsx`, placed below the Initial HCP input.
+
+**Visibility:** The section is rendered only when `roundsNeedingBackfill > 0`, where:
+
+```ts
+const roundsNeedingBackfill = roundsList.filter(
+  (r) =>
+    r.previousHCP == null ||
+    r.handicapIndex == null ||
+    r.hcpDelta == null
+).length;
+```
+
+Once all rounds have all three fields, the section disappears — communicating the one-time nature visually. No "done" state badge needed.
+
+**Section content:**
+
+- **Title:** "HCP History Backfill"
+- **Body:** "Your existing rounds don't have the new handicap history fields yet. Run this one-time recalculation to compute Old HCP, New HCP, and Δ for every round. New rounds you save will be calculated automatically."
+- **Button:** `Recalculate HCP history` (MUI `Button variant="contained" color="primary"`, disabled while `isLoading`)
+- **Progress state:** Replace the button with a `CircularProgress` + "Recalculating N rounds..." text during the run.
+- **Confirmation dialog:** A reusable `AlertDialog` (or `Dialog` + `DialogTitle` / `DialogContent` / `DialogActions`):
+  - Title: "Recalculate Handicap History?"
+  - Body: "This will update the Old HCP, New HCP, and Δ fields on every round using the same formula as new rounds. The operation cannot be undone."
+  - Buttons: Cancel / Recalculate
+- **Result feedback:** A `Snackbar` (or inline `Alert`) with "Updated N rounds, K already up to date." on success, or the error message on failure.
+
+**Re-trigger path:** If the user wants to re-run (e.g., to fix a data issue), they can edit and re-save one round, or delete and re-import. The button reappears as soon as any round is missing a field.
+
+---
+
+## 5. Table changes — `src/components/HandicapHistory/HandicapHistory.component.tsx`
+
+Add two new columns between "Score Diff." and the existing "Δ":
+
+| New column | Source | Format |
+|---|---|---|
+| **Old HCP** (`align="right"`) | `round.previousHCP` | `toFixed(1)`, or `—` if null |
+| **New HCP** (`align="right"`) | `round.handicapIndex` | `toFixed(1)`, or `—` if null |
+
+Keep existing Δ and Used (⭐) columns unchanged. Total columns: Date, Course, Tee, Strokes, Score Diff., Old HCP, New HCP, Δ, Used = 9 columns.
+
+Color hint (subtle): positive Δ rendered with `+` prefix (already implemented), negative Δ already has the minus sign. No additional color coding.
+
+---
+
+## 6. Chart changes — `src/components/HandicapHistory/HandicapHistory.component.tsx`
+
+**Goal:** Solid line through per-round `handicapIndex` values + dashed reference line at `initialHCP`. No anchor point at the earliest round. No single-point fallback that hides the data.
+
+### Remove
+
+- The `initialHCP` anchor point in the D-11 branch (lines 124-131 of the current file). The anchor was a workaround to show the "started here" value before the backfill — now redundant.
+- The `roundsWithHI.length === 0` D-14 single-point branch (lines 116-118). This is the branch that today hides the per-round data when stored HI is missing.
+- The CR-03 skip-index-0 fix (lines 125-127 + line 132) — only relevant when the anchor existed.
+- The `mostRecentWithHI` fallback in `currentHI` (lines 75-79) — after backfill, the most recent round's `handicapIndex` is always present when rounds exist.
+
+### Replace `progressionData` with
+
+```ts
+const progressionData = useMemo(() => {
+  return [...roundsWithSD]
+    .filter((r) => r.handicapIndex != null)
+    .sort((a, b) => a.roundDate - b.roundDate)
+    .map((r) => ({ date: r.roundDate, hi: r.handicapIndex as number }));
+}, [roundsWithSD]);
+```
+
+### Keep
+
+The dashed reference line at `initialHCP`:
+
+```jsx
+{hasInitialHCP && (
+  <ChartsReferenceLine
+    y={initialHCP as number}
+    label="Initial HCP"
+    lineStyle={{ strokeDasharray: '5 5', stroke: '#888' }}
+  />
+)}
+```
+
+### Keep
+
+The "your initial handicap is saved" `Alert` (D-14 banner) for the case of `initialHCP` set but zero rounds — this is a UX hint, not a chart concern.
+
+### Result matrix
+
+The chart card is rendered when `progressionData.length >= 1`. The reference line is part of the chart and only appears with it.
+
+| State | What renders |
+|---|---|
+| 0 rounds, no `initialHCP` | Empty-state Alert (existing) |
+| 0 rounds, has `initialHCP` | "Your initial handicap (X.X) is saved" Alert; no chart card |
+| ≥1 round, all with stored HI | Chart card: per-round HI line + dashed reference line at `initialHCP` |
+| ≥1 round, some missing stored HI (pre-backfill) | No chart card; Settings backfill section visible |
+| ≥1 round, no `initialHCP` | Chart card: per-round HI line, no reference line, legacy banner prompts to set `initialHCP` |
+
+---
+
+## 7. Files changed
+
+### Modified
+
+| File | Change |
+|---|---|
+| `src/types/roundData.types.tsx` | Add `previousHCP?: number \| null` to `IBasicRoundData` |
+| `src/utils/firestore/round.firestore.ts` | Pass `previousHCP` through `saveNewRound` and `importRoundsBatch` |
+| `src/utils/round/round.utils.tsx` | Add `previousHCP` param to `prepareRoundSaveBatch` |
+| `src/components/ImportRounds/RoundBuilder.utils.ts` | Add `previousHCP` to `IRoundImportDocument` interfaces and builder |
+| `src/components/Settings/Settings.component.tsx` | Add HCP History Backfill section with gated button, dialog, snackbar |
+| `src/components/HandicapHistory/HandicapHistory.component.tsx` | Add Old/New HCP columns; strip chart anchor + single-point branch; keep reference line |
+
+### New
+
+| File | Purpose |
+|---|---|
+| `src/utils/firestore/backfillHcpHistory.utils.ts` | `backfillHcpHistory(userId)` function |
+| `docs/superpowers/specs/2026-06-03-hcp-history-persistence-design.md` | This document |
+
+---
+
+## 8. Verification
+
+- `npm run type-check` — no TypeScript errors
+- `npm run test:calc:whs` — existing WHS tests still pass (no WHS rule changes)
+- `npm run test:calc:quick` / `test:calc:edge` — calculation tests still pass
+- **Manual — backfill trigger:**
+  - On a test account with mixed round states (some with all 3 fields, some missing), click "Recalculate HCP history"
+  - Verify the result snackbar reports `updated + skipped === rounds.length`
+  - Re-open Settings: section is hidden
+  - Re-open `/handicap-history`: table shows Old HCP / New HCP / Δ for every row; chart shows the per-round line + dashed reference line at `initialHCP`
+- **Manual — backfill idempotency:** Trigger again (via the re-trigger path: edit and re-save a round, which clears one field) → verify `updated` is small, `skipped` is large
+- **Manual — new round:** Save a brand-new round via the New Round form → confirm via Firestore console that the new round document has `previousHCP`, `handicapIndex`, `hcpDelta` populated
+- **Manual — legacy user (no `initialHCP`):** First round's Old HCP / Δ show `—`; subsequent rounds show real values; chart renders without reference line

--- a/src/components/HandicapHistory/HandicapHistory.component.tsx
+++ b/src/components/HandicapHistory/HandicapHistory.component.tsx
@@ -16,7 +16,6 @@ import { LineChart } from '@mui/x-charts/LineChart';
 import { ChartsReferenceLine } from '@mui/x-charts/ChartsReferenceLine';
 import TimelineIcon from '@mui/icons-material/Timeline';
 import { useAppStore } from '@/store/zustand';
-import { calculateHandicapIndex } from '@/utils/whs/hi.utils';
 import dayjs from 'dayjs';
 
 const getScalingCount = (count: number): number => {
@@ -68,73 +67,26 @@ const HandicapHistory = () => {
 		return bestIndices;
 	}, [last20SDs]);
 
-	// Current Handicap Index — prefers the most recent round's stored handicapIndex
-	// (Phase 5 HCP-INIT-04) and falls back to per-round WHS recalc for legacy data.
+	// Current Handicap Index — the most recent round's stored handicapIndex.
+	// After the backfill runs, this is always set when rounds exist.
 	const currentHI = useMemo(() => {
 		if (!roundsList.length) return null;
 		const mostRecentWithHI = roundsList
 			.slice()
 			.sort((a, b) => b.roundDate - a.roundDate)
 			.find((r) => r.handicapIndex != null);
-		if (mostRecentWithHI) return mostRecentWithHI.handicapIndex;
-		// Fallback: per-round WHS recalc (legacy / pre-Phase-5)
-		return calculateHandicapIndex(
-			roundsWithSD.map((r) => r.scoreDifferential as number)
-		);
-	}, [roundsList, roundsWithSD]);
+		return mostRecentWithHI?.handicapIndex ?? null;
+	}, [roundsList]);
 
-	// HCP progression data (chronological) — three branches per Phase 5 HCP-INIT:
-	//   D-11: initialHCP set + rounds have stored handicapIndex
-	//         → first point at initialHCP (earliest round date), then per-round stored HI
-	//   D-14: initialHCP set + 0 rounds have stored handicapIndex
-	//         → single point at (Date.now(), initialHCP) — chart shows anchor + reference line
-	//   D-15: initialHCP NOT set (legacy) — per-round WHS recalc, no reference line
+	// HCP progression — chronological, one point per round with stored HI.
+	// The dashed reference line at initialHCP (rendered separately) provides
+	// the "started here" context.
 	const progressionData = useMemo(() => {
-		// Branch: D-15 legacy fallback (no initialHCP) — keep existing per-round WHS recalc
-		if (!hasInitialHCP) {
-			const chronological = [...roundsWithSD].sort(
-				(a, b) => a.roundDate - b.roundDate
-			);
-			const points: { date: number; hi: number }[] = [];
-			const accumulated: number[] = [];
-			for (const round of chronological) {
-				accumulated.push(round.scoreDifferential as number);
-				const hi = calculateHandicapIndex([...accumulated]);
-				if (hi != null) {
-					points.push({ date: round.roundDate, hi });
-				}
-			}
-			return points;
-		}
-
-		// initialHCP set — work from rounds that have a stored handicapIndex
-		const roundsWithHI = roundsWithSD.filter(
-			(r) => r.handicapIndex != null
-		);
-
-		// Branch: D-14 single-point initialHCP (no rounds with stored HI yet)
-		if (roundsWithHI.length === 0) {
-			return [{ date: Date.now(), hi: initialHCP as number }];
-		}
-
-		// Branch: D-11 chart anchored to initialHCP, then per-round stored HI
-		const chronological = [...roundsWithHI].sort(
-			(a, b) => a.roundDate - b.roundDate
-		);
-		const earliestDate = chronological[0].roundDate;
-		// CR-03 fix: the anchor already represents the first round's date.
-		// Skipping index 0 prevents two points at the same x with different y,
-		// which would render as a vertical line of length |round1.hi - initialHCP|.
-		const anchor: { date: number; hi: number } = {
-			date: earliestDate,
-			hi: initialHCP as number,
-		};
-		const subsequentPoints = chronological.slice(1).map((round) => ({
-			date: round.roundDate,
-			hi: round.handicapIndex as number,
-		}));
-		return [anchor, ...subsequentPoints];
-	}, [roundsWithSD, hasInitialHCP, initialHCP]);
+		return [...roundsWithSD]
+			.filter((r) => r.handicapIndex != null)
+			.sort((a, b) => a.roundDate - b.roundDate)
+			.map((r) => ({ date: r.roundDate, hi: r.handicapIndex as number }));
+	}, [roundsWithSD]);
 
 	if (isLoadingRounds) {
 		return (

--- a/src/components/HandicapHistory/HandicapHistory.component.tsx
+++ b/src/components/HandicapHistory/HandicapHistory.component.tsx
@@ -177,15 +177,7 @@ const HandicapHistory = () => {
 											const isHighlighted =
 												highlightedIndices.has(idx);
 											return (
-												<TableRow
-													key={round.id}
-													sx={{
-														...(isHighlighted && {
-															backgroundColor:
-																'action.selected',
-														}),
-													}}
-												>
+												<TableRow key={round.id}>
 													<TableCell>
 														{dayjs(
 															round.roundDate
@@ -205,11 +197,28 @@ const HandicapHistory = () => {
 													</TableCell>
 													<TableCell align="right">
 														{round.scoreDifferential !=
-														null
-															? round.scoreDifferential.toFixed(
+														null ? (
+															isHighlighted ? (
+																<Box
+																	component="span"
+																	sx={{
+																		display: 'inline-block',
+																		padding: '5px',
+																		border: '1px solid black',
+																	}}
+																>
+																	{round.scoreDifferential.toFixed(
+																		1
+																	)}
+																</Box>
+															) : (
+																round.scoreDifferential.toFixed(
 																	1
 																)
-															: '\u2014'}
+															)
+														) : (
+															'\u2014'
+														)}
 													</TableCell>
 													<TableCell align="right">
 														{round.previousHCP != null

--- a/src/components/HandicapHistory/HandicapHistory.component.tsx
+++ b/src/components/HandicapHistory/HandicapHistory.component.tsx
@@ -167,9 +167,6 @@ const HandicapHistory = () => {
 											<TableCell align="right">
 												Δ
 											</TableCell>
-											<TableCell align="center">
-												Used
-											</TableCell>
 										</TableRow>
 									</TableHead>
 									<TableBody>
@@ -196,29 +193,42 @@ const HandicapHistory = () => {
 															?.totals ?? '\u2014'}
 													</TableCell>
 													<TableCell align="right">
-														{round.scoreDifferential !=
-														null ? (
-															isHighlighted ? (
-																<Box
-																	component="span"
-																	sx={{
-																		display: 'inline-block',
-																		padding: '5px',
-																		border: '1px solid black',
-																	}}
-																>
+														<Box
+															component="span"
+															sx={{
+																display: 'inline-block',
+																padding: '5px',
+																border: '2px solid',
+																borderColor: isHighlighted
+																	? 'black'
+																	: 'transparent',
+																backgroundColor: isHighlighted
+																	? '#fff59d'
+																	: 'transparent',
+																color: isHighlighted
+																	? 'rgba(0,0,0,0.87)'
+																	: 'inherit',
+															}}
+														>
+															{round.scoreDifferential !=
+															null ? (
+																<>
+																	{isHighlighted && (
+																		<Box
+																			component="span"
+																			sx={{ mr: '4px' }}
+																		>
+																			{'\u2605'}
+																		</Box>
+																	)}
 																	{round.scoreDifferential.toFixed(
 																		1
 																	)}
-																</Box>
+																</>
 															) : (
-																round.scoreDifferential.toFixed(
-																	1
-																)
-															)
-														) : (
-															'\u2014'
-														)}
+																'\u2014'
+															)}
+														</Box>
 													</TableCell>
 													<TableCell align="right">
 														{round.previousHCP != null
@@ -238,11 +248,6 @@ const HandicapHistory = () => {
 																		: ''
 																}${round.hcpDelta.toFixed(1)}`
 															: '\u2014'}
-													</TableCell>
-													<TableCell align="center">
-														{isHighlighted
-															? '\u2606'
-															: ''}
 													</TableCell>
 												</TableRow>
 											);

--- a/src/components/HandicapHistory/HandicapHistory.component.tsx
+++ b/src/components/HandicapHistory/HandicapHistory.component.tsx
@@ -207,6 +207,12 @@ const HandicapHistory = () => {
 												Score Diff.
 											</TableCell>
 											<TableCell align="right">
+												Old HCP
+											</TableCell>
+											<TableCell align="right">
+												New HCP
+											</TableCell>
+											<TableCell align="right">
 												Δ
 											</TableCell>
 											<TableCell align="center">
@@ -251,6 +257,16 @@ const HandicapHistory = () => {
 															? round.scoreDifferential.toFixed(
 																	1
 																)
+															: '\u2014'}
+													</TableCell>
+													<TableCell align="right">
+														{round.previousHCP != null
+															? round.previousHCP.toFixed(1)
+															: '\u2014'}
+													</TableCell>
+													<TableCell align="right">
+														{round.handicapIndex != null
+															? round.handicapIndex.toFixed(1)
 															: '\u2014'}
 													</TableCell>
 													<TableCell align="right">

--- a/src/components/ImportRounds/RoundBuilder.utils.ts
+++ b/src/components/ImportRounds/RoundBuilder.utils.ts
@@ -18,6 +18,7 @@ export interface IRoundImportDocument {
   roundNumber: number;
   totals: IRoundTotals;
   scoreDifferential: number | null;
+  previousHCP: number | null;
   handicapIndex: number | null;
   hcpDelta: number | null;
   userId: string;
@@ -34,6 +35,7 @@ export function buildRoundDocument(params: {
   match: ICourseMatchResult;
   roundNumber: number;
   userId: string;
+  previousHCP?: number | null;
   handicapIndex?: number | null;
   hcpDelta?: number | null;
 }): IRoundImportDocument {
@@ -55,6 +57,7 @@ export function buildRoundDocument(params: {
     roundNumber: params.roundNumber,
     totals,
     scoreDifferential: params.parsed.scoreDifferential,
+    previousHCP: params.previousHCP ?? null,
     handicapIndex: params.handicapIndex ?? null,
     hcpDelta: params.hcpDelta ?? null,
     userId: params.userId,

--- a/src/components/Settings/Settings.component.tsx
+++ b/src/components/Settings/Settings.component.tsx
@@ -1,8 +1,27 @@
 import { ThemeMode } from '@/types/user.types';
-import { Alert, Box, Card, CardContent, FormControlLabel, Switch, TextField, Typography } from '@mui/material';
+import {
+	Alert,
+	Box,
+	Button,
+	Card,
+	CardContent,
+	CircularProgress,
+	Dialog,
+	DialogActions,
+	DialogContent,
+	DialogContentText,
+	DialogTitle,
+	FormControlLabel,
+	Switch,
+	TextField,
+	Typography,
+} from '@mui/material';
 import React, { useEffect, useState } from 'react';
 import Spinner from '../common/spinner/Spinner.component';
 import { useAppStore } from '@/store/zustand';
+import { backfillHcpHistory } from '@/utils/firestore/backfillHcpHistory.utils';
+import { useSnackbar } from '@/components/Admin/SnackbarProvider.component';
+import { IBasicRoundData } from '@/types/roundData.types';
 
 // Validation regex: optional minus, integer, optional single-decimal place
 const HCP_VALIDATION_REGEX = /^-?\d+(\.\d)?$/;
@@ -28,10 +47,21 @@ const Settings = () => {
   const currentThemeMode = useAppStore((state) => state.themePreference);
   const updateUserThemePreference = useAppStore((state) => state.updateUserThemePreference);
   const updatePlayerProfile = useAppStore((state) => state.updatePlayerProfile);
+  const roundsList = useAppStore((state) => state.roundsList) as IBasicRoundData[];
+  const { showSnackbar } = useSnackbar();
+
+  const roundsNeedingBackfill = roundsList.filter(
+    (r) =>
+      r.previousHCP == null ||
+      r.handicapIndex == null ||
+      r.hcpDelta == null
+  ).length;
 
   const [hcpValue, setHcpValue] = useState<string>('');
   const [hcpError, setHcpError] = useState<string>('');
   const [isSavingHcp, setIsSavingHcp] = useState<boolean>(false);
+  const [backfillConfirmOpen, setBackfillConfirmOpen] = useState<boolean>(false);
+  const [isBackfilling, setIsBackfilling] = useState<boolean>(false);
 
   useEffect(() => {
     if (player?.initialHCP != null) {
@@ -87,6 +117,28 @@ const Settings = () => {
     }
   };
 
+  const handleBackfill = async () => {
+    if (!playerId) return;
+    setIsBackfilling(true);
+    try {
+      const result = await backfillHcpHistory(playerId);
+      if (result.success) {
+        showSnackbar(
+          `Updated ${result.updated} round${result.updated !== 1 ? 's' : ''}, ${result.skipped} already up to date.`,
+          'success'
+        );
+        await useAppStore.getState().getPlayerDetails(playerId);
+      } else {
+        showSnackbar(`Backfill failed: ${result.error ?? 'unknown error'}`, 'error');
+      }
+    } catch (err: any) {
+      showSnackbar(`Backfill failed: ${err?.message ?? 'unknown error'}`, 'error');
+    } finally {
+      setIsBackfilling(false);
+      setBackfillConfirmOpen(false);
+    }
+  };
+
   if (isPlayerLoading && !playerId) {
     return <Spinner />;
   }
@@ -133,6 +185,74 @@ const Settings = () => {
           </Card>
         </Box>
       )}
+
+      {roundsNeedingBackfill > 0 && (
+        <Box sx={{ mt: 3, maxWidth: 480 }}>
+          <Card>
+            <CardContent>
+              <Typography variant="title3" gutterBottom>
+                HCP History Backfill
+              </Typography>
+              <Typography variant="body" color="text.secondary" sx={{ mb: 2 }}>
+                {roundsNeedingBackfill} of your existing rounds don't have
+                Old HCP, New HCP, and Δ values yet. Run this one-time
+                recalculation to compute them using the same formula as
+                new rounds. New rounds will be calculated automatically
+                going forward.
+              </Typography>
+              {isBackfilling ? (
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+                  <CircularProgress size={20} />
+                  <Typography variant="body" color="text.secondary">
+                    Recalculating {roundsNeedingBackfill} rounds...
+                  </Typography>
+                </Box>
+              ) : (
+                <Button
+                  variant="contained"
+                  color="primary"
+                  onClick={() => setBackfillConfirmOpen(true)}
+                  disabled={!playerId}
+                >
+                  Recalculate HCP history
+                </Button>
+              )}
+            </CardContent>
+          </Card>
+        </Box>
+      )}
+
+      <Dialog
+        open={backfillConfirmOpen}
+        onClose={() => !isBackfilling && setBackfillConfirmOpen(false)}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle>Recalculate Handicap History?</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            This will update the Old HCP, New HCP, and Δ fields on every
+            round using the same formula as new rounds. The operation
+            cannot be undone.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={() => setBackfillConfirmOpen(false)}
+            disabled={isBackfilling}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={handleBackfill}
+            disabled={isBackfilling}
+          >
+            Recalculate
+          </Button>
+        </DialogActions>
+      </Dialog>
 
     </Box>
 

--- a/src/types/roundData.types.tsx
+++ b/src/types/roundData.types.tsx
@@ -170,6 +170,7 @@ export interface IBasicRoundData {
   userId?: string
   createdAt: number,
   scoreDifferential?: number | null,
+  previousHCP?: number | null,
   handicapIndex?: number | null,
   hcpDelta?: number | null,
   totals: IRoundTotals

--- a/src/utils/firestore/backfillHcpHistory.utils.test.ts
+++ b/src/utils/firestore/backfillHcpHistory.utils.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { computeRoundHcpHistory } from './backfillHcpHistory.utils';
+
+describe('computeRoundHcpHistory', () => {
+	it('returns empty for empty input', () => {
+		const out = computeRoundHcpHistory([], 18.0);
+		expect(out).toEqual([]);
+	});
+
+	it('anchors first round to initialHCP', () => {
+		const out = computeRoundHcpHistory(
+			[{ id: 'r1', roundDate: 1, scoreDifferential: 12.0 }],
+			18.0
+		);
+		expect(out).toHaveLength(1);
+		expect(out[0]).toMatchObject({
+			id: 'r1',
+			previousHCP: 18.0,
+			hcpDelta: +(12.0 - 18.0).toFixed(1),
+		});
+		expect(out[0].handicapIndex).toBe(12.0);
+	});
+
+	it('chains subsequent rounds off previous handicapIndex', () => {
+		const out = computeRoundHcpHistory(
+			[
+				{ id: 'r1', roundDate: 1, scoreDifferential: 12.0 },
+				{ id: 'r2', roundDate: 2, scoreDifferential: 14.0 },
+			],
+			18.0
+		);
+		expect(out).toHaveLength(2);
+		expect(out[1]).toMatchObject({
+			id: 'r2',
+			previousHCP: 12.0,
+		});
+		expect(out[1].hcpDelta).toBe(
+			+(out[1].handicapIndex! - 12.0).toFixed(1)
+		);
+	});
+
+	it('skips rounds with null scoreDifferential', () => {
+		const out = computeRoundHcpHistory(
+			[
+				{ id: 'r1', roundDate: 1, scoreDifferential: null },
+				{ id: 'r2', roundDate: 2, scoreDifferential: 14.0 },
+			],
+			18.0
+		);
+		expect(out).toHaveLength(1);
+		expect(out[0].id).toBe('r2');
+		expect(out[0].previousHCP).toBe(18.0);
+	});
+
+	it('returns null previousHCP/hcpDelta for first round when no initialHCP', () => {
+		const out = computeRoundHcpHistory(
+			[{ id: 'r1', roundDate: 1, scoreDifferential: 12.0 }],
+			null
+		);
+		expect(out[0].previousHCP).toBeNull();
+		expect(out[0].hcpDelta).toBeNull();
+		expect(out[0].handicapIndex).toBe(12.0);
+	});
+
+	it('produces null hcpDelta when first round has no anchor and we cannot compute delta', () => {
+		const out = computeRoundHcpHistory(
+			[
+				{ id: 'r1', roundDate: 1, scoreDifferential: 12.0 },
+				{ id: 'r2', roundDate: 2, scoreDifferential: 14.0 },
+			],
+			null
+		);
+		expect(out[0].previousHCP).toBeNull();
+		expect(out[0].hcpDelta).toBeNull();
+		expect(out[1].previousHCP).toBe(12.0);
+		expect(out[1].hcpDelta).toBe(
+			+(out[1].handicapIndex! - 12.0).toFixed(1)
+		);
+	});
+});

--- a/src/utils/firestore/backfillHcpHistory.utils.ts
+++ b/src/utils/firestore/backfillHcpHistory.utils.ts
@@ -1,0 +1,190 @@
+/**
+ * One-time backfill of per-round HCP history fields.
+ *
+ * Walks a player's rounds chronologically, computing `previousHCP`,
+ * `handicapIndex`, and `hcpDelta` using the same formula as
+ * `importRoundsBatch`. The first round's `previousHCP` is anchored to
+ * the player's `initialHCP` (or null if absent). Subsequent rounds
+ * anchor to the previous round's `handicapIndex`.
+ *
+ * Rounds with `scoreDifferential == null` are skipped from output with
+ * a warning; they don't break the running chain so subsequent rounds
+ * still anchor correctly.
+ *
+ * Pure helper `computeRoundHcpHistory` is unit-tested; the Firestore
+ * wrapper `backfillHcpHistory` is integration-tested manually.
+ */
+
+import {
+	collection,
+	getDocs,
+	orderBy,
+	query,
+	writeBatch,
+	doc,
+	Timestamp,
+	getDoc,
+} from 'firebase/firestore';
+import { db } from '@/utils/firebase/firebase.utils';
+import { calculateHandicapIndex } from '@/utils/whs/hi.utils';
+
+export interface IRoundHcpInput {
+	id: string;
+	roundDate: number;
+	scoreDifferential: number | null;
+}
+
+export interface IRoundHcpComputed {
+	id: string;
+	previousHCP: number | null;
+	handicapIndex: number | null;
+	hcpDelta: number | null;
+}
+
+/**
+ * Pure calculation: given a chronologically-sorted list of rounds and
+ * the player's initialHCP, return the per-round HCP fields to write.
+ *
+ * Rounds with a null `scoreDifferential` are omitted from the result
+ * (logged as a warning); the running chain continues uninterrupted so
+ * the next round with an SD still anchors to the most recent valid HI
+ * (or initialHCP if no prior valid HI exists).
+ */
+export const computeRoundHcpHistory = (
+	rounds: IRoundHcpInput[],
+	initialHCP: number | null
+): IRoundHcpComputed[] => {
+	const result: IRoundHcpComputed[] = [];
+	let runningSDs: number[] = [];
+	let runningHCP: number | null = initialHCP;
+
+	for (const round of rounds) {
+		if (round.scoreDifferential == null) {
+			console.warn(
+				`computeRoundHcpHistory: skipping round ${round.id} \u2014 null scoreDifferential`
+			);
+			continue;
+		}
+
+		const previousHCP: number | null = runningHCP;
+		const virtualSDs = [round.scoreDifferential, ...runningSDs].slice(0, 20);
+		const newHI = calculateHandicapIndex(virtualSDs);
+
+		let handicapIndex: number | null = null;
+		let hcpDelta: number | null = null;
+
+		if (newHI != null) {
+			handicapIndex = newHI;
+			if (previousHCP != null) {
+				hcpDelta = +(newHI - previousHCP).toFixed(1);
+			}
+			runningSDs = [round.scoreDifferential, ...runningSDs].slice(0, 19);
+			runningHCP = newHI;
+		}
+
+		result.push({ id: round.id, previousHCP, handicapIndex, hcpDelta });
+	}
+
+	return result;
+};
+
+export interface IBackfillResult {
+	success: boolean;
+	processed: number;
+	updated: number;
+	skipped: number;
+	error?: string;
+}
+
+/**
+ * Fetch all rounds, compute the HCP history, and write a single batch.
+ * Idempotent: re-runs produce the same values.
+ *
+ * `processed` counts rounds for which we computed values (excludes
+ * rounds with null scoreDifferential). `updated` counts batch writes
+ * actually issued. `skipped` counts rounds whose existing values
+ * already matched.
+ */
+export const backfillHcpHistory = async (
+	userId: string
+): Promise<IBackfillResult> => {
+	if (!userId) {
+		return {
+			success: false,
+			processed: 0,
+			updated: 0,
+			skipped: 0,
+			error: 'User ID required',
+		};
+	}
+
+	try {
+		const playerDocRef = doc(db, 'players', userId);
+		const playerSnap = await getDoc(playerDocRef);
+		const initialHCP: number | null = playerSnap.exists()
+			? (playerSnap.data().initialHCP ?? null)
+			: null;
+
+		const roundsColRef = collection(db, 'players', userId, 'rounds');
+		const roundsQuery = query(roundsColRef, orderBy('roundDate', 'asc'));
+		const roundsSnap = await getDocs(roundsQuery);
+
+		if (roundsSnap.empty) {
+			return { success: true, processed: 0, updated: 0, skipped: 0 };
+		}
+
+		const inputs: IRoundHcpInput[] = roundsSnap.docs.map((d) => {
+			const data = d.data();
+			const roundDate =
+				data.roundDate instanceof Timestamp
+					? data.roundDate.toMillis()
+					: Number(data.roundDate);
+			const sd = data.scoreDifferential ?? null;
+			return { id: d.id, roundDate, scoreDifferential: sd };
+		});
+
+		const computed = computeRoundHcpHistory(inputs, initialHCP);
+
+		const docsById = new Map(roundsSnap.docs.map((d) => [d.id, d]));
+
+		const batch = writeBatch(db);
+		let updated = 0;
+		let skipped = 0;
+		const processed = computed.length;
+
+		for (const next of computed) {
+			const origDoc = docsById.get(next.id);
+			if (!origDoc) continue;
+			const origData = origDoc.data();
+			const samePrev = origData.previousHCP === next.previousHCP;
+			const sameHI = origData.handicapIndex === next.handicapIndex;
+			const sameDelta = origData.hcpDelta === next.hcpDelta;
+			if (samePrev && sameHI && sameDelta) {
+				skipped += 1;
+				continue;
+			}
+			const roundRef = doc(db, 'players', userId, 'rounds', next.id);
+			batch.update(roundRef, {
+				previousHCP: next.previousHCP,
+				handicapIndex: next.handicapIndex,
+				hcpDelta: next.hcpDelta,
+			});
+			updated += 1;
+		}
+
+		if (updated > 0) {
+			await batch.commit();
+		}
+
+		return { success: true, processed, updated, skipped };
+	} catch (err: any) {
+		console.error('backfillHcpHistory failed:', err);
+		return {
+			success: false,
+			processed: 0,
+			updated: 0,
+			skipped: 0,
+			error: err?.message ?? 'Unknown error',
+		};
+	}
+};

--- a/src/utils/firestore/round.firestore.ts
+++ b/src/utils/firestore/round.firestore.ts
@@ -182,27 +182,28 @@ export const saveNewRound = async (): Promise<{ success: boolean; roundId: strin
       // Round save continues without SD — non-blocking
     }
 
-    // Compute Handicap Index and delta (per D-04, D-08)
+    // Compute Handicap Index, previousHCP, and delta (per D-04, D-08, HCP-PERSIST)
     let handicapIndex: number | null = null;
     let hcpDelta: number | null = null;
+    let previousHCP: number | null = null;
     try {
       // CR-02 fix: legacy users (pre-Phase-5 rounds, no stored handicapIndex) need
       // the live WHS recalc, not the player's initialHCP, as the previousHCP for
       // the new hcpDelta computation.
       const mostRecent = store.roundsList[0];
-      let previousHCP: number | null;
+      let prevHCP: number | null;
       if (mostRecent?.handicapIndex != null) {
-        previousHCP = mostRecent.handicapIndex;
+        prevHCP = mostRecent.handicapIndex;
       } else if (store.roundsList.length > 0) {
         // Legacy fallback: live WHS recalc from existing SDs (mirrors D-15 chart branch)
         const legacySDs = store.roundsList
           .map((r) => r.scoreDifferential)
           .filter((sd): sd is number => sd !== null && sd !== undefined);
-        previousHCP = calculateHandicapIndex(legacySDs);
+        prevHCP = calculateHandicapIndex(legacySDs);
       } else {
-        previousHCP = player?.initialHCP ?? null;
+        prevHCP = player?.initialHCP ?? null;
       }
-      if (previousHCP != null && scoreDifferential != null) {
+      if (prevHCP != null && scoreDifferential != null) {
         const previousSDs = store.roundsList
           .map((r) => r.scoreDifferential)
           .filter((sd): sd is number => sd !== null && sd !== undefined)
@@ -211,7 +212,8 @@ export const saveNewRound = async (): Promise<{ success: boolean; roundId: strin
         const newHI = calculateHandicapIndex(virtualSDs);
         if (newHI != null) {
           handicapIndex = newHI;
-          hcpDelta = +((newHI - previousHCP)).toFixed(1);
+          previousHCP = prevHCP;
+          hcpDelta = +((newHI - prevHCP)).toFixed(1);
         }
       }
     } catch (hiError: any) {
@@ -228,6 +230,7 @@ export const saveNewRound = async (): Promise<{ success: boolean; roundId: strin
       currentRoundDistances,
       holes,
       scoreDifferential,
+      previousHCP,
       handicapIndex,
       hcpDelta
     );

--- a/src/utils/firestore/round.firestore.ts
+++ b/src/utils/firestore/round.firestore.ts
@@ -91,6 +91,7 @@ export const importRoundsBatch = async (
     const newSD = roundDoc.scoreDifferential;
     let handicapIndex: number | null = null;
     let hcpDelta: number | null = null;
+    let previousHCP: number | null = runningHCP;
 
     if (runningHCP != null && newSD != null) {
       const virtualSDs = [newSD, ...runningSDs].slice(0, 20);
@@ -99,10 +100,13 @@ export const importRoundsBatch = async (
         handicapIndex = newHI;
         hcpDelta = +((newHI - runningHCP)).toFixed(1);
       }
+    } else if (runningHCP == null) {
+      previousHCP = null;
     }
 
     const enrichedDoc: IRoundImportDocument = {
       ...roundDoc,
+      previousHCP,
       handicapIndex,
       hcpDelta,
     };
@@ -119,6 +123,8 @@ export const importRoundsBatch = async (
     }
     if (handicapIndex != null) {
       runningHCP = handicapIndex;
+    } else {
+      runningHCP = null;
     }
   }
 

--- a/src/utils/round/round.utils.tsx
+++ b/src/utils/round/round.utils.tsx
@@ -89,6 +89,7 @@ export const prepareRoundSaveBatch = (
   currentRoundDistances: IDistance[],
   holes: IShots[],
   scoreDifferential?: number | null,
+  previousHCP?: number | null,
   handicapIndex?: number | null,
   hcpDelta?: number | null
 ): string => {
@@ -102,6 +103,7 @@ export const prepareRoundSaveBatch = (
     distances: currentRoundDistances,
     userId: userId,
     scoreDifferential: scoreDifferential ?? null,
+    previousHCP: previousHCP ?? null,
     handicapIndex: handicapIndex ?? null,
     hcpDelta: hcpDelta ?? null,
     roundDate: general.roundDate ? Timestamp.fromDate(new Date(general.roundDate)) : serverTimestamp(),


### PR DESCRIPTION
## Summary

Persists `previousHCP` on every round (alongside `handicapIndex` and `hcpDelta`), backfills these three fields on existing rounds via a one-time Settings trigger, and updates `/handicap-history` to show Old HCP / New HCP / Δ columns with a simplified per-round HI line chart.

**Why:** Phase 5 added stored `handicapIndex` and `hcpDelta` for new rounds, but `previousHCP` was kept as a local var only — so the table couldn't show "old → new HCP" per round and pre-Phase-5 rounds had none of the three fields. The chart's D-14 single-point branch also hid per-round data.

## Changes

**Data model**
- Add `previousHCP?: number | null` to `IBasicRoundData`
- Add `previousHCP` to `IRoundImportDocument` and `buildRoundDocument`

**Save paths (forward-going)**
- `saveNewRound` computes and persists `previousHCP` alongside HI/delta
- `importRoundsBatch` captures `runningHCP` as each round's `previousHCP`
- `prepareRoundSaveBatch` accepts and writes the new field

**Backfill (one-time)**
- New `backfillHcpHistory(userId)` utility — fetches all rounds, walks chronologically, writes a single batch
- Pure `computeRoundHcpHistory` helper is unit-tested (6/6 tests passing)
- Idempotent: re-runs produce no-op writes (counted as `skipped`)
- Null-SD rounds are skipped from output with `console.warn` but **don't break the chain** (next round still anchors correctly)
- Backfill loop uses ID-based doc lookup since `computed.length` ≤ `inputs.length`

**Settings UI**
- New gated "HCP History Backfill" card — only renders when `roundsNeedingBackfill > 0`
- Confirmation dialog + snackbar feedback
- Card auto-hides once all rounds have the three fields

**Handicap History**
- Table: added Old HCP and New HCP columns between Score Diff. and Δ
- Chart: stripped D-11 anchor, D-14 single-point, and D-15 legacy WHS recalc branches — now a simple per-round HI line filter
- Dashed reference line at `initialHCP` preserved

## Test Plan

- [x] `npm run type-check` — clean
- [x] `npm test -- --run backfillHcpHistory` — 6/6 tests passing
- [x] `npm run test:calc:whs` — 21/21 (no WHS rule changes)
- [x] `npm run build` — production build succeeds
- [ ] Manual UAT — backfill on a mixed-state account:
  - Confirm "HCP History Backfill" card visible with correct count
  - Click Recalculate → confirm dialog → confirm
  - Verify snackbar reports `updated + skipped === total`
  - Re-open Settings: card is gone
  - `/handicap-history`: Old HCP / New HCP / Δ on every row + per-round chart line + dashed reference line
- [ ] Manual UAT — backfill idempotency: clear one round's `previousHCP` in Firestore, re-run, verify `updated === 1`
- [ ] Manual UAT — new round save populates all three HCP fields in Firestore

## Plan Deviation

`computeRoundHcpHistory` follows the test contract (Step A) rather than the plan's Step 3 code, which was inconsistent:
- Tests expect null-SD rounds **skipped from output** (`out.length === 1`) and chain **NOT broken** (`r2.previousHCP === initialHCP`)
- Plan's Step 3 always pushed every round and reset `runningHCP = null` on null SD

Decision approved during execution. Aligns with design doc §3 ("don't write" for unprocessable rounds).

## Files

- `src/types/roundData.types.tsx`
- `src/components/ImportRounds/RoundBuilder.utils.ts`
- `src/utils/round/round.utils.tsx`
- `src/utils/firestore/round.firestore.ts`
- `src/utils/firestore/backfillHcpHistory.utils.ts` (new)
- `src/utils/firestore/backfillHcpHistory.utils.test.ts` (new)
- `src/components/Settings/Settings.component.tsx`
- `src/components/HandicapHistory/HandicapHistory.component.tsx`

## Refs

- Design: `docs/superpowers/specs/2026-06-03-hcp-history-persistence-design.md`
- Plan: `docs/superpowers/plans/2026-06-03-hcp-history-persistence.md`