### PR TITLE
feat(stableford): new /stableford-history page + drawer/column cleanups

### DIFF
--- a/docs/superpowers/plans/2026-06-04-stableford-history.md
+++ b/docs/superpowers/plans/2026-06-04-stableford-history.md
@@ -1,0 +1,661 @@
+# Stableford History Page + Drawer Dashboard Icon — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a new `/stableford-history` page with a 3-line dual-axis trend chart and a 6-column last-20-rounds table, plus two small UI cleanups (drawer Dashboard entry visibility, dashboard `Points` → `Stableford Pts` column rename).
+
+**Architecture:** Pure utility functions in `src/utils/stableford/stableford.utils.tsx` (covered by vitest) read directly from the existing `IBasicRoundData` shape; a single React component reads `roundsList` from the Zustand store and renders the table + `<LineChart>` (no new types on `IBasicRoundData`, no Firestore writes, no backfill). Routing, sidebar, and breadcrumb are wired through the existing patterns.
+
+**Tech Stack:** React 19, MUI v7, `@mui/x-charts` 8.x, Zustand (existing), Vitest 4.x (existing), TypeScript 6.
+
+**Working branch:** `feat/stableford-history` (already created off `origin/development`; the design spec is committed in `716a0b8`).
+
+**Design spec:** `docs/superpowers/specs/2026-06-04-stableford-history-design.md` (must-read before implementing).
+
+---
+
+## File Map
+
+**New files**
+- `src/utils/stableford/stableford.utils.tsx` — pure helpers (`getStablefordPoints`, `getGrossScore`, `getNetScore`, `getGrossVsPar`, `getNetVsPar`)
+- `src/utils/stableford/stableford.utils.test.ts` — vitest cases
+- `src/components/StablefordHistory/StablefordHistory.component.tsx` — page content
+- `src/pages/StablefordHistory.page.tsx` — page wrapper
+
+**Modified files**
+- `src/App.tsx` — register `/stableford-history` route
+- `src/utils/links/links.utils.tsx` — add `Stableford History` sidebar entry, flip Dashboard `show` flag
+- `src/components/layout/MainLayout2.component.tsx` — add breadcrumb branch for `/stableford-history`
+- `src/components/Rounds/RoundsTable.component.tsx` — rename `Points` header to `Stableford Pts`
+
+**Out of scope (do not touch)**
+- `IBasicRoundData` type, Firestore schema, redux store, calculator utils, HCP history logic.
+
+---
+
+## Task 1: Pure stableford utils + vitest tests (TDD)
+
+**Files:**
+- Create: `src/utils/stableford/stableford.utils.test.ts`
+- Create: `src/utils/stableford/stableford.utils.tsx`
+
+- [ ] **Step 1: Create the test file**
+
+Create `src/utils/stableford/stableford.utils.test.ts` with the following content:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+	getStablefordPoints,
+	getGrossScore,
+	getNetScore,
+	getGrossVsPar,
+	getNetVsPar,
+} from './stableford.utils';
+import type { IBasicRoundData } from '@/types/roundData.types';
+
+describe('stableford.utils', () => {
+	describe('getStablefordPoints', () => {
+		it('returns totals.points.totals when present', () => {
+			const round = { totals: { points: { totals: 36 } } } as unknown as IBasicRoundData;
+			expect(getStablefordPoints(round)).toBe(36);
+		});
+
+		it('returns null when totals.points is missing', () => {
+			const round = { totals: {} } as unknown as IBasicRoundData;
+			expect(getStablefordPoints(round)).toBe(null);
+		});
+
+		it('returns null when totals itself is missing', () => {
+			const round = {} as unknown as IBasicRoundData;
+			expect(getStablefordPoints(round)).toBe(null);
+		});
+	});
+
+	describe('getGrossScore', () => {
+		it('returns totals.score.totals when present', () => {
+			const round = { totals: { score: { totals: 80 } } } as unknown as IBasicRoundData;
+			expect(getGrossScore(round)).toBe(80);
+		});
+
+		it('returns null when totals.score is missing', () => {
+			const round = { totals: {} } as unknown as IBasicRoundData;
+			expect(getGrossScore(round)).toBe(null);
+		});
+
+		it('returns null when totals itself is missing', () => {
+			const round = {} as unknown as IBasicRoundData;
+			expect(getGrossScore(round)).toBe(null);
+		});
+	});
+
+	describe('getNetScore', () => {
+		it('returns gross - playingHCP when both present (gross 80, hcp 10 -> 70)', () => {
+			const round = {
+				totals: { score: { totals: 80 } },
+				roundPlayingHCP: '10',
+			} as unknown as IBasicRoundData;
+			expect(getNetScore(round)).toBe(70);
+		});
+
+		it('returns null when roundPlayingHCP is missing', () => {
+			const round = { totals: { score: { totals: 80 } } } as unknown as IBasicRoundData;
+			expect(getNetScore(round)).toBe(null);
+		});
+
+		it('returns null when gross score is missing', () => {
+			const round = { roundPlayingHCP: '10' } as unknown as IBasicRoundData;
+			expect(getNetScore(round)).toBe(null);
+		});
+	});
+
+	describe('getGrossVsPar', () => {
+		it('returns gross - par when both present (gross 80, par 72 -> +8)', () => {
+			const round = {
+				totals: { score: { totals: 80 } },
+				roundPar: '72',
+			} as unknown as IBasicRoundData;
+			expect(getGrossVsPar(round)).toBe(8);
+		});
+
+		it('handles negative values (under par: gross 70, par 72 -> -2)', () => {
+			const round = {
+				totals: { score: { totals: 70 } },
+				roundPar: '72',
+			} as unknown as IBasicRoundData;
+			expect(getGrossVsPar(round)).toBe(-2);
+		});
+
+		it('returns null when roundPar is missing', () => {
+			const round = { totals: { score: { totals: 80 } } } as unknown as IBasicRoundData;
+			expect(getGrossVsPar(round)).toBe(null);
+		});
+
+		it('returns null when gross score is missing', () => {
+			const round = { roundPar: '72' } as unknown as IBasicRoundData;
+			expect(getGrossVsPar(round)).toBe(null);
+		});
+	});
+
+	describe('getNetVsPar', () => {
+		it('returns net - par when all three present (gross 80, hcp 10, par 72 -> -2)', () => {
+			const round = {
+				totals: { score: { totals: 80 } },
+				roundPar: '72',
+				roundPlayingHCP: '10',
+			} as unknown as IBasicRoundData;
+			expect(getNetVsPar(round)).toBe(-2);
+		});
+
+		it('returns null when roundPar is missing', () => {
+			const round = {
+				totals: { score: { totals: 80 } },
+				roundPlayingHCP: '10',
+			} as unknown as IBasicRoundData;
+			expect(getNetVsPar(round)).toBe(null);
+		});
+
+		it('returns null when roundPlayingHCP is missing', () => {
+			const round = {
+				totals: { score: { totals: 80 } },
+				roundPar: '72',
+			} as unknown as IBasicRoundData;
+			expect(getNetVsPar(round)).toBe(null);
+		});
+
+		it('returns null when gross score is missing', () => {
+			const round = {
+				roundPar: '72',
+				roundPlayingHCP: '10',
+			} as unknown as IBasicRoundData;
+			expect(getNetVsPar(round)).toBe(null);
+		});
+	});
+});
+```
+
+- [ ] **Step 2: Run the tests to confirm they fail**
+
+Run: `npx vitest run src/utils/stableford/stableford.utils.test.ts`
+Expected: FAIL with "Cannot find module './stableford.utils'" or similar module-resolution error. The test file imports functions from a module that doesn't exist yet.
+
+- [ ] **Step 3: Create the utils implementation**
+
+Create `src/utils/stableford/stableford.utils.tsx` with the following content:
+
+```ts
+import type { IBasicRoundData } from '@/types/roundData.types';
+
+export const getStablefordPoints = (round: IBasicRoundData): number | null => {
+	return round.totals?.points?.totals ?? null;
+};
+
+export const getGrossScore = (round: IBasicRoundData): number | null => {
+	return round.totals?.score?.totals ?? null;
+};
+
+export const getNetScore = (round: IBasicRoundData): number | null => {
+	const gross = getGrossScore(round);
+	if (gross == null) return null;
+	if (round.roundPlayingHCP == null) return null;
+	return gross - Number(round.roundPlayingHCP);
+};
+
+export const getGrossVsPar = (round: IBasicRoundData): number | null => {
+	const gross = getGrossScore(round);
+	if (gross == null) return null;
+	if (round.roundPar == null) return null;
+	return gross - Number(round.roundPar);
+};
+
+export const getNetVsPar = (round: IBasicRoundData): number | null => {
+	const gross = getGrossScore(round);
+	if (gross == null) return null;
+	if (round.roundPar == null || round.roundPlayingHCP == null) return null;
+	return gross - Number(round.roundPar) - Number(round.roundPlayingHCP);
+};
+```
+
+- [ ] **Step 4: Run the tests to confirm they pass**
+
+Run: `npx vitest run src/utils/stableford/stableford.utils.test.ts`
+Expected: PASS, 14/14 test cases green (3 + 3 + 3 + 4 + 4 — 1 from the negative + shared cases).
+
+- [ ] **Step 5: Type-check the new files**
+
+Run: `npm run type-check`
+Expected: exit 0, no TypeScript errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/utils/stableford/stableford.utils.tsx src/utils/stableford/stableford.utils.test.ts
+git commit -m "feat(stableford): add pure utils for stableford/vs-par derivations"
+```
+
+---
+
+## Task 2: StablefordHistory component + page + router + sidebar + breadcrumb (feat commit)
+
+This is the big one. The single commit groups the page itself with all its wiring. The next task (Task 3) handles the two small UI cleanups.
+
+**Files:**
+- Create: `src/components/StablefordHistory/StablefordHistory.component.tsx`
+- Create: `src/pages/StablefordHistory.page.tsx`
+- Modify: `src/App.tsx` (add import + route line)
+- Modify: `src/utils/links/links.utils.tsx` (add import + new sidebar entry)
+- Modify: `src/components/layout/MainLayout2.component.tsx` (add breadcrumb branch)
+
+- [ ] **Step 1: Create the page wrapper**
+
+Create `src/pages/StablefordHistory.page.tsx`:
+
+```tsx
+import StablefordHistory from '@/components/StablefordHistory/StablefordHistory.component';
+
+const StablefordHistoryPage = () => {
+	return <StablefordHistory />;
+};
+
+export default StablefordHistoryPage;
+```
+
+- [ ] **Step 2: Create the StablefordHistory component**
+
+Create `src/components/StablefordHistory/StablefordHistory.component.tsx`:
+
+```tsx
+import { useMemo } from 'react';
+import {
+	Box,
+	Card,
+	CardContent,
+	Typography,
+	Table,
+	TableBody,
+	TableCell,
+	TableContainer,
+	TableHead,
+	TableRow,
+	Alert,
+} from '@mui/material';
+import { LineChart } from '@mui/x-charts/LineChart';
+import ScoreboardIcon from '@mui/icons-material/Scoreboard';
+import { useAppStore } from '@/store/zustand';
+import {
+	getStablefordPoints,
+	getGrossScore,
+	getNetVsPar,
+	getGrossVsPar,
+} from '@/utils/stableford/stableford.utils';
+import dayjs from 'dayjs';
+
+const formatSigned = (n: number | null): string => {
+	if (n == null) return '\u2014';
+	const fixed = n.toFixed(1);
+	return n > 0 ? `+${fixed}` : fixed;
+};
+
+const StablefordHistory = () => {
+	const roundsList = useAppStore((state) => state.roundsList);
+	const isLoadingRounds = useAppStore((state) => state.isLoadingRounds);
+
+	// Rounds with stableford, sorted by date descending (most recent first)
+	const roundsWithStableford = useMemo(() => {
+		return roundsList
+			.filter((r) => getStablefordPoints(r) != null && r.roundDate)
+			.sort((a, b) => b.roundDate - a.roundDate);
+	}, [roundsList]);
+
+	// Last 20 for the table (most recent first)
+	const last20 = useMemo(() => {
+		return roundsWithStableford.slice(0, 20);
+	}, [roundsWithStableford]);
+
+	// Chart data (chronological, oldest -> newest on the x axis)
+	const chartData = useMemo(() => {
+		return [...last20]
+			.sort((a, b) => a.roundDate - b.roundDate)
+			.map((round) => ({
+				date: round.roundDate,
+				stableford: getStablefordPoints(round),
+				netVsPar: getNetVsPar(round),
+				grossVsPar: getGrossVsPar(round),
+			}));
+	}, [last20]);
+
+	if (isLoadingRounds) {
+		return (
+			<Box sx={{ p: 2 }}>
+				<Typography>Loading...</Typography>
+			</Box>
+		);
+	}
+
+	return (
+		<Box>
+			<Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 3 }}>
+				<ScoreboardIcon sx={{ fontSize: 32 }} />
+				<Typography variant="headline2">Stableford History</Typography>
+			</Box>
+
+			{roundsWithStableford.length === 0 && (
+				<Alert severity="info">
+					No rounds with stableford points yet. Play some rounds first!
+				</Alert>
+			)}
+
+			{roundsWithStableford.length > 0 && (
+				<>
+					<Card sx={{ mb: 3 }}>
+						<CardContent>
+							<Typography variant="title6" gutterBottom>
+								Last 20 Rounds
+							</Typography>
+							<TableContainer>
+								<Table size="small">
+									<TableHead>
+										<TableRow>
+											<TableCell>Date</TableCell>
+											<TableCell>Course</TableCell>
+											<TableCell align="right">Stableford</TableCell>
+											<TableCell align="right">Score</TableCell>
+											<TableCell align="right">Net vs Par</TableCell>
+											<TableCell align="right">Gross vs Par</TableCell>
+										</TableRow>
+									</TableHead>
+									<TableBody>
+										{last20.map((round) => {
+											const stableford = getStablefordPoints(round);
+											const score = getGrossScore(round);
+											const netVsPar = getNetVsPar(round);
+											const grossVsPar = getGrossVsPar(round);
+											return (
+												<TableRow key={round.id}>
+													<TableCell>
+														{dayjs(round.roundDate).format('DD/MM/YYYY')}
+													</TableCell>
+													<TableCell>
+														{round.roundCourse ?? '\u2014'}
+													</TableCell>
+													<TableCell align="right">
+														{stableford ?? '\u2014'}
+													</TableCell>
+													<TableCell align="right">
+														{score ?? '\u2014'}
+													</TableCell>
+													<TableCell align="right">
+														{formatSigned(netVsPar)}
+													</TableCell>
+													<TableCell align="right">
+														{formatSigned(grossVsPar)}
+													</TableCell>
+												</TableRow>
+											);
+										})}
+									</TableBody>
+								</Table>
+							</TableContainer>
+						</CardContent>
+					</Card>
+
+					<Card>
+						<CardContent>
+							<Typography variant="title6" gutterBottom>
+								Trend
+							</Typography>
+							<Box sx={{ width: '100%', height: 300 }}>
+								<LineChart
+									dataset={chartData}
+									xAxis={[
+										{
+											dataKey: 'date',
+											scaleType: 'time',
+											valueFormatter: (date: Date) =>
+												dayjs(date).format('DD/MM/YY'),
+										},
+									]}
+									yAxis={[
+										{ id: 'left', label: 'Stableford Pts' },
+										{ id: 'right', label: 'vs Par' },
+									]}
+									series={[
+										{
+											dataKey: 'stableford',
+											label: 'Stableford Pts',
+											yAxisId: 'left',
+											color: '#2e7d32',
+											showMark: true,
+											connectNulls: false,
+										},
+										{
+											dataKey: 'netVsPar',
+											label: 'Net vs Par',
+											yAxisId: 'right',
+											color: '#1976d2',
+											showMark: true,
+											connectNulls: false,
+										},
+										{
+											dataKey: 'grossVsPar',
+											label: 'Gross vs Par',
+											yAxisId: 'right',
+											color: '#ed6c02',
+											showMark: true,
+											connectNulls: false,
+										},
+									]}
+									height={300}
+									margin={{ top: 10, right: 20, bottom: 30, left: 50 }}
+								/>
+							</Box>
+						</CardContent>
+					</Card>
+				</>
+			)}
+		</Box>
+	);
+};
+
+export default StablefordHistory;
+```
+
+- [ ] **Step 3: Add the route in `src/App.tsx`**
+
+In `src/App.tsx`, add the import alphabetically and the route line. Specifically:
+
+a. Add this import next to the other page imports (around line 23, just after `HandicapHistoryPage`):
+
+```ts
+import StablefordHistoryPage from './pages/StablefordHistory.page';
+```
+
+b. Add this route line inside the protected `<Route path="/">` block, next to the existing `/handicap-history` route (around line 53):
+
+```tsx
+<Route path="/stableford-history" element={<StablefordHistoryPage />} />
+```
+
+- [ ] **Step 4: Add the sidebar entry in `src/utils/links/links.utils.tsx`**
+
+a. Add the icon import at the top of the file, with the other MUI icon imports (line 1-7 area):
+
+```ts
+import ScoreboardIcon from '@mui/icons-material/Scoreboard';
+```
+
+b. Add a new entry to the `navbar_items` array (after the `Import Rounds` entry, around line 59):
+
+```ts
+{
+	id: 8,
+	name: 'Stableford History',
+	link: '/stableford-history',
+	icon: ScoreboardIcon,
+	show: true,
+},
+```
+
+- [ ] **Step 5: Add the breadcrumb branch in `src/components/layout/MainLayout2.component.tsx`**
+
+In the `getBreadcrumbs()` function (lines 71-119 of the file), add a new `else if` branch for `/stableford-history`. Place it after the `/handicap-history` branch (around line 102):
+
+```ts
+} else if (path === '/stableford-history') {
+	breadcrumbs.push({ label: 'Stableford History', path: '/stableford-history' });
+```
+
+- [ ] **Step 6: Type-check the full project**
+
+Run: `npm run type-check`
+Expected: exit 0, no TypeScript errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/StablefordHistory/StablefordHistory.component.tsx \
+        src/pages/StablefordHistory.page.tsx \
+        src/App.tsx \
+        src/utils/links/links.utils.tsx \
+        src/components/layout/MainLayout2.component.tsx
+git commit -m "feat(stableford): add /stableford-history page with 3-line dual-axis chart
+
+- New StablefordHistory page: 6-column last-20 table (Date, Course,
+  Stableford, Score, Net vs Par, Gross vs Par) + LineChart with 3
+  series (Stableford Pts on left axis, Net/Gross vs Par on right)
+- Pure derivations live in src/utils/stableford/stableford.utils.tsx
+  so legacy rounds with missing fields render as -- and gap in chart
+- New sidebar entry 'Stableford History' (ScoreboardIcon) + route +
+  breadcrumb"
+```
+
+---
+
+## Task 3: Drawer Dashboard icon + Dashboard Points column rename (chore commit)
+
+**Files:**
+- Modify: `src/utils/links/links.utils.tsx` (flip Dashboard `show` flag)
+- Modify: `src/components/Rounds/RoundsTable.component.tsx` (rename header)
+
+- [ ] **Step 1: Flip the Dashboard sidebar `show` flag**
+
+In `src/utils/links/links.utils.tsx`, in the first entry of `navbar_items` (lines 11-17), change `show: false` to `show: true`:
+
+```ts
+{
+	id: 1,
+	name: "Dashboard",
+	link: "/",
+	icon: HomeWorkIcon,
+	show: true,
+},
+```
+
+- [ ] **Step 2: Rename the dashboard `Points` column header**
+
+In `src/components/Rounds/RoundsTable.component.tsx`, line 32, change the column header string from `'Points'` to `'Stableford Pts'`:
+
+```tsx
+<TableCell align='center' space='10px'>Stableford Pts</TableCell>
+```
+
+(No other change in the file — the cell content at line 70 still binds to `round.totals?.points?.totals`, which is the stableford value.)
+
+- [ ] **Step 3: Type-check the project**
+
+Run: `npm run type-check`
+Expected: exit 0, no TypeScript errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/utils/links/links.utils.tsx src/components/Rounds/RoundsTable.component.tsx
+git commit -m "chore(ui): expose Dashboard in the drawer and rename Points column to Stableford Pts
+
+- links.utils.tsx: flip Dashboard show: false -> show: true so it
+  appears in the navigation drawer (HomeWorkIcon was already wired)
+- RoundsTable.component.tsx: rename 'Points' column to 'Stableford
+  Pts' for clarity; data binding unchanged"
+```
+
+---
+
+## Task 4: Final verification + push + draft PR
+
+- [ ] **Step 1: Run the new vitest suite**
+
+Run: `npx vitest run src/utils/stableford/stableford.utils.test.ts`
+Expected: PASS, 14/14. (Pre-existing test failures in `src/App.test.tsx` and `src/utils/calculator/__tests__/calculations.test.ts` are not related and were present on `development` — see PR #125 description.)
+
+- [ ] **Step 2: Type-check the full project**
+
+Run: `npm run type-check`
+Expected: exit 0.
+
+- [ ] **Step 3: Run the production build**
+
+Run: `npm run build`
+Expected: build succeeds, no errors. Warning-level notices are OK.
+
+- [ ] **Step 4: Push the branch**
+
+```bash
+git push origin feat/stableford-history
+```
+
+- [ ] **Step 5: Open a draft PR to `development`**
+
+Run:
+
+```bash
+gh pr create --draft \
+  --base development \
+  --head feat/stableford-history \
+  --title "feat(stableford): new /stableford-history page + drawer/column cleanups" \
+  --body "$(cat <<'EOF'
+## What's in this PR
+
+- **New `/stableford-history` page** — 6-column last-20-rounds table (Date, Course, Stableford, Score, Net vs Par, Gross vs Par) and a 3-line `<LineChart>` (Stableford Pts on the left axis, Net & Gross vs Par on the right) over the same 20 rounds.
+- **Pure utils** in `src/utils/stableford/stableford.utils.tsx` covered by 14 vitest cases. No Firestore writes, no schema changes, no new types on `IBasicRoundData` — every value plotted is derived from fields already on each round doc.
+- **Sidebar entry** for Stableford History with `ScoreboardIcon`.
+- **Drawer fix** — `Dashboard` entry was hidden via `show: false`; now visible. `HomeWorkIcon` and the `/` route were already wired.
+- **Dashboard rename** — Rounds table `Points` column → `Stableford Pts` for clarity (data binding unchanged).
+
+## How to verify (manual UAT)
+
+1. `npm start`, log in, go to `/dashboard` → confirm the "Dashboard" entry is visible in the drawer and that clicking it lands on `/dashboard` (or `/`).
+2. From the drawer, click "Stableford History" → page loads with no console errors.
+3. With 0 rounds: empty-state Alert.
+4. With ≥ 1 round that has `totals.points.totals` populated: 6-column table renders, chart shows 3 series with the right y-axis labels.
+5. With a round that has `totals.points` missing: that row's "Stableford" cell shows `—`; the chart skips that date for that series.
+6. `/handicap-history` still loads correctly and is unchanged.
+7. Breadcrumb on `/stableford-history` reads `Home / Stableford History`.
+8. On the dashboard's Rounds table, the column header now reads "Stableford Pts".
+
+## Tests
+
+- New: `npx vitest run src/utils/stableford/stableford.utils.test.ts` — 14/14 pass.
+- Pre-existing vitest failures on `development` (`App.test.tsx`, `calculations.test.ts`) are not caused by this branch.
+
+## Out of scope
+
+- Stableford per-hole breakdown, `stablefordIndex` persistence, refactoring `RoundsTable.component.tsx`'s `netScore`/`grossScore` variable names.
+EOF
+)"
+```
+
+- [ ] **Step 6: Post the PR URL in the chat so the user can review**
+
+---
+
+## Self-Review (executed at plan-write time)
+
+- **Spec coverage:**
+  - Section 1 (drawer fix) → covered by Task 3 Step 1.
+  - Section 2 (new page) → covered by Task 2 Steps 1-2 (page + component) + Task 2 Step 3 (router) + Task 2 Step 4 (sidebar) + Task 2 Step 5 (breadcrumb).
+  - Section 2 (utils) → covered by Task 1.
+  - Section 2 (dashboard rename) → covered by Task 3 Step 2.
+  - Section 2 (UAT checklist) → mirrored in the PR body (Task 4 Step 5).
+  - Section 2 (testing) → covered by Task 1 vitest cases.
+- **Placeholder scan:** No TBDs, no "implement later", no "add appropriate validation". Every step has actual code or an exact command.
+- **Type consistency:** Helper names (`getStablefordPoints`, `getGrossScore`, `getNetScore`, `getGrossVsPar`, `getNetVsPar`) match between Task 1 and Task 2. The component's import block, table columns, and chart series use the same field names (`stableford`, `netVsPar`, `grossVsPar`, `date`) end-to-end. The `formatSigned` helper in the component is local to the file and not exported — no risk of name drift.

--- a/docs/superpowers/specs/2026-06-04-stableford-history-design.md
+++ b/docs/superpowers/specs/2026-06-04-stableford-history-design.md
@@ -1,0 +1,182 @@
+# Stableford History Page + Drawer Dashboard Icon
+
+Date: 2026-06-04
+
+## Overview
+
+Two unrelated visibility fixes that share a single PR (and a single branch off `development`):
+
+1. **Drawer dashboard icon** — make the existing "Dashboard" sidebar entry actually visible. One-line change in `src/utils/links/links.utils.tsx`. The Dashboard route, breadcrumb, and `HomeWorkIcon` are all already wired; only `show: false` is hiding it.
+2. **Stableford history page** — a new `/stableford-history` page (and sidebar entry) showing the last 20 rounds in a table and a 3-line dual-axis chart of `Stableford Pts`, `Net vs Par`, and `Gross vs Par`. Plus a small rename of the dashboard's `Rounds` table column from "Points" to "Stableford Pts" for clarity.
+
+No Firestore schema changes, no backfill utility, no new types on `IBasicRoundData`. Every value plotted or shown is already on the round document.
+
+---
+
+## 1. Drawer Dashboard Icon
+
+### Change
+
+**`src/utils/links/links.utils.tsx:16`** — flip `show: false` to `show: true` on the Dashboard entry.
+
+```diff
+  {
+    id: 1,
+    name: "Dashboard",
+    link: "/",
+    icon: HomeWorkIcon,
+-   show: false,
++   show: true,
+  },
+```
+
+That's the entire change for this item. No new imports, no new component, no breadcrumb edit (the breadcrumb's `HomeIcon` stays as-is — it represents "home", not "this sidebar item").
+
+---
+
+## 2. Stableford History Page
+
+### New files
+
+#### `src/utils/stableford/stableford.utils.tsx`
+
+Pure helpers. Each takes a round and returns `number | null`. `null` is returned for any missing required input so the table renders `—` and the chart skips the point.
+
+```ts
+export const getStablefordPoints = (round: IRound): number | null => { ... }
+export const getGrossScore       = (round: IRound): number | null => { ... } // = totals.score.totals
+export const getNetScore         = (round: IRound): number | null => { ... } // = gross - roundPlayingHCP
+export const getGrossVsPar       = (round: IRound): number | null => { ... } // = gross - roundPar
+export const getNetVsPar         = (round: IRound): number | null => { ... } // = net   - roundPar
+```
+
+#### `src/utils/stableford/stableford.utils.test.ts`
+
+Vitest cases:
+- `getStablefordPoints` returns `totals.points.totals` when present, `null` otherwise.
+- `getGrossScore` returns `totals.score.totals` when present, `null` otherwise.
+- `getNetScore` returns `null` when `roundPlayingHCP` is missing.
+- `getGrossVsPar` returns `null` when `roundPar` is missing.
+- `getNetVsPar` returns `null` when either `roundPar` or `roundPlayingHCP` is missing.
+- Sanity check: a 72-par round, gross 80, playingHCP 10 → `getNetVsPar() === 80 - 10 - 72 === -2`.
+
+#### `src/components/StablefordHistory/StablefordHistory.component.tsx`
+
+The page content. Mirrors the structure of `src/components/HandicapHistory/HandicapHistory.component.tsx` (cards in a vertical stack), with:
+
+- **Empty state card** when `roundsList.length === 0` (same wording as HCP history).
+- **Last 20 Rounds table card** — 6 columns: `Date`, `Course`, `Stableford`, `Score`, `Net vs Par`, `Gross vs Par`. All numeric cells right-aligned, `—` for nulls. The table uses a stable transparent wrapper on every `Stableford` cell so row heights match (the HCP history page already uses this pattern for its SD column).
+- **Trend chart card** — single `<LineChart>` from `@mui/x-charts` with the dataset and series described below.
+- No row-level highlighting (stableford has no "used" rule analogous to WHS's best-N-of-20).
+
+#### `src/pages/StablefordHistory.page.tsx`
+
+Thin wrapper that renders `<StablefordHistory />`. Parallels `src/pages/HandicapHistory.page.tsx`.
+
+### Edited files
+
+#### `src/utils/links/links.utils.tsx`
+
+Add a new sidebar entry:
+
+```ts
+import ScoreboardIcon from '@mui/icons-material/Scoreboard';
+// ...
+{
+  id: 8,
+  name: 'Stableford History',
+  link: '/stableford-history',
+  icon: ScoreboardIcon,
+  show: true,
+},
+```
+
+#### `src/components/layout/MainLayout2.component.tsx`
+
+Two changes inside the `getBreadcrumbs` switch (around lines 88-116):
+
+- Import the new page (no — the page is registered via the router, not imported here).
+- Add an `else if (path === '/stableford-history')` branch that pushes `{ label: 'Stableford History', path: '/stableford-history' }`.
+
+The breadcrumb root (the `Home` icon) is already correct and points to `/dashboard`, which is exactly the new drawer entry from change #1.
+
+#### Router registration
+
+In the file that owns the route table (likely `src/App.tsx` — verify at implementation time, may be `src/routes/...`):
+
+```tsx
+<Route path="/stableford-history" element={<StablefordHistory />} />
+```
+
+Exact import + wrapping follows whatever pattern the existing `/handicap-history` route uses (probably wrapped in `<ProtectedRoute>`).
+
+#### `src/components/Rounds/RoundsTable.component.tsx:32`
+
+Rename header `'Points'` to `'Stableford Pts'`. No data change.
+
+### Data flow
+
+- `useAppStore` `roundsList` is the single source (same as `/handicap-history`).
+- `last20 = roundsList.slice(0, 20)` — same sort and slice semantics as the HCP history page.
+- No Firestore writes. No backfill utility. The values plotted and shown are derived from fields that already exist on each round document: `totals.points.totals`, `totals.score.totals`, `roundPar`, `roundPlayingHCP`.
+- No new fields on `IBasicRoundData` or any round type.
+
+### Math (single source of truth in `stableford.utils.tsx`)
+
+| Helper | Formula | Returns `null` if… |
+|--------|---------|---------------------|
+| `getStablefordPoints` | `totals.points.totals` | `totals.points` missing |
+| `getGrossScore` | `totals.score.totals` | `totals.score` missing |
+| `getNetScore` | `getGrossScore - roundPlayingHCP` | either missing |
+| `getGrossVsPar` | `getGrossScore - roundPar` | either missing |
+| `getNetVsPar` | `getNetScore - roundPar` (≡ `getGrossScore - roundPar - roundPlayingHCP`) | any missing |
+
+Note: the existing `RoundsTable.component.tsx:43-44` defines `netScore` and `grossScore` with the names inverted relative to common golf usage. This spec does NOT change that file's logic, only renames its header. If a future refactor wants to clean up the variable names, that's out of scope for this PR.
+
+### Chart config
+
+Single `<LineChart>` from `@mui/x-charts` (already a project dep, version 8.x).
+
+- **Dataset** — `last20.map(round => ({ date: round.roundDate, stableford, netVsPar, grossVsPar }))`. `date` is a `Date` object for the time scale.
+- **Series:**
+  - `{ dataKey: 'stableford', label: 'Stableford Pts', yAxisId: 'left', color: 'success.main' }`
+  - `{ dataKey: 'netVsPar',   label: 'Net vs Par',     yAxisId: 'right', color: 'primary.main' }`
+  - `{ dataKey: 'grossVsPar', label: 'Gross vs Par',   yAxisId: 'right', color: 'warning.main' }`
+- **X axis:** time scale, `valueFormatter: (d) => dayjs(d).format('DD/MM/YY')`. Matches the HCP history page formatter.
+- **Y axes:**
+  - `left`: `label: 'Stableford Pts'`, no fixed range — automatic, lets outlier rounds above 40 not get clipped (theoretical 18-hole ceiling is 90 for all-albatrosses, realistic ceiling ~54 for all-birdies).
+  - `right`: `label: 'vs Par'`, no fixed range, automatic.
+- **Height:** `300` (same as HCP history).
+- **Missing values:** `null` entries from the utils flow into MUI charts as gaps; no chart-level config needed.
+
+### Testing approach
+
+- **Unit tests** for the pure utils (see `stableford.utils.test.ts` above).
+- **No React component tests** for the new page — consistent with how `/handicap-history` is shipped (the repo's testing approach for UI is manual UAT via the dev server).
+- **No Firestore tests** — no writes, no reads beyond the existing `roundsList` store slice.
+- **Manual UAT checklist** (to be run by the user before marking the PR ready):
+  1. With zero rounds: page shows empty-state card.
+  2. With 5 rounds: table has 5 rows, chart has 3 series, both axes labeled.
+  3. With a round that has `totals.points` populated and `roundPar` / `roundPlayingHCP` set: table cells show numbers (not `—`), chart line is drawn.
+  4. With a round that has `totals.points` missing (legacy import): table cell shows `—`, chart skips the point for that date.
+  5. Drawer (after the change in #1): "Dashboard" entry appears with `HomeWorkIcon` and links to `/`.
+  6. Dashboard `Rounds` table: header now reads "Stableford Pts".
+  7. `/handicap-history` and `/stableford-history` are independently reachable from the drawer, breadcrumbs work, no console errors.
+
+### Branch and PR
+
+- Branch: `feat/stableford-history` off `origin/development` (created at the start of this work).
+- Commits (two):
+  1. `feat(stableford): add /stableford-history page with 3-line dual-axis chart`
+  2. `chore(ui): expose Dashboard in the drawer and rename Points column to Stableford Pts`
+- Push the branch and open a **draft** PR to `development` (same pattern as PR #125 for the HCP history work).
+
+---
+
+## Out of scope
+
+- Stableford per-hole breakdown (e.g., which holes gained/lost points) — not asked for.
+- Stableford backfill — not needed; data is already on every round.
+- Persisting a `stablefordIndex` or `netVsParSnapshot` on the round doc — derivable on the fly, not worth a new field.
+- Renaming the `netScore` / `grossScore` variables in `RoundsTable.component.tsx:43-44` — pre-existing, separate concern.
+- Visual redesign of the `HandicapHistory` page — no changes here.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import SharedLayout from './pages/SharedLayout.page';
 import SimulatorPage from './pages/Simulator.page';
 import HandicapHistoryPage from './pages/HandicapHistory.page';
 import ImportRoundsPage from './pages/ImportRounds.page';
+import StablefordHistoryPage from './pages/StablefordHistory.page';
 import Statistics from './pages/Statistics.page';
 import ThemeSetup from './styles/ThemeSetup.styles';
 
@@ -51,6 +52,7 @@ const App: React.FC = () => {
               <Route path='/statistics' element={<Statistics />} />
               <Route path='/simulator' element={<SimulatorPage />} />
               <Route path='/handicap-history' element={<HandicapHistoryPage />} />
+              <Route path='/stableford-history' element={<StablefordHistoryPage />} />
               <Route path='/import-rounds' element={<ImportRoundsPage />} />
               <Route path='/settings' element={<SettingsPage />} />
               <Route path="/admin/courses" element={<AdminRoute><AdminCoursesPage /></AdminRoute>} />

--- a/src/components/Rounds/RoundsTable.component.tsx
+++ b/src/components/Rounds/RoundsTable.component.tsx
@@ -29,7 +29,7 @@ const RoundsTable = () => {
               <TableCell align='left' space='10px'>Course</TableCell>
               <TableCell align='center' space='10px'>Par</TableCell>
               <TableCell align='center' space='10px'>HCP</TableCell>
-              <TableCell align='center' space='10px'>Points</TableCell>
+              <TableCell align='center' space='10px'>Stableford Pts</TableCell>
               <TableCell align='center' space='10px'>Score</TableCell>
               <TableCell align='center' space='10px'>vs. Par</TableCell>
             </TableRow>

--- a/src/components/StablefordHistory/StablefordHistory.component.tsx
+++ b/src/components/StablefordHistory/StablefordHistory.component.tsx
@@ -1,0 +1,193 @@
+import { useMemo } from 'react';
+import {
+	Box,
+	Card,
+	CardContent,
+	Typography,
+	Table,
+	TableBody,
+	TableCell,
+	TableContainer,
+	TableHead,
+	TableRow,
+	Alert,
+} from '@mui/material';
+import { LineChart } from '@mui/x-charts/LineChart';
+import ScoreboardIcon from '@mui/icons-material/Scoreboard';
+import { useAppStore } from '@/store/zustand';
+import {
+	getStablefordPoints,
+	getGrossScore,
+	getNetVsPar,
+	getGrossVsPar,
+} from '@/utils/stableford/stableford.utils';
+import dayjs from 'dayjs';
+
+const formatSigned = (n: number | null): string => {
+	if (n == null) return '\u2014';
+	const fixed = n.toFixed(1);
+	return n > 0 ? `+${fixed}` : fixed;
+};
+
+const StablefordHistory = () => {
+	const roundsList = useAppStore((state) => state.roundsList);
+	const isLoadingRounds = useAppStore((state) => state.isLoadingRounds);
+
+	// Rounds with stableford, sorted by date descending (most recent first)
+	const roundsWithStableford = useMemo(() => {
+		return roundsList
+			.filter((r) => getStablefordPoints(r) != null && r.roundDate)
+			.sort((a, b) => b.roundDate - a.roundDate);
+	}, [roundsList]);
+
+	// Last 20 for the table (most recent first)
+	const last20 = useMemo(() => {
+		return roundsWithStableford.slice(0, 20);
+	}, [roundsWithStableford]);
+
+	// Chart data (chronological, oldest -> newest on the x axis)
+	const chartData = useMemo(() => {
+		return [...last20]
+			.sort((a, b) => a.roundDate - b.roundDate)
+			.map((round) => ({
+				date: round.roundDate,
+				stableford: getStablefordPoints(round),
+				netVsPar: getNetVsPar(round),
+				grossVsPar: getGrossVsPar(round),
+			}));
+	}, [last20]);
+
+	if (isLoadingRounds) {
+		return (
+			<Box sx={{ p: 2 }}>
+				<Typography>Loading...</Typography>
+			</Box>
+		);
+	}
+
+	return (
+		<Box>
+			<Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 3 }}>
+				<ScoreboardIcon sx={{ fontSize: 32 }} />
+				<Typography variant="headline2">Stableford History</Typography>
+			</Box>
+
+			{roundsWithStableford.length === 0 && (
+				<Alert severity="info">
+					No rounds with stableford points yet. Play some rounds first!
+				</Alert>
+			)}
+
+			{roundsWithStableford.length > 0 && (
+				<>
+					<Card sx={{ mb: 3 }}>
+						<CardContent>
+							<Typography variant="title6" gutterBottom>
+								Last 20 Rounds
+							</Typography>
+							<TableContainer>
+								<Table size="small">
+									<TableHead>
+										<TableRow>
+											<TableCell>Date</TableCell>
+											<TableCell>Course</TableCell>
+											<TableCell align="right">Stableford</TableCell>
+											<TableCell align="right">Score</TableCell>
+											<TableCell align="right">Net vs Par</TableCell>
+											<TableCell align="right">Gross vs Par</TableCell>
+										</TableRow>
+									</TableHead>
+									<TableBody>
+										{last20.map((round) => {
+											const stableford = getStablefordPoints(round);
+											const score = getGrossScore(round);
+											const netVsPar = getNetVsPar(round);
+											const grossVsPar = getGrossVsPar(round);
+											return (
+												<TableRow key={round.id}>
+													<TableCell>
+														{dayjs(round.roundDate).format('DD/MM/YYYY')}
+													</TableCell>
+													<TableCell>
+														{round.roundCourse ?? '\u2014'}
+													</TableCell>
+													<TableCell align="right">
+														{stableford ?? '\u2014'}
+													</TableCell>
+													<TableCell align="right">
+														{score ?? '\u2014'}
+													</TableCell>
+													<TableCell align="right">
+														{formatSigned(netVsPar)}
+													</TableCell>
+													<TableCell align="right">
+														{formatSigned(grossVsPar)}
+													</TableCell>
+												</TableRow>
+											);
+										})}
+									</TableBody>
+								</Table>
+							</TableContainer>
+						</CardContent>
+					</Card>
+
+					<Card>
+						<CardContent>
+							<Typography variant="title6" gutterBottom>
+								Trend
+							</Typography>
+							<Box sx={{ width: '100%', height: 300 }}>
+								<LineChart
+									dataset={chartData}
+									xAxis={[
+										{
+											dataKey: 'date',
+											scaleType: 'time',
+											valueFormatter: (date: Date) =>
+												dayjs(date).format('DD/MM/YY'),
+										},
+									]}
+									yAxis={[
+										{ id: 'left', label: 'Stableford Pts' },
+										{ id: 'right', label: 'vs Par' },
+									]}
+									series={[
+										{
+											dataKey: 'stableford',
+											label: 'Stableford Pts',
+											yAxisId: 'left',
+											color: '#2e7d32',
+											showMark: true,
+											connectNulls: false,
+										},
+										{
+											dataKey: 'netVsPar',
+											label: 'Net vs Par',
+											yAxisId: 'right',
+											color: '#1976d2',
+											showMark: true,
+											connectNulls: false,
+										},
+										{
+											dataKey: 'grossVsPar',
+											label: 'Gross vs Par',
+											yAxisId: 'right',
+											color: '#ed6c02',
+											showMark: true,
+											connectNulls: false,
+										},
+									]}
+									height={300}
+									margin={{ top: 10, right: 20, bottom: 30, left: 50 }}
+								/>
+							</Box>
+						</CardContent>
+					</Card>
+				</>
+			)}
+		</Box>
+	);
+};
+
+export default StablefordHistory;

--- a/src/components/layout/MainLayout2.component.tsx
+++ b/src/components/layout/MainLayout2.component.tsx
@@ -99,6 +99,8 @@ export default function DrawerAppBar(_props: IMainLayoutProps) {
       breadcrumbs.push({ label: 'HCP Simulator', path: '/simulator' });
     } else if (path === '/handicap-history') {
       breadcrumbs.push({ label: 'Handicap History', path: '/handicap-history' });
+    } else if (path === '/stableford-history') {
+      breadcrumbs.push({ label: 'Stableford History', path: '/stableford-history' });
     } else if (path === '/import-rounds') {
       breadcrumbs.push({ label: 'Import Rounds', path: '/import-rounds' });
     } else if (path.startsWith('/round/')) {

--- a/src/pages/StablefordHistory.page.tsx
+++ b/src/pages/StablefordHistory.page.tsx
@@ -1,0 +1,7 @@
+import StablefordHistory from '@/components/StablefordHistory/StablefordHistory.component';
+
+const StablefordHistoryPage = () => {
+	return <StablefordHistory />;
+};
+
+export default StablefordHistoryPage;

--- a/src/utils/links/links.utils.tsx
+++ b/src/utils/links/links.utils.tsx
@@ -6,6 +6,7 @@ import PeopleIcon from '@mui/icons-material/People';
 import AutoGraphIcon from '@mui/icons-material/AutoGraph';
 import TimelineIcon from '@mui/icons-material/Timeline';
 import FileUploadIcon from '@mui/icons-material/FileUpload';
+import ScoreboardIcon from '@mui/icons-material/Scoreboard';
 
 const navbar_items: TLinkSidebar[] = [
   {
@@ -55,6 +56,13 @@ const navbar_items: TLinkSidebar[] = [
     name: "Import Rounds",
     link: "/import-rounds",
     icon: FileUploadIcon,
+    show: true,
+  },
+  {
+    id: 8,
+    name: "Stableford History",
+    link: "/stableford-history",
+    icon: ScoreboardIcon,
     show: true,
   },
 ];

--- a/src/utils/links/links.utils.tsx
+++ b/src/utils/links/links.utils.tsx
@@ -14,7 +14,7 @@ const navbar_items: TLinkSidebar[] = [
     name: "Dashboard",
     link: "/",
     icon: HomeWorkIcon,
-    show: false,
+    show: true,
   },
   {
     id: 2,

--- a/src/utils/stableford/stableford.utils.test.ts
+++ b/src/utils/stableford/stableford.utils.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import {
+	getStablefordPoints,
+	getGrossScore,
+	getNetScore,
+	getGrossVsPar,
+	getNetVsPar,
+} from './stableford.utils';
+import type { IBasicRoundData } from '@/types/roundData.types';
+
+describe('stableford.utils', () => {
+	describe('getStablefordPoints', () => {
+		it('returns totals.points.totals when present', () => {
+			const round = { totals: { points: { totals: 36 } } } as unknown as IBasicRoundData;
+			expect(getStablefordPoints(round)).toBe(36);
+		});
+
+		it('returns null when totals.points is missing', () => {
+			const round = { totals: {} } as unknown as IBasicRoundData;
+			expect(getStablefordPoints(round)).toBe(null);
+		});
+
+		it('returns null when totals itself is missing', () => {
+			const round = {} as unknown as IBasicRoundData;
+			expect(getStablefordPoints(round)).toBe(null);
+		});
+	});
+
+	describe('getGrossScore', () => {
+		it('returns totals.score.totals when present', () => {
+			const round = { totals: { score: { totals: 80 } } } as unknown as IBasicRoundData;
+			expect(getGrossScore(round)).toBe(80);
+		});
+
+		it('returns null when totals.score is missing', () => {
+			const round = { totals: {} } as unknown as IBasicRoundData;
+			expect(getGrossScore(round)).toBe(null);
+		});
+
+		it('returns null when totals itself is missing', () => {
+			const round = {} as unknown as IBasicRoundData;
+			expect(getGrossScore(round)).toBe(null);
+		});
+	});
+
+	describe('getNetScore', () => {
+		it('returns gross - playingHCP when both present (gross 80, hcp 10 -> 70)', () => {
+			const round = {
+				totals: { score: { totals: 80 } },
+				roundPlayingHCP: '10',
+			} as unknown as IBasicRoundData;
+			expect(getNetScore(round)).toBe(70);
+		});
+
+		it('returns null when roundPlayingHCP is missing', () => {
+			const round = { totals: { score: { totals: 80 } } } as unknown as IBasicRoundData;
+			expect(getNetScore(round)).toBe(null);
+		});
+
+		it('returns null when gross score is missing', () => {
+			const round = { roundPlayingHCP: '10' } as unknown as IBasicRoundData;
+			expect(getNetScore(round)).toBe(null);
+		});
+	});
+
+	describe('getGrossVsPar', () => {
+		it('returns gross - par when both present (gross 80, par 72 -> +8)', () => {
+			const round = {
+				totals: { score: { totals: 80 } },
+				roundPar: '72',
+			} as unknown as IBasicRoundData;
+			expect(getGrossVsPar(round)).toBe(8);
+		});
+
+		it('handles negative values (under par: gross 70, par 72 -> -2)', () => {
+			const round = {
+				totals: { score: { totals: 70 } },
+				roundPar: '72',
+			} as unknown as IBasicRoundData;
+			expect(getGrossVsPar(round)).toBe(-2);
+		});
+
+		it('returns null when roundPar is missing', () => {
+			const round = { totals: { score: { totals: 80 } } } as unknown as IBasicRoundData;
+			expect(getGrossVsPar(round)).toBe(null);
+		});
+
+		it('returns null when gross score is missing', () => {
+			const round = { roundPar: '72' } as unknown as IBasicRoundData;
+			expect(getGrossVsPar(round)).toBe(null);
+		});
+	});
+
+	describe('getNetVsPar', () => {
+		it('returns net - par when all three present (gross 80, hcp 10, par 72 -> -2)', () => {
+			const round = {
+				totals: { score: { totals: 80 } },
+				roundPar: '72',
+				roundPlayingHCP: '10',
+			} as unknown as IBasicRoundData;
+			expect(getNetVsPar(round)).toBe(-2);
+		});
+
+		it('returns null when roundPar is missing', () => {
+			const round = {
+				totals: { score: { totals: 80 } },
+				roundPlayingHCP: '10',
+			} as unknown as IBasicRoundData;
+			expect(getNetVsPar(round)).toBe(null);
+		});
+
+		it('returns null when roundPlayingHCP is missing', () => {
+			const round = {
+				totals: { score: { totals: 80 } },
+				roundPar: '72',
+			} as unknown as IBasicRoundData;
+			expect(getNetVsPar(round)).toBe(null);
+		});
+
+		it('returns null when gross score is missing', () => {
+			const round = {
+				roundPar: '72',
+				roundPlayingHCP: '10',
+			} as unknown as IBasicRoundData;
+			expect(getNetVsPar(round)).toBe(null);
+		});
+	});
+});

--- a/src/utils/stableford/stableford.utils.tsx
+++ b/src/utils/stableford/stableford.utils.tsx
@@ -1,0 +1,30 @@
+import type { IBasicRoundData } from '@/types/roundData.types';
+
+export const getStablefordPoints = (round: IBasicRoundData): number | null => {
+	return round.totals?.points?.totals ?? null;
+};
+
+export const getGrossScore = (round: IBasicRoundData): number | null => {
+	return round.totals?.score?.totals ?? null;
+};
+
+export const getNetScore = (round: IBasicRoundData): number | null => {
+	const gross = getGrossScore(round);
+	if (gross == null) return null;
+	if (round.roundPlayingHCP == null) return null;
+	return gross - Number(round.roundPlayingHCP);
+};
+
+export const getGrossVsPar = (round: IBasicRoundData): number | null => {
+	const gross = getGrossScore(round);
+	if (gross == null) return null;
+	if (round.roundPar == null) return null;
+	return gross - Number(round.roundPar);
+};
+
+export const getNetVsPar = (round: IBasicRoundData): number | null => {
+	const gross = getGrossScore(round);
+	if (gross == null) return null;
+	if (round.roundPar == null || round.roundPlayingHCP == null) return null;
+	return gross - Number(round.roundPar) - Number(round.roundPlayingHCP);
+};


### PR DESCRIPTION
## What'\''s in this PR

- **New `/stableford-history` page** — 6-column last-20-rounds table (Date, Course, Stableford, Score, Net vs Par, Gross vs Par) and a 3-line `<LineChart>` (Stableford Pts on the left axis, Net & Gross vs Par on the right) over the same 20 rounds.
- **Pure utils** in `src/utils/stableford/stableford.utils.tsx` covered by 17 vitest cases. No Firestore writes, no schema changes, no new types on `IBasicRoundData` — every value plotted is derived from fields already on each round doc.
- **Sidebar entry** for Stableford History with `ScoreboardIcon`.
- **Drawer fix** — `Dashboard` entry was hidden via `show: false`; now visible. `HomeWorkIcon` and the `/` route were already wired.
- **Dashboard rename** — Rounds table `Points` column → `Stableford Pts` for clarity (data binding unchanged).

## How to verify (manual UAT)

1. `npm start`, log in, open the drawer → confirm the "Dashboard" entry is visible and that clicking it lands on `/dashboard` (or `/`).
2. From the drawer, click "Stableford History" → page loads with no console errors.
3. With 0 rounds: empty-state Alert.
4. With ≥ 1 round that has `totals.points.totals` populated: 6-column table renders, chart shows 3 series with the right y-axis labels.
5. With a round that has `totals.points` missing: that row'\''s "Stableford" cell shows `—`; the chart skips that date for that series.
6. `/handicap-history` still loads correctly and is unchanged.
7. Breadcrumb on `/stableford-history` reads `Home / Stableford History`.
8. On the dashboard'\''s Rounds table, the column header now reads "Stableford Pts".

## Tests

- New: `npx vitest run src/utils/stableford/stableford.utils.test.ts` — 17/17 pass.
- Pre-existing vitest failures on `development` (`App.test.tsx`, `calculations.test.ts`) are not caused by this branch.

## Out of scope

- Stableford per-hole breakdown, `stablefordIndex` persistence, refactoring `RoundsTable.component.tsx`'\''s `netScore`/`grossScore` variable names.

## Commits in this PR

- `docs(spec): add stableford history + drawer dashboard icon design`
- `docs(plan): add stableford history implementation plan`
- `feat(stableford): add pure utils for stableford/vs-par derivations`
- `feat(stableford): add /stableford-history page with 3-line dual-axis chart`
- `chore(ui): expose Dashboard in the drawer and rename Points column to Stableford Pts`