### PR TITLE
refactor(history): consolidate handicap + stableford into /history tabs

### DIFF
--- a/docs/superpowers/plans/2026-06-04-history-tabs.md
+++ b/docs/superpowers/plans/2026-06-04-history-tabs.md
@@ -1,0 +1,387 @@
+# History Tabs Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Consolidate the two history routes (`/handicap-history` and `/stableford-history`) into a single tabbed page at `/history` that reads `?tab=stableford` from the URL.
+
+**Architecture:** Thin new `History` component renders `MuiTabs` and conditionally mounts one of the two existing components (`HandicapHistory` or `StablefordHistory`). The two existing components stay in place; they lose their individual page headers (3-7 lines removed from each). Old routes are deleted, no redirect.
+
+**Tech Stack:** React 19, MUI v7, `@mui/x-charts` 8.x, react-router-dom v7, Zustand (existing), TypeScript 6.
+
+**Working branch:** `feat/history-tabs` (already created off `origin/development`; the design spec is committed in `d4ae2b6`).
+
+**Design spec:** `docs/superpowers/specs/2026-06-04-history-tabs-design.md` (must-read before implementing).
+
+---
+
+## File Map
+
+**New files**
+- `src/components/History/History.component.tsx` — tabbed shell (page header + Tabs + conditional render of one of the two existing components)
+- `src/pages/History.page.tsx` — thin wrapper
+
+**Modified files**
+- `src/components/HandicapHistory/HandicapHistory.component.tsx` — remove header block (lines 101-105) and `TimelineIcon` import (line 17)
+- `src/components/StablefordHistory/StablefordHistory.component.tsx` — remove header block (lines 70-74) and `ScoreboardIcon` import (line 16)
+- `src/App.tsx` — swap routes
+- `src/utils/links/links.utils.tsx` — remove `ScoreboardIcon` import, drop the Stableford History entry, rename "Handicap History" → "History" and `link: '/handicap-history'` → `link: '/history'`
+- `src/components/layout/MainLayout2.component.tsx` — replace the two `/handicap-history` and `/stableford-history` breadcrumb branches with a single `/history` branch
+
+**Deleted files**
+- `src/pages/HandicapHistory.page.tsx` — orphaned after the route change
+- `src/pages/StablefordHistory.page.tsx` — orphaned after the route change
+
+**Untouched (verify with grep before deleting page files)**
+- `src/utils/stableford/stableford.utils.tsx` and its test
+- `src/utils/firestore/backfillHcpHistory.utils.ts` and its test
+- `src/components/Rounds/RoundsTable.component.tsx`
+- Anything else in `src/`
+
+---
+
+## Task 1: Refactor — new History page + remove old routes / pages / component headers (one commit)
+
+This is the big commit. It groups the new tabbed page, the route swap, the component header removals, and the page file deletions into one atomic change so the codebase is never in a half-migrated state.
+
+**Files:**
+- Create: `src/components/History/History.component.tsx`
+- Create: `src/pages/History.page.tsx`
+- Modify: `src/App.tsx`
+- Modify: `src/components/HandicapHistory/HandicapHistory.component.tsx`
+- Modify: `src/components/StablefordHistory/StablefordHistory.component.tsx`
+- Delete: `src/pages/HandicapHistory.page.tsx`
+- Delete: `src/pages/StablefordHistory.page.tsx`
+
+- [ ] **Step 1: Create the `History` tabbed component**
+
+Create `src/components/History/History.component.tsx` with the following content:
+
+```tsx
+import { useSearchParams, useNavigate } from 'react-router-dom';
+import { Box, Tabs, Tab, Typography } from '@mui/material';
+import TimelineIcon from '@mui/icons-material/Timeline';
+import HandicapHistory from '@/components/HandicapHistory/HandicapHistory.component';
+import StablefordHistory from '@/components/StablefordHistory/StablefordHistory.component';
+
+type HistoryTab = 'handicap' | 'stableford';
+
+const History = () => {
+	const [searchParams] = useSearchParams();
+	const navigate = useNavigate();
+	const rawTab = searchParams.get('tab');
+	const tab: HistoryTab = rawTab === 'stableford' ? 'stableford' : 'handicap';
+
+	const handleChange = (_: unknown, value: HistoryTab) => {
+		navigate(value === 'stableford' ? '/history?tab=stableford' : '/history');
+	};
+
+	return (
+		<Box>
+			<Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+				<TimelineIcon sx={{ fontSize: 32 }} />
+				<Typography variant="headline2">History</Typography>
+			</Box>
+			<Tabs value={tab} onChange={handleChange} sx={{ mb: 2 }}>
+				<Tab value="handicap" label="Handicap" />
+				<Tab value="stableford" label="Stableford" />
+			</Tabs>
+			{tab === 'stableford' ? <StablefordHistory /> : <HandicapHistory />}
+		</Box>
+	);
+};
+
+export default History;
+```
+
+- [ ] **Step 2: Create the page wrapper**
+
+Create `src/pages/History.page.tsx` with the following content:
+
+```tsx
+import History from '@/components/History/History.component';
+
+const HistoryPage = () => {
+	return <History />;
+};
+
+export default HistoryPage;
+```
+
+- [ ] **Step 3: Update `src/App.tsx` — swap the imports and routes**
+
+Open `src/App.tsx`. The current imports around the two history pages are:
+
+```ts
+import HandicapHistoryPage from './pages/HandicapHistory.page';
+import ImportRoundsPage from './pages/ImportRounds.page';
+import StablefordHistoryPage from './pages/StablefordHistory.page';
+```
+
+Replace those three lines with:
+
+```ts
+import HistoryPage from './pages/History.page';
+import ImportRoundsPage from './pages/ImportRounds.page';
+```
+
+Then update the two route lines inside the protected `<Route path="/">` block. The current lines (single-quoted) are:
+
+```tsx
+<Route path='/handicap-history' element={<HandicapHistoryPage />} />
+<Route path='/stableford-history' element={<StablefordHistoryPage />} />
+```
+
+Replace those two lines with one line:
+
+```tsx
+<Route path='/history' element={<HistoryPage />} />
+```
+
+- [ ] **Step 4: Remove the page header from `HandicapHistory.component.tsx`**
+
+Open `src/components/HandicapHistory/HandicapHistory.component.tsx`. Delete the `import TimelineIcon from '@mui/icons-material/Timeline';` line (currently line 17). Then in the returned JSX (currently around line 101), delete this 5-line block:
+
+```tsx
+			<Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 3 }}>
+				<TimelineIcon sx={{ fontSize: 32 }} />
+				<Typography variant="headline2">Handicap History</Typography>
+			</Box>
+```
+
+The file should still type-check and the rest of the component (filter, sort, last 20, highlighted SDs, chart) is untouched.
+
+- [ ] **Step 5: Remove the page header from `StablefordHistory.component.tsx`**
+
+Open `src/components/StablefordHistory/StablefordHistory.component.tsx`. Delete the `import ScoreboardIcon from '@mui/icons-material/Scoreboard';` line (currently line 16). Then in the returned JSX (currently around line 70), delete this 5-line block:
+
+```tsx
+			<Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 3 }}>
+				<ScoreboardIcon sx={{ fontSize: 32 }} />
+				<Typography variant="headline2">Stableford History</Typography>
+			</Box>
+```
+
+- [ ] **Step 6: Verify no remaining references to the old page imports or paths**
+
+Run: `grep -rn "HandicapHistoryPage\|StablefordHistoryPage\|/handicap-history\|/stableford-history" src/`
+Expected: no matches. (The plan description above is in `docs/`, which is not in `src/`, so the grep should be clean.)
+
+If matches appear, they must be removed before continuing. Common places to check if something slipped through: a stray import in a barrel file, a leftover route in `App.tsx`, a leftover breadcrumb branch.
+
+- [ ] **Step 7: Delete the two orphaned page files**
+
+```bash
+git rm src/pages/HandicapHistory.page.tsx src/pages/StablefordHistory.page.tsx
+```
+
+- [ ] **Step 8: Type-check the full project**
+
+Run: `npm run type-check`
+Expected: exit 0, no TypeScript errors.
+
+- [ ] **Step 9: Run the existing vitest suites to confirm no regressions**
+
+Run: `npx vitest run src/utils/stableford/stableford.utils.test.ts src/utils/firestore/backfillHcpHistory.utils.test.ts`
+Expected: both files pass (17/17 + 6/6). Pre-existing failures in `App.test.tsx` and `calculations.test.ts` are unrelated and were present on `development` — see PR #125/#128.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/components/History/History.component.tsx \
+        src/pages/History.page.tsx \
+        src/App.tsx \
+        src/components/HandicapHistory/HandicapHistory.component.tsx \
+        src/components/StablefordHistory/StablefordHistory.component.tsx
+git rm src/pages/HandicapHistory.page.tsx src/pages/StablefordHistory.page.tsx
+git commit -m "refactor(history): consolidate handicap + stableford history into /history tabs
+
+- New /history route with MuiTabs shell (Handicap / Stableford)
+- ?tab=stableford query param selects the Stableford tab; default is
+  Handicap; invalid values fall back to Handicap
+- New History.component.tsx is a thin shell that conditionally mounts
+  one of the two existing components (no rewrite)
+- HandicapHistory and StablefordHistory components drop their individual
+  page headers and unused icon imports
+- Old /handicap-history and /stableford-history routes deleted (no
+  redirect) along with their orphaned page wrappers
+- No data flow, utils, types, or Firestore changes"
+```
+
+---
+
+## Task 2: Drawer + breadcrumb rename (chore commit)
+
+**Files:**
+- Modify: `src/utils/links/links.utils.tsx`
+- Modify: `src/components/layout/MainLayout2.component.tsx`
+
+- [ ] **Step 1: Update the sidebar entry in `src/utils/links/links.utils.tsx`**
+
+a. Remove the `import ScoreboardIcon from '@mui/icons-material/Scoreboard';` line at the top of the file (it was added in PR #128 and is no longer referenced).
+
+b. Delete the Stableford History entry at the bottom of the `navbar_items` array:
+
+```ts
+  {
+    id: 8,
+    name: 'Stableford History',
+    link: '/stableford-history',
+    icon: ScoreboardIcon,
+    show: true,
+  },
+```
+
+c. Rename the existing Handicap History entry from:
+
+```ts
+  {
+    id: 6,
+    name: 'Handicap History',
+    link: '/handicap-history',
+    icon: TimelineIcon,
+    show: true,
+  },
+```
+
+to:
+
+```ts
+  {
+    id: 6,
+    name: 'History',
+    link: '/history',
+    icon: TimelineIcon,
+    show: true,
+  },
+```
+
+(The `id: 6` stays — internal key, not display order.)
+
+- [ ] **Step 2: Update the breadcrumb branch in `src/components/layout/MainLayout2.component.tsx`**
+
+In the `getBreadcrumbs()` function, replace these two `else if` branches:
+
+```ts
+    } else if (path === '/handicap-history') {
+      breadcrumbs.push({ label: 'Handicap History', path: '/handicap-history' });
+    } else if (path === '/stableford-history') {
+      breadcrumbs.push({ label: 'Stableford History', path: '/stableford-history' });
+```
+
+with this single branch:
+
+```ts
+    } else if (path === '/history') {
+      breadcrumbs.push({ label: 'History', path: '/history' });
+```
+
+The rest of the switch is unchanged. Breadcrumb on `/history` now reads `Home / History` regardless of which tab is active (the tab lives in the URL `?tab=`, not the breadcrumb).
+
+- [ ] **Step 3: Type-check the project**
+
+Run: `npm run type-check`
+Expected: exit 0, no TypeScript errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/utils/links/links.utils.tsx src/components/layout/MainLayout2.component.tsx
+git commit -m "chore(ui): rename Handicap History drawer entry to History
+
+- links.utils.tsx: drop ScoreboardIcon import and the Stableford
+  History entry; rename Handicap History -> History and its link
+  /handicap-history -> /history; TimelineIcon kept
+- MainLayout2.component.tsx: replace the two /handicap-history and
+  /stableford-history breadcrumb branches with a single /history branch"
+```
+
+---
+
+## Task 3: Final verification + push + draft PR
+
+- [ ] **Step 1: Re-run the vitest suites**
+
+Run: `npx vitest run src/utils/stableford/stableford.utils.test.ts src/utils/firestore/backfillHcpHistory.utils.test.ts`
+Expected: 17/17 + 6/6 pass.
+
+- [ ] **Step 2: Type-check the full project**
+
+Run: `npm run type-check`
+Expected: exit 0.
+
+- [ ] **Step 3: Run the production build**
+
+Run: `npm run build`
+Expected: build succeeds (the pre-existing chunk-size warning is OK).
+
+- [ ] **Step 4: Push the branch**
+
+```bash
+git push origin feat/history-tabs
+```
+
+- [ ] **Step 5: Open a draft PR to `development`**
+
+Run:
+
+```bash
+gh pr create --draft \
+  --base development \
+  --head feat/history-tabs \
+  --title "refactor(history): consolidate handicap + stableford into /history tabs" \
+  --body "$(cat <<'EOF'
+## What'\''s in this PR
+
+- **New `/history` route** with MUI Tabs (Handicap / Stableford). `?tab=stableford` selects the Stableford tab; default is Handicap; invalid values fall back to Handicap. State survives refresh.
+- **Thin `History` shell** reads the query param and conditionally mounts one of the two existing components. No rewrite of `HandicapHistory` or `StablefordHistory` — both keep their data logic, charts, tables.
+- The two existing components lose their individual page headers and unused icon imports (3-7 line edits).
+- **Old `/handicap-history` and `/stableford-history` routes deleted** (no redirect, per spec). Their orphaned `*.page.tsx` files are removed.
+- **Drawer:** Stableford History entry removed; "Handicap History" renamed to "History" with `link: /history`. `TimelineIcon` kept.
+- **Breadcrumb:** `Home / History` (tab is not in the breadcrumb — it lives in the URL `?tab=`).
+
+## How to verify (manual UAT)
+
+1. `npm start`, log in, open the drawer → confirm one "History" entry pointing to `/history`.
+2. Open `/history` → Handicap tab content renders, no console errors, breadcrumb reads `Home / History`.
+3. Click the "Stableford" tab → URL becomes `/history?tab=stableford`, Stableford table + 3-line chart render.
+4. Refresh at `/history?tab=stableford` → Stableford tab stays selected.
+5. Open `/history?tab=garbage` → falls back to Handicap.
+6. Old `/handicap-history` and `/stableford-history` return the catch-all Error page.
+7. `/handicap-history` link no longer appears in the drawer (only History).
+
+## Tests
+
+- `npx vitest run src/utils/stableford/stableford.utils.test.ts src/utils/firestore/backfillHcpHistory.utils.test.ts` — 17/17 + 6/6 pass.
+- Pre-existing vitest failures on `development` (`App.test.tsx`, `calculations.test.ts`) are unrelated and were present before this branch.
+
+## Out of scope
+
+- The internal structure of the two existing history components (charts, tables, highlights, calculations) — unchanged.
+- Per-user tab preference persistence (localStorage) — explicitly rejected in brainstorming.
+- Old-route redirect logic — explicitly rejected in brainstorming.
+
+## Commits in this PR
+
+- `docs(spec): add /history tabbed consolidation design`
+- `refactor(history): consolidate handicap + stableford history into /history tabs`
+- `chore(ui): rename Handicap History drawer entry to History`
+EOF
+)"
+```
+
+- [ ] **Step 6: Post the PR URL in the chat so the user can review**
+
+---
+
+## Self-Review (executed at plan-write time)
+
+- **Spec coverage:**
+  - Section 1 (URL & tab handling) → Task 1 Step 1 (query param parsing + invalid fallback).
+  - Section 2 (new files) → Task 1 Steps 1-2 (`History.component.tsx`, `History.page.tsx`).
+  - Section 3 (modified files) → Task 1 Steps 3-5 (App.tsx, both component headers) + Task 2 Steps 1-2 (sidebar, breadcrumb).
+  - Section 4 (deleted files) → Task 1 Steps 6-7 (grep + git rm).
+  - Section 5 (data flow) → no task needed; "unchanged" is informational.
+  - Section 6 (testing) → Task 3 Steps 1-3 (re-run vitest, type-check, build).
+  - Section 7 (branch & PR) → Task 3 Steps 4-6 (push + gh pr create + post URL).
+- **Placeholder scan:** No TBDs, no "implement later", no "add appropriate validation". Every step has actual code or an exact command.
+- **Type consistency:** The `HistoryTab` type is defined once in `History.component.tsx` (Task 1 Step 1) and only used there. The `History` component imports `HandicapHistory` and `StablefordHistory` by their default-exported names (consistent with how the existing `App.tsx` and `MainLayout2.component.tsx` already import them). The breadcrumb branch in Task 2 Step 2 uses the literal `'/history'` path, matching the route in `App.tsx` (Task 1 Step 3) and the `link:` in `links.utils.tsx` (Task 2 Step 1).

--- a/docs/superpowers/specs/2026-06-04-history-tabs-design.md
+++ b/docs/superpowers/specs/2026-06-04-history-tabs-design.md
@@ -1,0 +1,137 @@
+# Consolidate Handicap + Stableford History into `/history` (tabbed)
+
+Date: 2026-06-04
+
+## Overview
+
+After the HCP history persistence + backfill work (PR #125) and the new stableford history page (PR #128) both merged to `development`, the user has two separate history routes (`/handicap-history`, `/stableford-history`) that show closely related views of the same dataset. This refactor consolidates them into a single tabbed page at `/history`, with `?tab=stableford` as the only query param needed to switch views.
+
+The two existing components (`HandicapHistory.component.tsx` and `StablefordHistory.component.tsx`) stay in their current files and folders. A thin new `History` page reads the query param, renders `MuiTabs`, and conditionally mounts one of the two existing components. The two components lose their individual header lines (3-7 lines removed from each).
+
+No data flow changes, no utils changes, no Firestore changes, no new dependencies. Pure UI refactor.
+
+---
+
+## 1. URL & tab handling
+
+- Route: `/history` (single, replaces both old routes)
+- Query param: `?tab=stableford` selects the Stableford tab. Any other value (including missing or `?tab=garbage`) falls back to the Handicap tab. `?tab=handicap` is also accepted for symmetry.
+- Old routes `/handicap-history` and `/stableford-history` are **deleted, no redirect** (per the brainstorming Q1 decision). They fall through to the catch-all `<Route path="*">` which renders the `Error` page.
+
+## 2. New files
+
+### `src/components/History/History.component.tsx`
+
+- Default export `History` (functional component)
+- Uses `useSearchParams` from `react-router-dom` to read `tab`
+- Uses `useNavigate` to push the new URL when a tab is clicked
+- Renders a `<Box>` containing:
+  - Page header: `<TimelineIcon />` + `<Typography variant="headline2">History</Typography>`
+  - `<Tabs value={tab} onChange={...}>` with two `<Tab value="handicap" label="Handicap" />` and `<Tab value="stableford" label="Stableford" />` (MUI Tabs)
+  - Conditionally: `tab === 'stableford' ? <StablefordHistory /> : <HandicapHistory />`
+- The two child components manage their own loading / empty states (already wired); the wrapper itself has no data.
+- No `useMemo`, no `useEffect`, no store access — it's a pure router shell.
+
+### `src/pages/History.page.tsx`
+
+Three-line wrapper, same shape as the deleted `HandicapHistory.page.tsx` and `StablefordHistory.page.tsx`:
+
+```tsx
+import History from '@/components/History/History.component';
+
+const HistoryPage = () => {
+	return <History />;
+};
+
+export default HistoryPage;
+```
+
+## 3. Modified files
+
+### `src/components/HandicapHistory/HandicapHistory.component.tsx`
+
+Remove the page-header block. Specifically, delete the `<Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 3 }}>` block at the top of the returned JSX (contains `<TimelineIcon />` and `<Typography variant="headline2">Handicap History</Typography>`). The component still does all its data work (filter, sort, last 20, highlighted SDs, chart) — only the header is gone.
+
+The `TimelineIcon` import is no longer needed in this file (only the page-level `History` component will use it). Remove the import.
+
+### `src/components/StablefordHistory/StablefordHistory.component.tsx`
+
+Same change: remove the page-header block (currently contains `<ScoreboardIcon />` and `<Typography variant="headline2">Stableford History</Typography>`). The `ScoreboardIcon` import is removed from this file.
+
+### `src/App.tsx`
+
+- Remove `import HandicapHistoryPage from './pages/HandicapHistory.page';`
+- Remove `import StablefordHistoryPage from './pages/StablefordHistory.page';`
+- Add `import HistoryPage from './pages/History.page';`
+- Remove the two route lines:
+  - `<Route path='/handicap-history' element={<HandicapHistoryPage />} />`
+  - `<Route path='/stableford-history' element={<StablefordHistoryPage />} />`
+- Add one route line:
+  - `<Route path='/history' element={<HistoryPage />} />`
+
+### `src/utils/links/links.utils.tsx`
+
+- Remove the `ScoreboardIcon` import (no longer used).
+- Remove the sidebar entry I added in PR #128: `{ id: 8, name: 'Stableford History', link: '/stableford-history', icon: ScoreboardIcon, show: true }`.
+- Rename the existing first entry: `{ id: 1, name: 'Handicap History', link: '/handicap-history', icon: TimelineIcon, show: true }` → `{ id: 1, name: 'History', link: '/history', icon: TimelineIcon, show: true }`. `TimelineIcon` is kept because "history" is generic and the icon still reads well.
+
+(The `id: 1` stays; IDs are stable internal keys, not display order.)
+
+### `src/components/layout/MainLayout2.component.tsx`
+
+In the `getBreadcrumbs()` function:
+
+- Remove the two `else if` branches:
+  - `} else if (path === '/handicap-history') { ... }`
+  - `} else if (path === '/stableford-history') { ... }`
+- Add one branch:
+  - `} else if (path === '/history') { breadcrumbs.push({ label: 'History', path: '/history' }); }`
+
+Breadcrumb always reads `Home / History` (tab is not in the breadcrumb — it lives in the URL `?tab=`).
+
+## 4. Deleted files
+
+- `src/pages/HandicapHistory.page.tsx` — orphaned, no importer
+- `src/pages/StablefordHistory.page.tsx` — orphaned, no importer
+
+(Verification step before deletion: `grep -r "HandicapHistoryPage\|StablefordHistoryPage" src/` returns no matches.)
+
+## 5. Data flow
+
+Unchanged. Both `HandicapHistory` and `StablefordHistory` continue to read `roundsList` from `useAppStore` and apply their existing `useMemo` filter/sort/slice logic. The new `History` wrapper has no data dependency.
+
+The store, the stableford utils, the HCP backfill, and the round types are all untouched by this refactor.
+
+## 6. Testing approach
+
+- **No new vitest cases** — the change is pure UI routing and a one-line title edit. The existing 17 stableford utils tests + 6 backfillHcpHistory tests are unaffected and must continue to pass.
+- **No new types** — the new `History` component has no props and no data signature.
+- **Manual UAT** (mirrored in the PR body):
+  1. Open `/history` → Handicap tab content (Last 20 Rounds table + HCP Progression chart) renders, no console errors.
+  2. Click "Stableford" tab → URL becomes `/history?tab=stableford`, Stableford table + 3-line chart render.
+  3. Refresh at `/history?tab=stableford` → Stableford tab stays selected.
+  4. Open `/history?tab=garbage` → falls back to Handicap.
+  5. Old `/handicap-history` and `/stableford-history` return the catch-all Error page (no redirect).
+  6. Drawer shows one "History" entry, links to `/history`.
+  7. Breadcrumb on `/history` reads `Home / History`.
+  8. `/handicap-history` link no longer appears in the drawer (only History).
+
+## 7. Branch & PR
+
+- Branch: `feat/history-tabs` (created at the start of this work, off `origin/development`).
+- Commits (two):
+  1. `refactor(history): consolidate handicap + stableford history into /history tabs`
+  2. `chore(ui): rename Handicap History drawer entry to History` (bundles sidebar + breadcrumb rename so it's a single small follow-up commit)
+- Push the branch and open a **draft** PR to `development`.
+
+## 8. Out of scope
+
+- The internal structure of `HandicapHistory.component.tsx` and `StablefordHistory.component.tsx` (charts, tables, highlights, calculations) — unchanged.
+- Stableford history table columns or chart config — unchanged.
+- HCP history persistence + backfill — unchanged.
+- Per-user tab preference persistence (localStorage) — explicitly rejected in brainstorming; default is always Handicap.
+- Old-route redirect logic (301/302 from `/handicap-history` or `/stableford-history` to `/history`) — explicitly rejected in brainstorming; both routes 404.
+
+## 9. Rollback
+
+If the refactor ships and needs to be undone, a single revert of the two commits on `development` restores the old behavior cleanly, since the two existing component files are still untouched (just stripped of their headers).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,9 +20,8 @@ import RoundsData from './pages/RoundsData.page';
 import SettingsPage from './pages/Settings.page';
 import SharedLayout from './pages/SharedLayout.page';
 import SimulatorPage from './pages/Simulator.page';
-import HandicapHistoryPage from './pages/HandicapHistory.page';
+import HistoryPage from './pages/History.page';
 import ImportRoundsPage from './pages/ImportRounds.page';
-import StablefordHistoryPage from './pages/StablefordHistory.page';
 import Statistics from './pages/Statistics.page';
 import ThemeSetup from './styles/ThemeSetup.styles';
 
@@ -51,8 +50,7 @@ const App: React.FC = () => {
               <Route path='/addNewRound' element={<AddNewRound />} />
               <Route path='/statistics' element={<Statistics />} />
               <Route path='/simulator' element={<SimulatorPage />} />
-              <Route path='/handicap-history' element={<HandicapHistoryPage />} />
-              <Route path='/stableford-history' element={<StablefordHistoryPage />} />
+              <Route path='/history' element={<HistoryPage />} />
               <Route path='/import-rounds' element={<ImportRoundsPage />} />
               <Route path='/settings' element={<SettingsPage />} />
               <Route path="/admin/courses" element={<AdminRoute><AdminCoursesPage /></AdminRoute>} />

--- a/src/components/HandicapHistory/HandicapHistory.component.tsx
+++ b/src/components/HandicapHistory/HandicapHistory.component.tsx
@@ -14,7 +14,6 @@ import {
 } from '@mui/material';
 import { LineChart } from '@mui/x-charts/LineChart';
 import { ChartsReferenceLine } from '@mui/x-charts/ChartsReferenceLine';
-import TimelineIcon from '@mui/icons-material/Timeline';
 import { useAppStore } from '@/store/zustand';
 import dayjs from 'dayjs';
 
@@ -98,11 +97,6 @@ const HandicapHistory = () => {
 
 	return (
 		<Box>
-			<Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 3 }}>
-				<TimelineIcon sx={{ fontSize: 32 }} />
-				<Typography variant="headline2">Handicap History</Typography>
-			</Box>
-
 			{roundsWithSD.length === 0 && !hasInitialHCP && (
 				<Alert severity="info">
 					No rounds with score differentials yet. Play some rounds first!

--- a/src/components/History/History.component.tsx
+++ b/src/components/History/History.component.tsx
@@ -1,0 +1,34 @@
+import { useSearchParams, useNavigate } from 'react-router-dom';
+import { Box, Tabs, Tab, Typography } from '@mui/material';
+import TimelineIcon from '@mui/icons-material/Timeline';
+import HandicapHistory from '@/components/HandicapHistory/HandicapHistory.component';
+import StablefordHistory from '@/components/StablefordHistory/StablefordHistory.component';
+
+type HistoryTab = 'handicap' | 'stableford';
+
+const History = () => {
+	const [searchParams] = useSearchParams();
+	const navigate = useNavigate();
+	const rawTab = searchParams.get('tab');
+	const tab: HistoryTab = rawTab === 'stableford' ? 'stableford' : 'handicap';
+
+	const handleChange = (_: unknown, value: HistoryTab) => {
+		navigate(value === 'stableford' ? '/history?tab=stableford' : '/history');
+	};
+
+	return (
+		<Box>
+			<Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+				<TimelineIcon sx={{ fontSize: 32 }} />
+				<Typography variant="headline2">History</Typography>
+			</Box>
+			<Tabs value={tab} onChange={handleChange} sx={{ mb: 2 }}>
+				<Tab value="handicap" label="Handicap" />
+				<Tab value="stableford" label="Stableford" />
+			</Tabs>
+			{tab === 'stableford' ? <StablefordHistory /> : <HandicapHistory />}
+		</Box>
+	);
+};
+
+export default History;

--- a/src/components/StablefordHistory/StablefordHistory.component.tsx
+++ b/src/components/StablefordHistory/StablefordHistory.component.tsx
@@ -13,7 +13,6 @@ import {
 	Alert,
 } from '@mui/material';
 import { LineChart } from '@mui/x-charts/LineChart';
-import ScoreboardIcon from '@mui/icons-material/Scoreboard';
 import { useAppStore } from '@/store/zustand';
 import {
 	getStablefordPoints,
@@ -67,11 +66,6 @@ const StablefordHistory = () => {
 
 	return (
 		<Box>
-			<Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 3 }}>
-				<ScoreboardIcon sx={{ fontSize: 32 }} />
-				<Typography variant="headline2">Stableford History</Typography>
-			</Box>
-
 			{roundsWithStableford.length === 0 && (
 				<Alert severity="info">
 					No rounds with stableford points yet. Play some rounds first!

--- a/src/components/layout/MainLayout2.component.tsx
+++ b/src/components/layout/MainLayout2.component.tsx
@@ -97,10 +97,8 @@ export default function DrawerAppBar(_props: IMainLayoutProps) {
       breadcrumbs.push({ label: 'Settings', path: '/settings' });
     } else if (path === '/simulator') {
       breadcrumbs.push({ label: 'HCP Simulator', path: '/simulator' });
-    } else if (path === '/handicap-history') {
-      breadcrumbs.push({ label: 'Handicap History', path: '/handicap-history' });
-    } else if (path === '/stableford-history') {
-      breadcrumbs.push({ label: 'Stableford History', path: '/stableford-history' });
+    } else if (path === '/history') {
+      breadcrumbs.push({ label: 'History', path: '/history' });
     } else if (path === '/import-rounds') {
       breadcrumbs.push({ label: 'Import Rounds', path: '/import-rounds' });
     } else if (path.startsWith('/round/')) {

--- a/src/pages/HandicapHistory.page.tsx
+++ b/src/pages/HandicapHistory.page.tsx
@@ -1,7 +1,0 @@
-import HandicapHistory from '@/components/HandicapHistory/HandicapHistory.component';
-
-const HandicapHistoryPage = () => {
-	return <HandicapHistory />;
-};
-
-export default HandicapHistoryPage;

--- a/src/pages/History.page.tsx
+++ b/src/pages/History.page.tsx
@@ -1,0 +1,7 @@
+import History from '@/components/History/History.component';
+
+const HistoryPage = () => {
+	return <History />;
+};
+
+export default HistoryPage;

--- a/src/pages/StablefordHistory.page.tsx
+++ b/src/pages/StablefordHistory.page.tsx
@@ -1,7 +1,0 @@
-import StablefordHistory from '@/components/StablefordHistory/StablefordHistory.component';
-
-const StablefordHistoryPage = () => {
-	return <StablefordHistory />;
-};
-
-export default StablefordHistoryPage;

--- a/src/utils/links/links.utils.tsx
+++ b/src/utils/links/links.utils.tsx
@@ -6,7 +6,6 @@ import PeopleIcon from '@mui/icons-material/People';
 import AutoGraphIcon from '@mui/icons-material/AutoGraph';
 import TimelineIcon from '@mui/icons-material/Timeline';
 import FileUploadIcon from '@mui/icons-material/FileUpload';
-import ScoreboardIcon from '@mui/icons-material/Scoreboard';
 
 const navbar_items: TLinkSidebar[] = [
   {
@@ -46,8 +45,8 @@ const navbar_items: TLinkSidebar[] = [
   },
   {
     id: 6,
-    name: "Handicap History",
-    link: "/handicap-history",
+    name: "History",
+    link: "/history",
     icon: TimelineIcon,
     show: true,
   },
@@ -56,13 +55,6 @@ const navbar_items: TLinkSidebar[] = [
     name: "Import Rounds",
     link: "/import-rounds",
     icon: FileUploadIcon,
-    show: true,
-  },
-  {
-    id: 8,
-    name: "Stableford History",
-    link: "/stableford-history",
-    icon: ScoreboardIcon,
     show: true,
   },
 ];


### PR DESCRIPTION
## What'\''s in this PR

- **New `/history` route** with MUI Tabs (Handicap / Stableford). `?tab=stableford` selects the Stableford tab; default is Handicap; invalid values fall back to Handicap. State survives refresh.
- **Thin `History` shell** reads the query param and conditionally mounts one of the two existing components. No rewrite of `HandicapHistory` or `StablefordHistory` — both keep their data logic, charts, tables.
- The two existing components lose their individual page headers and unused icon imports (3-7 line edits).
- **Old `/handicap-history` and `/stableford-history` routes deleted** (no redirect, per spec). Their orphaned `*.page.tsx` files are removed.
- **Drawer:** Stableford History entry removed; "Handicap History" renamed to "History" with `link: /history`. `TimelineIcon` kept.
- **Breadcrumb:** `Home / History` (tab is not in the breadcrumb — it lives in the URL `?tab=`).

## How to verify (manual UAT)

1. `npm start`, log in, open the drawer → confirm one "History" entry pointing to `/history`.
2. Open `/history` → Handicap tab content renders, no console errors, breadcrumb reads `Home / History`.
3. Click the "Stableford" tab → URL becomes `/history?tab=stableford`, Stableford table + 3-line chart render.
4. Refresh at `/history?tab=stableford` → Stableford tab stays selected.
5. Open `/history?tab=garbage` → falls back to Handicap.
6. Old `/handicap-history` and `/stableford-history` return the catch-all Error page.
7. `/handicap-history` link no longer appears in the drawer (only History).

## Tests

- `npx vitest run src/utils/stableford/stableford.utils.test.ts src/utils/firestore/backfillHcpHistory.utils.test.ts` — 17/17 + 6/6 pass.
- Pre-existing vitest failures on `development` (`App.test.tsx`, `calculations.test.ts`) are unrelated and were present before this branch.

## Out of scope

- The internal structure of the two existing history components (charts, tables, highlights, calculations) — unchanged.
- Per-user tab preference persistence (localStorage) — explicitly rejected in brainstorming.
- Old-route redirect logic — explicitly rejected in brainstorming.

## Commits in this PR

- `docs(spec): add /history tabbed consolidation design`
- `refactor(history): consolidate handicap + stableford history into /history tabs`
- `chore(ui): rename Handicap History drawer entry to History`