### PR TITLE
fix(deploy): inject Firebase env vars + add login page footer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+VITE_APP_NAME='Personal Golf Score'
+VITE_APP_API_KEY='your-firebase-api-key'
+VITE_APP_AUTH_DOMAIN='your-project.firebaseapp.com'
+VITE_APP_PROJECT_ID='your-project-id'
+VITE_APP_STORAGE_BUCKET='your-project.appspot.com'
+VITE_APP_MESSAGING_SENDER_ID='your-sender-id'
+VITE_APP_APP_ID='1:your-sender-id:web:your-app-id'
+VITE_APP_MEASUREMENT_ID='G-XXXXXXXXXX'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,8 +16,16 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run type-check
-      - name: Build with release version
+      - name: Build with env + release version
         env:
+          VITE_APP_NAME: ${{ secrets.VITE_APP_NAME }}
+          VITE_APP_API_KEY: ${{ secrets.VITE_APP_API_KEY }}
+          VITE_APP_AUTH_DOMAIN: ${{ secrets.VITE_APP_AUTH_DOMAIN }}
+          VITE_APP_PROJECT_ID: ${{ secrets.VITE_APP_PROJECT_ID }}
+          VITE_APP_STORAGE_BUCKET: ${{ secrets.VITE_APP_STORAGE_BUCKET }}
+          VITE_APP_MESSAGING_SENDER_ID: ${{ secrets.VITE_APP_MESSAGING_SENDER_ID }}
+          VITE_APP_APP_ID: ${{ secrets.VITE_APP_APP_ID }}
+          VITE_APP_MEASUREMENT_ID: ${{ secrets.VITE_APP_MEASUREMENT_ID }}
           VITE_APP_RELEASE_VERSION: ${{ github.ref_name }}
         run: npm run build
       - uses: FirebaseExtended/action-hosting-deploy@v0

--- a/src/components/LoginForm/Signin.component.tsx
+++ b/src/components/LoginForm/Signin.component.tsx
@@ -8,6 +8,7 @@ import Typography from '@mui/material/Typography';
 import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
 import Logo from '../../assets/icons8-golf-67.png';
+import Footer from '../layout/Footer.component';
 import GoogleLoginButton from './components/GoogleLoginButton.component';
 import LoginForm from './components/LoginForm.component';
 
@@ -52,6 +53,7 @@ const SignIn = (props: { disableCustomTheme?: boolean }) => {
             </Typography>
           </Box>
         </LoginCard>
+        <Footer />
       </SigninContainer>
     </>
 


### PR DESCRIPTION
## What

**1. Critical: deploy was shipping broken builds**

`deploy.yml` ran `npm run build` with no env vars, so every `VITE_*` env var was undefined in production. Two visible symptoms:
- Login fails with `FirebaseError: auth/invalid-api-key` (`VITE_APP_API_KEY` was empty)
- `<title>` rendered literally as `%VITE_APP_NAME%` (Vite skips `%VAR%` substitution when undefined)

All 4 deploys (v1.0, v1.1, v1.1.1, v1.1.2) shipped this way. Local builds worked because `.env` is gitignored but present locally.

Fix: source every `VITE_*` env var from `secrets.*` in the build step.

**2. Login page now shows the version footer**

The Footer (with auto-derived release version) was only rendered inside the authenticated `MainLayout2`. Added it to the `SigninContainer` Stack so unauthenticated users also see `vX.Y.Z` at the bottom of the login page.

**3. `.env.example` for new contributors**

Documents the 8 env vars the app needs.

## GitHub secrets to add (one-time)

In the repo: **Settings > Secrets and variables > Actions > New repository secret** — add 8 secrets, one per line from your local `.env`:

```
VITE_APP_NAME                = 'Personal Golf Score'
VITE_APP_API_KEY             = (your Firebase API key)
VITE_APP_AUTH_DOMAIN         = pgs-personalgolfscore.firebaseapp.com
VITE_APP_PROJECT_ID          = pgs-personalgolfscore
VITE_APP_STORAGE_BUCKET      = pgs-personalgolfscore.appspot.com
VITE_APP_MESSAGING_SENDER_ID = 26033768355
VITE_APP_APP_ID              = 1:26033768355:web:bd6a43dc19affbfdc0bc16
VITE_APP_MEASUREMENT_ID      = G-2GPMKQTCWM
```

(Values match your local `.env`. Copy verbatim — including single quotes around strings if your local file uses them, or just the inner value if you'd rather not deal with quoting.)

Once those secrets exist, the next `v*` tag push will build a working bundle.

## Verification

- type-check: clean
- vitest: 23/23