### PR TITLE
fix: roundHoles calculation in test data generator (Closes #135)

### DIFF
--- a/docs/llm-wiki/.obsidian/graph.json
+++ b/docs/llm-wiki/.obsidian/graph.json
@@ -17,6 +17,6 @@
   "repelStrength": 10,
   "linkStrength": 1,
   "linkDistance": 250,
-  "scale": 2.0188644263019566,
+  "scale": 1.4040474647427257,
   "close": false
 }

--- a/docs/llm-wiki/.obsidian/workspace.json
+++ b/docs/llm-wiki/.obsidian/workspace.json
@@ -178,9 +178,11 @@
   },
   "active": "fcee208e4dc30f11",
   "lastOpenFiles": [
+    "raw/issues/135-test-calc-quick-expected-values.md",
+    "raw/issues",
+    "wiki/index.md",
     "wiki/conventions/branch-strategy.md",
     "raw/RETROSPECTIVE.md",
-    "wiki/index.md",
     "wiki/features/initial-hcp-progression.md",
     "wiki/features/whs-simulator.md",
     "wiki/features/admin-panel.md",
@@ -203,7 +205,6 @@
     "raw/REQUIREMENTS.md",
     "wiki/log.md",
     "wiki/history/2026-06-05-drawer-active-route.md",
-    "wiki/history/2026-06-05-all-rounds-pagination.md",
-    "wiki/history/2026-06-04-history-tabs-refactor.md"
+    "wiki/history/2026-06-05-all-rounds-pagination.md"
   ]
 }

--- a/docs/llm-wiki/raw/issues/135-test-calc-quick-expected-values.md
+++ b/docs/llm-wiki/raw/issues/135-test-calc-quick-expected-values.md
@@ -1,0 +1,62 @@
+---
+source: https://github.com/AlexDevsTheWeb/personalgolfscore/issues/135
+state: OPEN
+created: 2026-06-13
+tags: [bug, test, calc, stableford]
+---
+
+# [BUG] test:calc:quick: per-hole expected values don't sum to total
+
+## Summary
+
+`npm run test:calc:quick` reports FAIL on "Mixed Scenarios Test (3 holes)" — per-hole points mismatch but totals summary passes (calculatedPoints=9, totalsPoints=9).
+
+## Root Cause
+
+Two interacting bugs:
+
+### Bug A: `roundHoles` set to `holeConfigs.length` instead of 18
+
+In `src/dev-tools/testDataGenerator.ts:66`, `createTestRound` sets:
+
+```typescript
+this.roundHoles = config.holeConfigs.length;
+```
+
+For the quick 3-hole test, this makes `roundHoles = 3` instead of 18. This feeds into `calculateStablefordPoints`:
+
+```typescript
+diff = roundPlayingHCP - roundHoles; // = 15 - 3 = 12 (wrong: huge positive)
+```
+
+The `diff > 0` branch fires, adding +2 to `newPar` instead of +0. The inflated `newPar` causes `calculatePoints` to return `undefined` (no condition matches), which gets coerced to `0` via `|| 0`.
+
+With the correct `roundHoles = 18`:
+- `diff = 15 - 18 = -3`
+- `diff < 0`, `hcp <= -3` is false → `newPar` unchanged
+- `calculatePoints` matches eagle/birdie/par correctly
+
+### Bug B: Wrong `expectedPoints` in test fixture
+
+The `expectedPoints` values in the `mixedScenarios` fixture (hole 1: 5, hole 2: 3) were set based on the broken behavior and don't match the correct calculation.
+
+## Correct Expected Values (with roundHoles=18)
+
+| Hole | Par | Strokes | HCP | Result | Points |
+|------|-----|---------|-----|--------|--------|
+| 1 | 5 | 3 | 7 | Eagle | 4 |
+| 2 | 4 | 3 | 12 | Birdie | 3 |
+| 3 | 4 | 4 | 5 | Par | 2 |
+
+Total: 9 — matches `calculatedPoints` and `totalsPoints`.
+
+## Fix
+
+1. **`testDataGenerator.ts`**: Add `roundHoles` field to `TestRoundConfig` or `courseInfo`, default to 18, use instead of `config.holeConfigs.length`
+2. **`testDataGenerator.ts`**: Fix `expectedPoints` in `mixedScenarios`: hole 1 → 4, hole 2 → 3
+
+## Acceptance Criteria
+
+- `npm run test:calc:quick` shows ✅ for all 3 holes
+- Per-hole expected values sum to the stated expected total (9)
+- `npm run test:calc:edge` and `npm run test:calc:all` also pass

--- a/docs/llm-wiki/raw/issues/135-test-calc-quick-expected-values.md
+++ b/docs/llm-wiki/raw/issues/135-test-calc-quick-expected-values.md
@@ -60,3 +60,16 @@ Total: 9 — matches `calculatedPoints` and `totalsPoints`.
 - `npm run test:calc:quick` shows ✅ for all 3 holes
 - Per-hole expected values sum to the stated expected total (9)
 - `npm run test:calc:edge` and `npm run test:calc:all` also pass
+
+## Resolution (2026-06-13)
+
+Fixed in commit `5463254` on branch `fix/test-calc-quick-expected-values`.
+PR #136 → `development` (Closes #135).
+
+| File | Change |
+|------|--------|
+| `testDataGenerator.ts` | Added `holes?: number` (default 18) to `TestCourseInfo`; `roundHoles` now uses `config.courseInfo.holes` instead of config length |
+| `testDataGenerator.ts` | Fixed `calculationEdgeCases` hole 2 `expectedGIR` (true→false: 7 strokes−5 putts=2 to green, par3 needs ≤1) |
+| `edgeCaseTests.ts` | Fixed `statisticalAnomalies` holes 1–2 `expectedPoints` (4→5: net albatross with diff=0 HCP) |
+
+All 17 `npm run test:calc:all` scenarios pass ✅

--- a/docs/llm-wiki/wiki/index.md
+++ b/docs/llm-wiki/wiki/index.md
@@ -48,6 +48,10 @@
 - [v2 (Planning)](../raw/milestones/v2-current.md) — Next milestone, scope being defined
 - [v1.0 Full Requirements Traceability](../raw/milestones/v1.0-REQUIREMENTS.md) — Complete CALC/COURSE/ADMIN/SIM/NAV/IMPORT/HCP-INIT mapping
 
+## Open Issues
+
+- [#135 test:calc:quick per-hole expected values](raw/issues/135-test-calc-quick-expected-values.md) — `roundHoles` set to holeConfigs.length (3) instead of 18, corrupting Stableford calculation in quick test
+
 ## History (Changelog)
 - [Libraries Update](history/2026-05-17-libraries-update.md) — May 2026: library version bumps + type error fixes
 - [Handicap History Feature](history/2026-06-01-handicap-history.md) — June 1: HI calculation changes + new page

--- a/docs/llm-wiki/wiki/log.md
+++ b/docs/llm-wiki/wiki/log.md
@@ -5,6 +5,19 @@
 - **Created**: `raw/milestones/v1.0-REQUIREMENTS.md`, `raw/milestones/v1.0-ROADMAP.md`, `raw/milestones/v2-current.md`
 - **Updated**: `raw/MILESTONES.md` (added v2 section), `raw/ROADMAP.md` (v2 current focus), `wiki/index.md` (milestones section), `wiki/overview.md` (milestone status table)
 
+## [2026-06-13] ingest | Issue #135 — test:calc:quick expected values
+- **Source**: GitHub issue #135
+- **Created**: `raw/issues/135-test-calc-quick-expected-values.md` — Full root cause analysis: `roundHoles` set to holeConfigs.length instead of 18, corrupting Stableford calculation
+- **Updated**: `wiki/index.md` — Added "Open Issues" section
+
+## [2026-06-13] fix | RoundHoles calculation bug (fixes #135)
+- **Commit**: `5463254` on `fix/test-calc-quick-expected-values`
+- **PR**: #136 → `development` (Closes #135)
+- **Fixed**: `testDataGenerator.ts` — Added `holes` (default 18) to `TestCourseInfo`; `roundHoles` uses it instead of config length
+- **Fixed**: `edgeCaseTests.ts` — `statisticalAnomalies` expectedPoints 4→5 (net albatross with diff=0)
+- **Fixed**: `testDataGenerator.ts` — `calculationEdgeCases` hole 2 `expectedGIR` true→false (pre-existing)
+- **Updated**: `raw/issues/135-test-calc-quick-expected-values.md` — Added Resolution section
+
 ## [2026-06-13] update | Strengthen Branch Rules + Read-Wiki-First Rule
 - **Updated**: `wiki/conventions/branch-strategy.md` — explicit rule: "NEVER push directly to development/release/*/main"; added "Read the wiki" as step 0 in workflow
 - **Updated**: `wiki/conventions/coding.md` — added "Before You Code" section: read wiki first to understand architecture, patterns, conventions, decisions

--- a/src/dev-tools/edgeCaseTests.ts
+++ b/src/dev-tools/edgeCaseTests.ts
@@ -501,7 +501,7 @@ export class EdgeCaseTests {
             toGreen: '5W',
             toGreenMeters: 200,
             expectedGIR: true,
-            expectedPoints: 4,
+            expectedPoints: 5, // Net albatross (diff=0, newPar=6, strokes=3 → par-3)
           },
           // All hole-in-ones
           {
@@ -515,7 +515,7 @@ export class EdgeCaseTests {
             teeClub: 'i8',
             driveDistance: 150,
             expectedGIR: true,
-            expectedPoints: 4,
+            expectedPoints: 5, // Net albatross (diff=0, newPar=4, strokes=1 → par-3)
           },
           // 10 on a par 3
           {

--- a/src/dev-tools/testDataGenerator.ts
+++ b/src/dev-tools/testDataGenerator.ts
@@ -11,6 +11,7 @@ export interface TestRoundConfig {
     par: number;
     tee: string;
     playerHCP: number;
+    holes?: number; // Total holes in the round (default 18). NOT the number of test hole configs.
   };
   holeConfigs: TestHoleConfig[];
   description: string;
@@ -63,7 +64,7 @@ export class TestDataGenerator {
    */
   createTestRound(config: TestRoundConfig): IShots[] {
     this.roundPlayingHCP = config.courseInfo.playerHCP;
-    this.roundHoles = config.holeConfigs.length;
+    this.roundHoles = config.courseInfo.holes || 18;
 
     return config.holeConfigs.map(holeConfig => this.createTestHole(holeConfig));
   }
@@ -251,7 +252,7 @@ export class TestDataGenerator {
             toGreen: '3W',
             toGreenMeters: 240,
             expectedGIR: true,
-            expectedPoints: 5,
+            expectedPoints: 4, // Eagle (3 strokes on par 5)
           },
           // Birdie on par 4
           {
@@ -268,7 +269,7 @@ export class TestDataGenerator {
             toGreen: 'i8',
             toGreenMeters: 125,
             expectedGIR: true,
-            expectedPoints: 3,
+            expectedPoints: 3, // Birdie (3 strokes on par 4)
           },
           // Par with up & down
           {
@@ -343,7 +344,7 @@ export class TestDataGenerator {
             teeClub: 'i7',
             toGreen: 'i7',
             toGreenMeters: 165,
-            expectedGIR: true,
+            expectedGIR: false, // 7 strokes - 5 putts = 2 to green, par3 needs ≤1
           },
           // Multiple penalties
           {


### PR DESCRIPTION
## Summary

Root cause: `TestDataGenerator.setTestRound` set `roundHoles` to `holeConfigs.length` (e.g., 3 for the quick test) instead of the actual round size (18), corrupting Stableford handicap stroke allocation in `calculateStablefordPoints`.

## Changes

**`src/dev-tools/testDataGenerator.ts`** — Core fix:
- Added `holes?: number` (default 18) to `TestCourseInfo`
- Changed `roundHoles` init from `config.holeConfigs.length` to `config.courseInfo.holes || 18`
- Fixed `calculationEdgeCases` hole 2 `expectedGIR` (true→false: 7 strokes − 5 putts = 2 to green, par 3 needs ≤1)

**`src/dev-tools/edgeCaseTests.ts`** — Corrected expected values:
- `statisticalAnomalies` holes 1–2: `expectedPoints` 4→5 (net albatross with diff=0 HCP stroke allocation)

## Verification

All 17 `npm run test:calc:all` scenarios pass (quick, edge, full suite).

Closes #135