### PR TITLE
fix: anchor importRoundsBatch HCP chain to currentHCP instead of initialHCP

### DIFF
--- a/docs/llm-wiki/.obsidian/workspace.json
+++ b/docs/llm-wiki/.obsidian/workspace.json
@@ -11,10 +11,14 @@
             "id": "fcee208e4dc30f11",
             "type": "leaf",
             "state": {
-              "type": "graph",
-              "state": {},
-              "icon": "lucide-git-fork",
-              "title": "Graph view"
+              "type": "markdown",
+              "state": {
+                "file": "OPENCODE.md",
+                "mode": "source",
+                "source": false
+              },
+              "icon": "lucide-file",
+              "title": "OPENCODE"
             }
           }
         ]
@@ -90,6 +94,7 @@
             "state": {
               "type": "backlink",
               "state": {
+                "file": "OPENCODE.md",
                 "collapseAll": false,
                 "extraContext": false,
                 "sortOrder": "alphabetical",
@@ -99,7 +104,7 @@
                 "unlinkedCollapsed": true
               },
               "icon": "links-coming-in",
-              "title": "Backlinks"
+              "title": "Backlinks for OPENCODE"
             }
           },
           {
@@ -108,11 +113,12 @@
             "state": {
               "type": "outgoing-link",
               "state": {
+                "file": "OPENCODE.md",
                 "linksCollapsed": false,
                 "unlinkedCollapsed": true
               },
               "icon": "links-going-out",
-              "title": "Outgoing links"
+              "title": "Outgoing links from OPENCODE"
             }
           },
           {
@@ -150,12 +156,13 @@
             "state": {
               "type": "outline",
               "state": {
+                "file": "OPENCODE.md",
                 "followCursor": false,
                 "showSearch": false,
                 "searchQuery": ""
               },
               "icon": "lucide-list",
-              "title": "Outline"
+              "title": "Outline of OPENCODE"
             }
           }
         ]
@@ -176,8 +183,11 @@
       "bases:Create new base": false
     }
   },
-  "active": "fcee208e4dc30f11",
+  "active": "e70b3edea179ccd2",
   "lastOpenFiles": [
+    "raw/issues/137-import-hcp-chain-anchor.md",
+    "wiki/overview.md",
+    "OPENCODE.md",
     "raw/issues/135-test-calc-quick-expected-values.md",
     "raw/issues",
     "wiki/index.md",
@@ -202,9 +212,6 @@
     "raw/ROADMAP.md",
     "raw/PROJECT.md",
     "raw/MILESTONES.md",
-    "raw/REQUIREMENTS.md",
-    "wiki/log.md",
-    "wiki/history/2026-06-05-drawer-active-route.md",
-    "wiki/history/2026-06-05-all-rounds-pagination.md"
+    "raw/REQUIREMENTS.md"
   ]
 }

--- a/docs/llm-wiki/raw/issues/137-import-hcp-chain-anchor.md
+++ b/docs/llm-wiki/raw/issues/137-import-hcp-chain-anchor.md
@@ -52,3 +52,15 @@ The fix ensures:
 - If `currentHCP` exists (after prior imports) → chain starts from the last computed HI
 - If no `currentHCP` but `initialHCP` exists → chain starts from initialHCP (correct for first batch)
 - If neither → null (graceful, no HI/delta computed for that batch)
+
+## Resolution (2026-06-13)
+
+Fixed in commit `641efac` on branch `fix/import-rounds-hcp-chain-anchor`.
+PR #138 → `development` (Closes #137).
+
+**After merge**: go to Settings → click "Recalculate HCP History" to fix existing rounds' `previousHCP`/`hcpDelta`. Future imports will chain correctly automatically.
+
+| File | Change |
+|------|--------|
+| `app.store.ts:869` | Changed `const initialHCP = state.player?.initialHCP ?? null` → `const anchorHCP = state.player?.currentHCP ?? state.player?.initialHCP ?? null` |
+| `round.firestore.ts:73,88` | Renamed param `initialHCP` → `anchorHCP`; `runningHCP` initialized from it |

--- a/docs/llm-wiki/raw/issues/137-import-hcp-chain-anchor.md
+++ b/docs/llm-wiki/raw/issues/137-import-hcp-chain-anchor.md
@@ -1,0 +1,54 @@
+# Issue #137 — Import Rounds HCP Chain Anchor Bug
+
+## Summary
+
+When importing rounds in multiple batches via the `import-rounds` route, the first round of each subsequent batch gets an incorrect `previousHCP` because `importRoundsBatch` anchors the running HCP chain to the player's `initialHCP` (a fixed value) instead of their `currentHCP` (which reflects the last computed HI after all prior imports).
+
+## Impact
+
+- The HCP History chart shows correct `handicapIndex` values per round (computed from score differentials)
+- But `previousHCP` and `hcpDelta` are wrong on the first round of each subsequent import batch
+- Example: initialHCP=14.0, after batch 1 currentHCP=11.5. Batch 2's first round gets `previousHCP=14.0` instead of `previousHCP=11.5`
+
+## Root Cause
+
+In `app.store.ts:869`:
+```typescript
+const initialHCP = state.player?.initialHCP ?? null;
+```
+
+Passes `initialHCP` (static, user-set value) as the chain anchor to `importRoundsBatch`. After prior import batches have updated `currentHCP` to the last computed HI, the next batch still anchors to the original `initialHCP`.
+
+In `round.firestore.ts:88`:
+```typescript
+let runningHCP: number | null = initialHCP;
+```
+
+The running chain resets to the fixed initial value instead of picking up from the last computed HI.
+
+## Trace
+
+With initialHCP=14.0, three rounds imported in two batches:
+
+| Batch | Round | prevHCP (actual) | prevHCP (should be) | HI (based on SDs) |
+|-------|-------|---|---|---|
+| 1     | A     | 14.0 | 14.0 | 12.0 |
+| 1     | B     | 12.0 | 12.0 | 11.5 |
+| 2     | C     | **14.0** ✗ | **11.5** | 10.0 |
+
+The `handicapIndex` is correct in all cases (computed from SDs, not runningHCP). Only `previousHCP` and `hcpDelta` are wrong.
+
+## Related
+
+- The Settings page has a "Recalculate HCP History" button that runs `backfillHcpHistory()`, which recomputes all per-round HCP fields from scratch
+- The `backfillHcpHistory` utility uses the same `computeRoundHcpHistory()` logic but starts fresh with all rounds chronologically — it is NOT affected by this bug
+
+## Fix
+
+1. **`app.store.ts:869`**: Change from `initialHCP` to `currentHCP ?? initialHCP`
+2. **`round.firestore.ts:88`**: Update parameter/variable to reflect using the anchor correctly
+
+The fix ensures:
+- If `currentHCP` exists (after prior imports) → chain starts from the last computed HI
+- If no `currentHCP` but `initialHCP` exists → chain starts from initialHCP (correct for first batch)
+- If neither → null (graceful, no HI/delta computed for that batch)

--- a/docs/llm-wiki/wiki/index.md
+++ b/docs/llm-wiki/wiki/index.md
@@ -50,7 +50,8 @@
 
 ## Open Issues
 
-- [#135 test:calc:quick per-hole expected values](raw/issues/135-test-calc-quick-expected-values.md) — `roundHoles` set to holeConfigs.length (3) instead of 18, corrupting Stableford calculation in quick test
+- [#135 test:calc:quick per-hole expected values](raw/issues/135-test-calc-quick-expected-values.md) — `roundHoles` set to holeConfigs.length (3) instead of 18, corrupting Stableford calculation in quick test (resolved)
+- [#137 import HCP chain anchored to initialHCP instead of currentHCP](raw/issues/137-import-hcp-chain-anchor.md) — Multi-batch import produces wrong `previousHCP`/`hcpDelta` on first round of each subsequent batch
 
 ## History (Changelog)
 - [Libraries Update](history/2026-05-17-libraries-update.md) — May 2026: library version bumps + type error fixes

--- a/docs/llm-wiki/wiki/log.md
+++ b/docs/llm-wiki/wiki/log.md
@@ -44,6 +44,13 @@
 - **Created**: `raw/issues/137-import-hcp-chain-anchor.md` — Root cause analysis: `importRoundsBatch` uses `initialHCP` instead of `currentHCP` as chain anchor, corrupting `previousHCP`/`hcpDelta` on first round of each subsequent import batch
 - **Updated**: `wiki/index.md` — Added #137 to Open Issues
 
+## [2026-06-13] fix | Import HCP chain anchor bug (fixes #137)
+- **Commit**: `641efac` on `fix/import-rounds-hcp-chain-anchor`
+- **PR**: #138 → `development` (Closes #137)
+- **Fixed**: `app.store.ts:869` — passes `currentHCP ?? initialHCP ?? null` instead of just `initialHCP`
+- **Fixed**: `round.firestore.ts:73,88` — param renamed to `anchorHCP` for clarity
+- **After merge**: run Settings → "Recalculate HCP History" to fix existing rounds
+
 ## [2026-06-13] ingest | Initial Wiki Seed
 - **Description**: First ingest of all existing project documentation into the wiki
 - **Sources** (24 files from `raw/`):

--- a/docs/llm-wiki/wiki/log.md
+++ b/docs/llm-wiki/wiki/log.md
@@ -39,6 +39,11 @@
 - **Created**: `wiki/features/initial-hcp-progression.md` — Initial HCP input, per-round HI/delta, chart
 - **Updated**: `wiki/overview.md` (v1.0 MVP summary, post-v1.0 additions, updated concerns)
 
+## [2026-06-13] ingest | Issue #137 — Import HCP chain anchor bug
+- **Source**: GitHub issue #137
+- **Created**: `raw/issues/137-import-hcp-chain-anchor.md` — Root cause analysis: `importRoundsBatch` uses `initialHCP` instead of `currentHCP` as chain anchor, corrupting `previousHCP`/`hcpDelta` on first round of each subsequent import batch
+- **Updated**: `wiki/index.md` — Added #137 to Open Issues
+
 ## [2026-06-13] ingest | Initial Wiki Seed
 - **Description**: First ingest of all existing project documentation into the wiki
 - **Sources** (24 files from `raw/`):

--- a/src/store/zustand/app.store.ts
+++ b/src/store/zustand/app.store.ts
@@ -866,9 +866,9 @@ export const useAppStore = create<AppState>()(
             const previousSDs = state.roundsList
               .map((r) => r.scoreDifferential)
               .filter((sd): sd is number => sd !== null && sd !== undefined);
-            const initialHCP = state.player?.initialHCP ?? null;
+            const anchorHCP = state.player?.currentHCP ?? state.player?.initialHCP ?? null;
 
-            const result = await importRoundsBatch(userId, docs, previousSDs, initialHCP);
+            const result = await importRoundsBatch(userId, docs, previousSDs, anchorHCP);
 
             // Refetch player to sync currentHCP snapshot in store
             try {

--- a/src/utils/firestore/round.firestore.ts
+++ b/src/utils/firestore/round.firestore.ts
@@ -70,7 +70,7 @@ export const importRoundsBatch = async (
   userId: string,
   roundDocs: IRoundImportDocument[],
   previousSDsMostRecentFirst: number[],
-  initialHCP: number | null
+  anchorHCP: number | null
 ): Promise<{ success: boolean; importedCount: number; roundIds: string[] }> => {
   if (!userId) {
     throw new Error('User not authenticated');
@@ -85,7 +85,7 @@ export const importRoundsBatch = async (
 
   const roundIds: string[] = [];
   let runningSDs = [...previousSDsMostRecentFirst].slice(0, 19);
-  let runningHCP: number | null = initialHCP;
+  let runningHCP: number | null = anchorHCP;
 
   for (const roundDoc of sortedDocs) {
     const newSD = roundDoc.scoreDifferential;


### PR DESCRIPTION
## Summary

When importing rounds in multiple batches via the `import-rounds` route, the first round of each subsequent batch gets an incorrect `previousHCP` because `importRoundsBatch` anchored the running HCP chain to the player's `initialHCP` (a fixed, user-set value) instead of their `currentHCP` (which reflects the last computed HI after all prior imports).

## Root Cause

- `app.store.ts:869`: passed `state.player.initialHCP` as the chain anchor
- `round.firestore.ts:88`: `runningHCP` started from `initialHCP` instead of `currentHCP`

## The Bug In Action

initialHCP=14.0, three rounds imported in two batches:

| Batch | Round | prevHCP (actual) | prevHCP (should be) | HI (correct either way) |
|-------|-------|---|---|---|
| 1 | A | 14.0 | 14.0 | 12.0 |
| 1 | B | 12.0 | 12.0 | 11.5 |
| 2 | C | 14.0 (wrong) | 11.5 | 10.0 |

Note: `handicapIndex` was always correct (computed from SDs, not runningHCP). Only `previousHCP` and `hcpDelta` were wrong.

## Fixed

`app.store.ts:869`: passes `currentHCP ?? initialHCP ?? null` so that after prior imports the chain picks up from the last computed HI.

`round.firestore.ts:88`: parameter renamed to `anchorHCP` for clarity, initializes `runningHCP` from it.

The Settings page's existing "Recalculate HCP History" button already uses `backfillHcpHistory()` which recomputes from scratch -- not affected by this bug. Run it after this fix to correct any existing rounds' `previousHCP`/`hcpDelta`.

## Verification

- All 17 `npm run test:calc:all` scenarios pass
- Type check passes

Closes #137
